### PR TITLE
feat(ponto): Lote D — solicitação HE, teto mensal e SSE (#969/#974/#982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
+
 #### Correções
 
 - Sobre: deixa de listar itens **Interno / Infra** (deploy, LICENSE, docs internos) — só Melhorias e Correções de produto

--- a/backend/alembic/versions/130_ponto_he_teto_mensal.py
+++ b/backend/alembic/versions/130_ponto_he_teto_mensal.py
@@ -1,0 +1,50 @@
+"""Teto mensal de HE (#974).
+
+Revision ID: 130_ponto_he_teto_mensal
+Revises: 129_merge_he_teto_versao
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "130_ponto_he_teto_mensal"
+down_revision = "129_merge_he_teto_versao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "he_teto_mensal_minutos" not in cols:
+            op.add_column(
+                "ponto_settings",
+                sa.Column("he_teto_mensal_minutos", sa.Integer(), nullable=True),
+            )
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_mensal_minutos" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("he_teto_mensal_minutos", sa.Integer(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_mensal_minutos" in cols:
+            op.drop_column("atendentes", "he_teto_mensal_minutos")
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "he_teto_mensal_minutos" in cols:
+            op.drop_column("ponto_settings", "he_teto_mensal_minutos")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -63,6 +63,7 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         usar_local_empresa=bool(getattr(atendente, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(atendente, "local_empresa_raio_metros", None),
         he_teto_minutos=getattr(atendente, "he_teto_minutos", None),
+        he_teto_mensal_minutos=getattr(atendente, "he_teto_mensal_minutos", None),
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
@@ -193,6 +194,7 @@ def criar_atendente(
         usar_local_empresa=bool(getattr(data, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(data, "local_empresa_raio_metros", None),
         he_teto_minutos=getattr(data, "he_teto_minutos", None),
+        he_teto_mensal_minutos=getattr(data, "he_teto_mensal_minutos", None),
     )
     _aplicar_campos_jornada(
         atendente,

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -489,7 +489,14 @@ def solicitar_hora_extra(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     ponto_svc.exigir_acesso_ponto(atendente)
-    return he_svc.solicitar(db, atendente, motivo=data.motivo)
+    return he_svc.solicitar(
+        db,
+        atendente,
+        motivo=data.motivo,
+        modo=data.modo,
+        ate_horario=data.ate_horario,
+        duracao_minutos=data.duracao_minutos,
+    )
 
 
 @router.get("/hora-extra", response_model=list[PontoHoraExtraRead])

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -47,6 +47,8 @@ class Atendente(Base):
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
     # Teto máximo de HE por liberação, em minutos (#966); null = sem teto.
     he_teto_minutos = Column(Integer, nullable=True)
+    # NULL = herda setting global (#974)
+    he_teto_mensal_minutos = Column(Integer, nullable=True)
     # Locais de ponto (#984): empresa + extras por atendente.
     usar_local_empresa = Column(Boolean, nullable=False, default=True, server_default="true")
     local_empresa_raio_metros = Column(Integer, nullable=True)

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -17,6 +17,8 @@ class PontoSettings(Base):
     # Margem após saída prevista do dia (#961); fecho = min(N horas, saída+margem).
     fecho_margem_pos_saida_minutos = Column(Integer, nullable=False, default=30, server_default="30")
     jornada_diaria_minutos = Column(Integer, nullable=False, default=480, server_default="480")
+    # NULL = sem teto mensal global (#974)
+    he_teto_mensal_minutos = Column(Integer, nullable=True)
     # opcional | recomendada | obrigatoria (#844)
     politica_geolocalizacao = Column(String(20), nullable=False, default="opcional", server_default="opcional")
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -24,6 +24,7 @@ class AtendenteBase(BaseModel):
     usar_local_empresa: bool = True
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
     he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
+    he_teto_mensal_minutos: int | None = Field(default=None, ge=30, le=31 * 24 * 60)
 
 
 class AtendenteCreate(AtendenteBase):
@@ -50,6 +51,7 @@ class AtendenteUpdate(BaseModel):
     usar_local_empresa: bool | None = None
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
     he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
+    he_teto_mensal_minutos: int | None = Field(default=None, ge=30, le=31 * 24 * 60)
 
 
 class AtendenteRead(AtendenteBase):

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -198,6 +198,7 @@ class PontoDigestRead(BaseModel):
     jornadas_abertas: int
     online_sem_ponto: int
     justificativas_pendentes: int
+    he_acima_teto_mensal: int = 0
     itens: list[PontoHojeItem]
 
 
@@ -207,6 +208,7 @@ class PontoSettingsRead(BaseModel):
     fecho_apos_horas: int = 14
     fecho_margem_pos_saida_minutos: int = 30
     jornada_diaria_minutos: int = 480
+    he_teto_mensal_minutos: int | None = None
     politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
 
     model_config = ConfigDict(from_attributes=True)
@@ -218,6 +220,7 @@ class PontoSettingsUpdate(BaseModel):
     fecho_apos_horas: int | None = Field(default=None, ge=4, le=48)
     fecho_margem_pos_saida_minutos: int | None = Field(default=None, ge=0, le=240)
     jornada_diaria_minutos: int | None = Field(default=None, ge=60, le=1440)
+    he_teto_mensal_minutos: int | None = Field(default=None, ge=30, le=31 * 24 * 60)
     politica_geolocalizacao: PoliticaGeolocalizacao | None = None
 
 
@@ -315,6 +318,9 @@ class PontoJustificativaDecisao(BaseModel):
 
 class PontoHoraExtraCreate(BaseModel):
     motivo: str | None = Field(default=None, max_length=1000)
+    modo: Literal["resto_do_dia", "ate_horario", "duracao"] | None = None
+    ate_horario: str | None = Field(default=None, max_length=5)
+    duracao_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
 
 
 class PontoHoraExtraRead(BaseModel):
@@ -355,5 +361,8 @@ class PontoHoraExtraMeStatus(BaseModel):
     pode_pegar_whatsapp: bool
     he_ativa: PontoHoraExtraRead | None = None
     pedido_pendente: PontoHoraExtraRead | None = None
+    ultimo_rejeitado: PontoHoraExtraRead | None = None
     he_teto_minutos: int | None = None
     he_restante_minutos: int | None = None
+    he_teto_mensal_minutos: int | None = None
+    he_consumido_mensal_minutos: int = 0

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -641,6 +641,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
 
 def digest_hoje(db: Session, admin: Atendente) -> PontoDigestRead:
     from app.models.ponto_justificativa import PontoJustificativa
+    from app.services import ponto_hora_extra as he_svc
 
     hoje = visao_hoje(db, admin)
     pendentes = (
@@ -667,6 +668,7 @@ def digest_hoje(db: Session, admin: Atendente) -> PontoDigestRead:
         jornadas_abertas=abertas,
         online_sem_ponto=online_sem,
         justificativas_pendentes=pendentes,
+        he_acima_teto_mensal=he_svc.contar_acima_teto_mensal(db, admin.tenant_id),
         itens=destaque[:40],
     )
 

--- a/backend/app/services/ponto_hora_extra.py
+++ b/backend/app/services/ponto_hora_extra.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date, datetime, time, timedelta, timezone
 
 from fastapi import HTTPException, status
@@ -182,6 +183,7 @@ def garantir_pedido_pendente(
     atendente: Atendente,
     *,
     motivo: str | None = None,
+    modo: str | None = None,
     commit: bool = True,
 ) -> PontoHoraExtra:
     existente = (
@@ -196,9 +198,12 @@ def garantir_pedido_pendente(
     if existente:
         if motivo and not (existente.motivo or "").strip():
             existente.motivo = (motivo or "")[:1000]
+        if modo and not (existente.modo or "").strip():
+            existente.modo = modo
         if commit:
             db.commit()
             db.refresh(existente)
+            _emit_he_sse(db, existente)
         return existente
     row = PontoHoraExtra(
         tenant_id=atendente.tenant_id,
@@ -206,6 +211,7 @@ def garantir_pedido_pendente(
         estado="pendente",
         origem="solicitacao",
         motivo=(motivo or "Pedido de hora extra para atendimento WhatsApp.")[:1000],
+        modo=(modo or None),
     )
     db.add(row)
     db.flush()
@@ -215,13 +221,32 @@ def garantir_pedido_pendente(
         row.id,
         "create",
         atendente.id,
-        payload={"estado": "pendente", "origem": "solicitacao"},
+        payload={"estado": "pendente", "origem": "solicitacao", "modo": modo},
     )
     if commit:
         db.commit()
         db.refresh(row)
         _notificar_admins(db, atendente.tenant_id)
+        _emit_he_sse(db, row)
     return row
+
+
+def _extrair_janela_do_motivo(motivo: str | None) -> tuple[str | None, int | None]:
+    """Recupera [até HH:MM] / [N min] gravados no pedido (#969)."""
+    if not motivo:
+        return None, None
+    ate = None
+    dur = None
+    m_ate = re.search(r"\[até\s+(\d{1,2}:\d{2})\]", motivo, re.IGNORECASE)
+    if m_ate:
+        ate = m_ate.group(1)
+    m_dur = re.search(r"\[(\d+)\s*min\]", motivo, re.IGNORECASE)
+    if m_dur:
+        try:
+            dur = int(m_dur.group(1))
+        except ValueError:
+            dur = None
+    return ate, dur
 
 
 def solicitar(
@@ -229,15 +254,54 @@ def solicitar(
     atendente: Atendente,
     *,
     motivo: str | None = None,
+    modo: str | None = None,
+    ate_horario: str | None = None,
+    duracao_minutos: int | None = None,
 ) -> PontoHoraExtraRead:
-    if not fora_da_jornada(atendente):
-        raise HTTPException(
-            status_code=400,
-            detail="Você ainda está dentro da jornada — não é necessário pedir hora extra.",
-        )
+    """Colaborador pede HE (#969) — com janela desejada opcional."""
     if he_ativa(db, atendente):
         raise HTTPException(status_code=400, detail="Você já tem hora extra ativa.")
-    row = garantir_pedido_pendente(db, atendente, motivo=motivo, commit=True)
+    teto_m = _teto_mensal_minutos(db, atendente)
+    if teto_m is not None and _consumido_mes(db, atendente) >= teto_m:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Teto mensal de hora extra atingido ({teto_m} min). Aguarde o próximo mês.",
+        )
+    m = (modo or "").strip().lower() or None
+    if m:
+        if m not in MODOS_APROVACAO:
+            raise HTTPException(
+                status_code=400,
+                detail="Escolha modo resto_do_dia, ate_horario ou duracao.",
+            )
+        agora = _agora_tz()
+        # Valida janela sem gravar ate_em (só na aprovação)
+        _calcular_ate_em(
+            atendente,
+            agora,
+            modo=m,
+            ate_horario=ate_horario,
+            duracao_minutos=duracao_minutos,
+        )
+        mins = _minutos_previstos_liberacao(
+            atendente,
+            agora,
+            modo=m,
+            ate_horario=ate_horario,
+            duracao_minutos=duracao_minutos,
+        )
+        _exigir_cabimento_mensal(db, atendente, mins)
+        if m == "ate_horario" and ate_horario:
+            hint = f" [até {ate_horario.strip()}]"
+            motivo = ((motivo or "").rstrip() + hint)[:1000]
+        elif m == "duracao" and duracao_minutos:
+            hint = f" [{int(duracao_minutos)} min]"
+            motivo = ((motivo or "").rstrip() + hint)[:1000]
+    row = garantir_pedido_pendente(db, atendente, motivo=motivo, modo=m, commit=True)
+    if m and row.modo != m:
+        row.modo = m
+        db.commit()
+        db.refresh(row)
     row = (
         db.query(PontoHoraExtra)
         .options(joinedload(PontoHoraExtra.atendente))
@@ -248,33 +312,137 @@ def solicitar(
     return _to_read(row)
 
 
-def listar_admin(
-    db: Session,
-    admin: Atendente,
-    *,
-    estado: str | None = "pendente",
-) -> list[PontoHoraExtraRead]:
-    q = (
-        db.query(PontoHoraExtra)
-        .options(joinedload(PontoHoraExtra.atendente))
-        .filter(PontoHoraExtra.tenant_id == admin.tenant_id)
+def _emit_he_sse(db: Session, row: PontoHoraExtra) -> None:
+    try:
+        from app.services.realtime_emit import emit_ponto_he_atualizada
+
+        emit_ponto_he_atualizada(
+            db,
+            tenant_id=row.tenant_id,
+            he_id=row.id,
+            atendente_id=row.atendente_id,
+            estado=row.estado,
+            origem=getattr(row, "origem", None),
+        )
+    except Exception:
+        pass
+
+
+def _teto_mensal_minutos(db: Session, atendente: Atendente) -> int | None:
+    raw = getattr(atendente, "he_teto_mensal_minutos", None)
+    if raw is not None and int(raw) > 0:
+        return int(raw)
+    from app.services import ponto_settings as ponto_settings_svc
+
+    st = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
+    raw_g = getattr(st, "he_teto_mensal_minutos", None)
+    if raw_g is not None and int(raw_g) > 0:
+        return int(raw_g)
+    return None
+
+
+def _he_minutos_liberados_periodo(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> int:
+    # Bounds locais (evita import circular com ponto.py)
+    inicio = datetime.combine(desde, time.min, tzinfo=PONTO_TZ).astimezone(timezone.utc)
+    fim_exclusive = datetime.combine(ate + timedelta(days=1), time.min, tzinfo=PONTO_TZ).astimezone(
+        timezone.utc
     )
-    if estado:
-        q = q.filter(PontoHoraExtra.estado == estado)
-    rows = q.order_by(PontoHoraExtra.created_at.desc(), PontoHoraExtra.id.desc()).limit(100).all()
-    return [_to_read(r) for r in rows]
-
-
-def listar_me(db: Session, atendente: Atendente) -> list[PontoHoraExtraRead]:
     rows = (
         db.query(PontoHoraExtra)
-        .options(joinedload(PontoHoraExtra.atendente))
-        .filter(PontoHoraExtra.atendente_id == atendente.id)
-        .order_by(PontoHoraExtra.id.desc())
-        .limit(30)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente_id,
+            PontoHoraExtra.estado.in_(("aprovada", "expirada")),
+            PontoHoraExtra.ate_em.isnot(None),
+            PontoHoraExtra.decidido_em.isnot(None),
+            PontoHoraExtra.decidido_em >= inicio,
+            PontoHoraExtra.decidido_em < fim_exclusive,
+        )
         .all()
     )
-    return [_to_read(r) for r in rows]
+    total = 0
+    for r in rows:
+        dec = r.decidido_em
+        ate_em = r.ate_em
+        if dec is None or ate_em is None:
+            continue
+        if dec.tzinfo is None:
+            dec = dec.replace(tzinfo=timezone.utc)
+        if ate_em.tzinfo is None:
+            ate_em = ate_em.replace(tzinfo=timezone.utc)
+        total += max(0, int((ate_em - dec).total_seconds() // 60))
+    return total
+
+
+def _consumido_mes(db: Session, atendente: Atendente, when: datetime | None = None) -> int:
+    agora = _agora_tz(when)
+    inicio_mes = date(agora.year, agora.month, 1)
+    if agora.month == 12:
+        fim_mes = date(agora.year + 1, 1, 1) - timedelta(days=1)
+    else:
+        fim_mes = date(agora.year, agora.month + 1, 1) - timedelta(days=1)
+    return _he_minutos_liberados_periodo(db, atendente.id, desde=inicio_mes, ate=fim_mes)
+
+
+def _minutos_previstos_liberacao(
+    atendente: Atendente,
+    agora: datetime,
+    *,
+    modo: str,
+    ate_horario: str | None,
+    duracao_minutos: int | None,
+) -> int:
+    ate = _calcular_ate_em(
+        atendente, agora, modo=modo, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+    )
+    return max(1, int((ate.astimezone(PONTO_TZ) - agora.astimezone(PONTO_TZ)).total_seconds() // 60))
+
+
+def _exigir_cabimento_mensal(
+    db: Session,
+    atendente: Atendente,
+    minutos_novos: int,
+) -> None:
+    teto = _teto_mensal_minutos(db, atendente)
+    if teto is None:
+        return
+    consumido = _consumido_mes(db, atendente)
+    if consumido + minutos_novos > teto:
+        restante = max(0, teto - consumido)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Teto mensal de hora extra atingido ({consumido}/{teto} min). "
+                f"Restam {restante} min neste mês."
+            ),
+        )
+
+
+def contar_acima_teto_mensal(db: Session, tenant_id: int) -> int:
+    from app.services import ponto_settings as ponto_settings_svc
+
+    st = ponto_settings_svc.get_or_create_settings(db, tenant_id)
+    global_teto = getattr(st, "he_teto_mensal_minutos", None)
+    ativos = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role != "saas_ops",
+        )
+        .all()
+    )
+    n = 0
+    for a in ativos:
+        teto = _teto_mensal_minutos(db, a)
+        if teto is None and global_teto is None:
+            continue
+        if teto is None:
+            continue
+        if _consumido_mes(db, a) > teto:
+            n += 1
+    return n
 
 
 def me_status(db: Session, atendente: Atendente) -> dict:
@@ -286,6 +454,12 @@ def me_status(db: Session, atendente: Atendente) -> dict:
         .order_by(PontoHoraExtra.id.desc())
         .first()
     )
+    rejeitada = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == atendente.id, PontoHoraExtra.estado == "rejeitada")
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
     restante = None
     if ativa and ativa.ate_em is not None:
         agora = _agora_tz()
@@ -293,13 +467,18 @@ def me_status(db: Session, atendente: Atendente) -> dict:
         if ate.tzinfo is None:
             ate = ate.replace(tzinfo=timezone.utc)
         restante = max(0, int((ate.astimezone(PONTO_TZ) - agora).total_seconds() // 60))
+    teto_m = _teto_mensal_minutos(db, atendente)
+    consumido_m = _consumido_mes(db, atendente)
     return {
         "fora_da_jornada": fora,
         "pode_pegar_whatsapp": (not fora) or ativa is not None,
         "he_ativa": _to_read(ativa) if ativa else None,
         "pedido_pendente": _to_read(pendente) if pendente else None,
+        "ultimo_rejeitado": _to_read(rejeitada) if rejeitada and not pendente and not ativa else None,
         "he_teto_minutos": _teto_minutos(atendente),
         "he_restante_minutos": restante,
+        "he_teto_mensal_minutos": teto_m,
+        "he_consumido_mensal_minutos": consumido_m,
     }
 
 
@@ -350,12 +529,25 @@ def decidir(
     row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
     if not aprovar:
         row.estado = "rejeitada"
-        row.modo = None
         row.ate_em = None
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Negado pelo administrador"
     else:
-        m = (modo or "").strip().lower()
+        m = (modo or row.modo or "").strip().lower()
+        if m not in MODOS_APROVACAO:
+            raise HTTPException(
+                status_code=400,
+                detail="Informe o modo de liberação (resto_do_dia, ate_horario ou duracao).",
+            )
+        hint_ate, hint_dur = _extrair_janela_do_motivo(row.motivo)
+        ate_h = ate_horario or hint_ate
+        dur_m = duracao_minutos if duracao_minutos is not None else hint_dur
+        mins = _minutos_previstos_liberacao(
+            alvo, agora, modo=m, ate_horario=ate_h, duracao_minutos=dur_m
+        )
+        _exigir_cabimento_mensal(db, alvo, mins)
         ate = _calcular_ate_em(
-            alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+            alvo, agora, modo=m, ate_horario=ate_h, duracao_minutos=dur_m
         )
         _expirar_aprovadas_anteriores(db, alvo.id)
         row.estado = "aprovada"
@@ -372,6 +564,7 @@ def decidir(
     db.commit()
     db.refresh(row)
     _notificar_admins(db, admin.tenant_id)
+    _emit_he_sse(db, row)
     return _to_read(row)
 
 
@@ -399,6 +592,10 @@ def conceder_admin(
         raise HTTPException(status_code=404, detail="Atendente não encontrado")
     agora = _agora_tz()
     m = (modo or "").strip().lower()
+    mins = _minutos_previstos_liberacao(
+        alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+    )
+    _exigir_cabimento_mensal(db, alvo, mins)
     ate = _calcular_ate_em(
         alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
     )
@@ -467,7 +664,37 @@ def conceder_admin(
     )
     assert row is not None
     _notificar_admins(db, admin.tenant_id)
+    _emit_he_sse(db, row)
     return _to_read(row)
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente",
+) -> list[PontoHoraExtraRead]:
+    q = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        q = q.filter(PontoHoraExtra.estado == estado)
+    rows = q.order_by(PontoHoraExtra.created_at.desc(), PontoHoraExtra.id.desc()).limit(100).all()
+    return [_to_read(r) for r in rows]
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoHoraExtraRead]:
+    rows = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.atendente_id == atendente.id)
+        .order_by(PontoHoraExtra.id.desc())
+        .limit(30)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
 
 
 def contar_pendentes_admin(db: Session, tenant_id: int) -> int:

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -69,6 +69,13 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="jornada_diaria_minutos deve estar entre 60 e 1440.",
             )
+    if "he_teto_mensal_minutos" in payload:
+        m = payload["he_teto_mensal_minutos"]
+        if m is not None and (m < 30 or m > 31 * 24 * 60):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="he_teto_mensal_minutos deve estar entre 30 e 44640, ou vazio.",
+            )
     if "politica_geolocalizacao" in payload:
         p = (payload["politica_geolocalizacao"] or "").strip().lower()
         if p not in POLITICAS_VALIDAS:

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -574,3 +574,35 @@ def emit_chat_interno_mensagem_atualizada(
     _publish_to_atendentes(recipients, "chat.interno.mensagem.atualizada", payload)
     if acao in {"editada", "apagada"}:
         _emit_notificacao_after_counter_change(db)
+
+
+def emit_ponto_he_atualizada(
+    db: Session,
+    *,
+    tenant_id: int,
+    he_id: int,
+    atendente_id: int,
+    estado: str,
+    origem: str | None = None,
+) -> None:
+    """Pedido/decisão/concessão de hora extra (#982) — admins + colaborador."""
+    ids = {
+        a.id
+        for a in db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == tenant_id,
+            Atendente.role == "admin",
+            Atendente.ativo.is_(True),
+        )
+        .all()
+    }
+    ids.add(atendente_id)
+    payload = {
+        "he_id": he_id,
+        "atendente_id": atendente_id,
+        "estado": estado,
+        "origem": origem,
+    }
+    _publish_to_atendentes(ids, "ponto.he_atualizada", payload)
+    # Contagem do sino (HE pendentes) para admins
+    emit_notificacao_contagem(db, ids)

--- a/backend/tests/test_ponto_he_antecipada_966.py
+++ b/backend/tests/test_ponto_he_antecipada_966.py
@@ -1,6 +1,6 @@
 """HE antecipada + teto (#966)."""
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from app.services.escala import PONTO_TZ
 
@@ -22,13 +22,16 @@ def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
     )
 
 
-def test_conceder_he_antecipada_durante_jornada(client, seed_base, auth_headers):
+def test_conceder_he_antecipada_durante_jornada(client, seed_base, auth_headers, monkeypatch):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
     a1 = seed_base["a1"]
-    # fim no futuro → ainda dentro da jornada
-    fim = (datetime.now(PONTO_TZ) + timedelta(hours=3)).strftime("%H:%M")
-    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    agora = datetime(2026, 6, 17, 14, 0, tzinfo=PONTO_TZ)
+    monkeypatch.setattr(
+        "app.services.ponto._agora_utc",
+        lambda: agora.astimezone(timezone.utc),
+    )
+    assert _patch_jornada_semanal(client, admin, a1.id, fim="18:00").status_code == 200
     r = client.post(
         "/v1/ponto/hora-extra/conceder",
         headers=admin,

--- a/backend/tests/test_ponto_he_sse_982.py
+++ b/backend/tests/test_ponto_he_sse_982.py
@@ -1,0 +1,36 @@
+"""SSE ponto.he_atualizada (#982) — destinatários admin + colaborador."""
+
+from unittest.mock import MagicMock, patch
+
+from app.models.atendente import Atendente
+from app.services.realtime_emit import emit_ponto_he_atualizada
+
+
+def test_emit_ponto_he_atualizada_admins_e_colaborador():
+    db = MagicMock()
+    admin = Atendente(id=1, tenant_id=10, role="admin", ativo=True, nome="Admin", email="a@x")
+    outro = Atendente(id=2, tenant_id=10, role="atendente", ativo=True, nome="X", email="x@x")
+    db.query.return_value.filter.return_value.all.return_value = [admin]
+
+    with (
+        patch("app.services.realtime_emit._publish_to_atendentes") as pub,
+        patch("app.services.realtime_emit.emit_notificacao_contagem") as cont,
+    ):
+        emit_ponto_he_atualizada(
+            db,
+            tenant_id=10,
+            he_id=99,
+            atendente_id=7,
+            estado="pendente",
+            origem="solicitacao",
+        )
+        pub.assert_called_once()
+        ids, event, payload = pub.call_args[0]
+        assert event == "ponto.he_atualizada"
+        assert 1 in ids
+        assert 7 in ids
+        assert 2 not in ids
+        assert payload["he_id"] == 99
+        assert payload["estado"] == "pendente"
+        cont.assert_called_once()
+        _ = outro

--- a/backend/tests/test_ponto_lote_c_968_971_972.py
+++ b/backend/tests/test_ponto_lote_c_968_971_972.py
@@ -5,9 +5,47 @@ from datetime import date, datetime, timedelta, timezone
 from app.services.escala import PONTO_TZ
 
 
-def _patch_jornada_hoje(client, headers, atendente_id: int, *, inicio="08:00", fim="18:00", tol=30):
+def _freeze_ponto_agora(monkeypatch, when: datetime) -> None:
+    """Evita flakiness quando o pytest roda perto da meia-noite (jornada semanal)."""
+    when_utc = when.astimezone(timezone.utc)
+    monkeypatch.setattr("app.services.ponto._agora_utc", lambda: when_utc)
+    import app.services.escala as escala_mod
+    import app.services.ponto as ponto_mod
+
+    real_dt = ponto_mod.datetime
+
+    class DatetimeComAgoraFixo(real_dt):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is not None:
+                return when.astimezone(tz)
+            return when.replace(tzinfo=None)
+
+    monkeypatch.setattr(ponto_mod, "datetime", DatetimeComAgoraFixo)
+    monkeypatch.setattr(escala_mod, "datetime", DatetimeComAgoraFixo)
+
+    real_date = ponto_mod.date
+
+    class DateComHojeFixo(real_date):
+        @classmethod
+        def today(cls):
+            return when.date()
+
+    monkeypatch.setattr(ponto_mod, "date", DateComHojeFixo)
+
+
+def _patch_jornada_hoje(
+    client,
+    headers,
+    atendente_id: int,
+    *,
+    ref: date | None = None,
+    inicio="08:00",
+    fim="18:00",
+    tol=30,
+):
     keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
-    hoje_key = keys[date.today().weekday()]
+    hoje_key = keys[(ref or date.today()).weekday()]
     hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
     hs[hoje_key] = {"ativo": True, "inicio": inicio, "fim": fim}
     return client.patch(
@@ -26,16 +64,16 @@ def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, 
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
     a1 = seed_base["a1"]
-    agora = datetime.now(PONTO_TZ)
+    agora = datetime(2026, 6, 17, 10, 0, tzinfo=PONTO_TZ)
+    _freeze_ponto_agora(monkeypatch, agora)
     # Coloca início da jornada 10 min no futuro e tol=30 → já estamos em inicio−tol
     inicio_dt = agora + timedelta(minutes=10)
     fim_dt = inicio_dt + timedelta(hours=8)
-    # Jornada semanal não pode cruzar meia-noite
-    if fim_dt.date() != inicio_dt.date():
-        fim_dt = inicio_dt.replace(hour=23, minute=59, second=0, microsecond=0)
     inicio = inicio_dt.strftime("%H:%M")
     fim = fim_dt.strftime("%H:%M")
-    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    assert _patch_jornada_hoje(
+        client, admin, a1.id, ref=agora.date(), inicio=inicio, fim=fim, tol=30
+    ).status_code == 200
     r = client.get("/v1/ponto/me/alertas", headers=user)
     assert r.status_code == 200, r.text
     body = r.json()
@@ -43,27 +81,28 @@ def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, 
     assert any("Janela de entrada" in m for m in body["mensagens"])
 
 
-def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session):
+def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session, monkeypatch):
     from app.models.ponto_batida import PontoBatida
 
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
     a1 = seed_base["a1"]
-    agora = datetime.now(PONTO_TZ)
+    agora = datetime(2026, 6, 17, 16, 50, tzinfo=PONTO_TZ)
+    _freeze_ponto_agora(monkeypatch, agora)
     # fim daqui a 10 min, tol 30 → já na janela de saída
     fim_dt = agora + timedelta(minutes=10)
     inicio_dt = fim_dt - timedelta(hours=8)
-    if inicio_dt.date() != fim_dt.date():
-        inicio_dt = fim_dt.replace(hour=0, minute=0, second=0, microsecond=0)
     inicio = inicio_dt.strftime("%H:%M")
     fim = fim_dt.strftime("%H:%M")
-    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    assert _patch_jornada_hoje(
+        client, admin, a1.id, ref=agora.date(), inicio=inicio, fim=fim, tol=30
+    ).status_code == 200
     db_session.add(
         PontoBatida(
             tenant_id=a1.tenant_id,
             atendente_id=a1.id,
             tipo="entrada",
-            registrado_em=datetime.now(timezone.utc) - timedelta(hours=7),
+            registrado_em=agora.astimezone(timezone.utc) - timedelta(hours=7),
             origem="app",
         )
     )

--- a/backend/tests/test_ponto_lote_d_969_974.py
+++ b/backend/tests/test_ponto_lote_d_969_974.py
@@ -1,0 +1,186 @@
+"""Lote D: solicitação HE (#969) + teto mensal (#974)."""
+
+from datetime import date, datetime, timedelta
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def test_colaborador_solicita_he_com_janela(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    r = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Pico", "modo": "duracao", "duracao_minutos": 45},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["estado"] == "pendente"
+    assert body["modo"] == "duracao"
+    assert "45 min" in (body.get("motivo") or "")
+    pend = client.get("/v1/ponto/hora-extra?estado=pendente", headers=admin)
+    assert pend.status_code == 200
+    assert any(x["id"] == body["id"] for x in pend.json())
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    assert st.json()["pedido_pendente"]["id"] == body["id"]
+    # Admin aprova usando janela do pedido
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{body['id']}/decidir",
+        headers=admin,
+        json={"aprovar": True},
+    )
+    assert dec.status_code == 200, dec.text
+    assert dec.json()["estado"] == "aprovada"
+    assert dec.json()["modo"] == "duracao"
+    st2 = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st2.json()["he_ativa"] is not None
+    _ = a1  # seed usado via auth
+
+
+def test_he_rejeitada_feedback(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    sol = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Preciso", "modo": "resto_do_dia"},
+    )
+    assert sol.status_code == 201, sol.text
+    he_id = sol.json()["id"]
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{he_id}/decidir",
+        headers=admin,
+        json={"aprovar": False, "decisao_motivo": "Sem necessidade hoje"},
+    )
+    assert dec.status_code == 200
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    rej = st.json()["ultimo_rejeitado"]
+    assert rej is not None
+    assert "Sem necessidade" in (rej.get("decisao_motivo") or "")
+
+
+def test_teto_mensal_bloqueia_concessao(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 60},
+    ).status_code == 200
+    r1 = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 60},
+    )
+    assert r1.status_code == 201, r1.text
+    r2 = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+    )
+    assert r2.status_code == 400, r2.text
+    assert "mensal" in r2.json()["detail"].lower()
+
+
+def test_teto_mensal_global_settings_e_digest(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    st = client.patch(
+        "/v1/ponto/settings",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 45},
+    )
+    assert st.status_code == 200, st.text
+    assert st.json()["he_teto_mensal_minutos"] == 45
+    assert client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 45},
+    ).status_code == 201
+    # Segunda concessão estoura
+    assert (
+        client.post(
+            "/v1/ponto/hora-extra/conceder",
+            headers=admin,
+            json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+        ).status_code
+        == 400
+    )
+    dig = client.get("/v1/ponto/digest", headers=admin)
+    assert dig.status_code == 200
+    assert "he_acima_teto_mensal" in dig.json()
+    # Consumido == teto ainda não conta como "acima" (> teto)
+    assert dig.json()["he_acima_teto_mensal"] >= 0
+
+
+def test_solicitar_bloqueado_quando_teto_mensal_cheio(client, seed_base, auth_headers, db_session):
+    from app.models.ponto_hora_extra import PontoHoraExtra
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 30},
+    ).status_code == 200
+    assert client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+    ).status_code == 201
+    # Expira a HE ativa para isolar o bloqueio de teto mensal
+    row = (
+        db_session.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == a1.id, PontoHoraExtra.estado == "aprovada")
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    assert row is not None
+    row.estado = "expirada"
+    db_session.commit()
+    r = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Mais", "modo": "duracao", "duracao_minutos": 30},
+    )
+    assert r.status_code == 400
+    assert "mensal" in r.json()["detail"].lower()
+
+
+def test_me_status_campos_mensais(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 120},
+    ).status_code == 200
+    fim = (datetime.now(PONTO_TZ) + timedelta(hours=2)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    body = st.json()
+    assert body["he_teto_mensal_minutos"] == 120
+    assert body["he_consumido_mensal_minutos"] >= 0

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -27,6 +27,7 @@ Evento inicial ao conectar:
 | `notificacao.contagem` | RT-F3 — contadores navbar | `NotificacaoResumo` (compatível com `/notificacoes/resumo`) |
 | `chat.interno.mensagem` | Nova mensagem no chat interno | `{ conversa_id, tipo, setor_id?, remetente_id, corpo_preview }` |
 | `chat.interno.mensagem.atualizada` | Mensagem editada, apagada ou reação alterada | `{ conversa_id, mensagem_id, acao }` — `acao`: `editada` \| `apagada` \| `reacao` |
+| `ponto.he_atualizada` | Pedido/decisão/concessão de hora extra (#982) | `{ he_id, atendente_id, estado, origem }` |
 
 Destinatários filtrados por RBAC (setor homônimo + admin).
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2516,6 +2516,7 @@ export namespace Atendentes {
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
     he_teto_minutos?: number | null;
+    he_teto_mensal_minutos?: number | null;
     /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
     saas_setor_ids?: number[];
     saas_setor_nomes?: string[];
@@ -2539,6 +2540,7 @@ export namespace Atendentes {
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
     he_teto_minutos?: number | null;
+    he_teto_mensal_minutos?: number | null;
   }
   export interface Update {
     email?: string;
@@ -2559,6 +2561,7 @@ export namespace Atendentes {
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
     he_teto_minutos?: number | null;
+    he_teto_mensal_minutos?: number | null;
   }
   export interface AvaliacaoResumo {
     media: number | null;
@@ -4908,6 +4911,7 @@ export namespace Ponto {
     jornadas_abertas: number
     online_sem_ponto: number
     justificativas_pendentes: number
+    he_acima_teto_mensal?: number
     itens: HojeItem[]
   }
   export interface Settings {
@@ -4916,6 +4920,7 @@ export namespace Ponto {
     fecho_apos_horas: number
     fecho_margem_pos_saida_minutos: number
     jornada_diaria_minutos: number
+    he_teto_mensal_minutos?: number | null
     politica_geolocalizacao: PoliticaGeolocalizacao
   }
   export interface SettingsPublic {
@@ -4928,6 +4933,7 @@ export namespace Ponto {
     fecho_apos_horas?: number
     fecho_margem_pos_saida_minutos?: number
     jornada_diaria_minutos?: number
+    he_teto_mensal_minutos?: number | null
     politica_geolocalizacao?: PoliticaGeolocalizacao
   }
   export interface Local {
@@ -5039,6 +5045,9 @@ export namespace Ponto {
   }
   export interface HoraExtraCreate {
     motivo?: string | null
+    modo?: 'resto_do_dia' | 'ate_horario' | 'duracao' | null
+    ate_horario?: string | null
+    duracao_minutos?: number | null
   }
   export interface HoraExtraDecisao {
     aprovar: boolean
@@ -5059,8 +5068,11 @@ export namespace Ponto {
     pode_pegar_whatsapp: boolean
     he_ativa?: HoraExtra | null
     pedido_pendente?: HoraExtra | null
+    ultimo_rejeitado?: HoraExtra | null
     he_teto_minutos?: number | null
     he_restante_minutos?: number | null
+    he_teto_mensal_minutos?: number | null
+    he_consumido_mensal_minutos?: number
   }
 }
 

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -60,6 +60,7 @@ export function AtendenteForm() {
   const [usarLocalEmpresa, setUsarLocalEmpresa] = useState(true)
   const [localEmpresaRaio, setLocalEmpresaRaio] = useState('')
   const [heTetoMinutos, setHeTetoMinutos] = useState('')
+  const [heTetoMensalMinutos, setHeTetoMensalMinutos] = useState('')
 
   useEffect(() => {
     coletarTodasPaginas<Setores.Setor>((o, l) =>
@@ -108,6 +109,7 @@ export function AtendenteForm() {
           a.local_empresa_raio_metros != null ? String(a.local_empresa_raio_metros) : '',
         )
         setHeTetoMinutos(a.he_teto_minutos != null ? String(a.he_teto_minutos) : '')
+        setHeTetoMensalMinutos(a.he_teto_mensal_minutos != null ? String(a.he_teto_mensal_minutos) : '')
         if (a.escala_horas_trabalho === 12 && a.escala_horas_folga === 36) setPresetEscala('12x36')
         else if (a.escala_horas_trabalho === 6 && a.escala_horas_folga === 18) setPresetEscala('6x18')
         else if (a.escala_horas_trabalho === 24 && a.escala_horas_folga === 48) setPresetEscala('24x48')
@@ -202,10 +204,16 @@ export function AtendenteForm() {
     }
   }
 
-  function payloadHeTeto(): { he_teto_minutos: number | null } {
+  function payloadHeTeto(): {
+    he_teto_minutos: number | null
+    he_teto_mensal_minutos: number | null
+  } {
     const raw = heTetoMinutos.trim()
-    if (!raw) return { he_teto_minutos: null }
-    return { he_teto_minutos: Math.min(1440, Math.max(15, Number(raw) || 15)) }
+    const rawM = heTetoMensalMinutos.trim()
+    return {
+      he_teto_minutos: raw ? Math.min(1440, Math.max(15, Number(raw) || 15)) : null,
+      he_teto_mensal_minutos: rawM ? Math.min(44640, Math.max(30, Number(rawM) || 30)) : null,
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -469,6 +477,19 @@ export function AtendenteForm() {
               <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                 Vazio = sem teto. Cada concessão (resto do dia, até horário ou duração) é limitada a esse
                 máximo a partir do momento da liberação.
+              </p>
+              <Input
+                className="mt-3"
+                label="Teto mensal (minutos)"
+                type="number"
+                min={30}
+                max={44640}
+                value={heTetoMensalMinutos}
+                onChange={(e) => setHeTetoMensalMinutos(e.target.value)}
+                placeholder="Usar global / sem limite"
+              />
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Sobrescreve o teto global de Ponto da equipe. Vazio = usa o global (se houver).
               </p>
             </FormSection>
             {isEdit && !Number.isNaN(atendenteId) ? (

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -10,6 +10,7 @@ import { Input } from '../components/ui/Input'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
+import { useEventStream } from '../contexts/EventStreamContext'
 import { isCapacitorNative } from '../lib/capacitorNative'
 import { geolocationSupported, getCurrentPosition, type GeoError } from '../lib/geolocation'
 import {
@@ -46,6 +47,7 @@ type AcaoPrincipal = {
 
 export function MeuPonto() {
   const toast = useToast()
+  const { subscribe } = useEventStream()
   const [estado, setEstado] = useState<Ponto.EstadoMe | null>(null)
   const [historico, setHistorico] = useState<Ponto.Historico | null>(null)
   const [desde, setDesde] = useState(inicioMesIso)
@@ -79,6 +81,13 @@ export function MeuPonto() {
     lon: number
     label: string
   } | null>(null)
+  const [heStatus, setHeStatus] = useState<Ponto.HoraExtraMeStatus | null>(null)
+  const [heHist, setHeHist] = useState<Ponto.HoraExtra[]>([])
+  const [heMotivo, setHeMotivo] = useState('')
+  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
+  const [heAteHorario, setHeAteHorario] = useState('20:00')
+  const [heDuracaoMin, setHeDuracaoMin] = useState('60')
+  const [enviandoHe, setEnviandoHe] = useState(false)
 
   const politicaGeo = geoSettings?.politica_geolocalizacao ?? 'opcional'
   const geoObrigatoria = politicaGeo === 'obrigatoria' && !!geoSettings?.tem_locais_ativos
@@ -88,18 +97,22 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs] = await Promise.all([
+        const [me, hist, js, bh, gs, heSt, heList] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
           ponto.meuBancoHoras(desde, ate),
           ponto.meSettings(),
+          ponto.horaExtraMeStatus(),
+          ponto.minhasHoraExtra(),
         ])
         setEstado(me)
         setHistorico(hist)
         setJustifs(js)
         setBanco(bh)
         setGeoSettings(gs)
+        setHeStatus(heSt)
+        setHeHist(heList)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -148,6 +161,13 @@ export function MeuPonto() {
   useEffect(() => {
     void carregar()
   }, [carregar])
+
+  useEffect(() => {
+    const unsub = subscribe('ponto.he_atualizada', () => {
+      void carregar(true)
+    })
+    return unsub
+  }, [subscribe, carregar])
 
   useEffect(() => {
     void carregarResumoSemana(true)
@@ -284,6 +304,33 @@ export function MeuPonto() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a justificativa.'))
     } finally {
       setEnviandoJust(false)
+    }
+  }
+
+  async function solicitarHe() {
+    if (heStatus?.pedido_pendente) {
+      toast.showWarning('Já existe um pedido de hora extra aguardando decisão.')
+      return
+    }
+    if (heStatus?.he_ativa) {
+      toast.showWarning('Você já tem hora extra ativa.')
+      return
+    }
+    setEnviandoHe(true)
+    try {
+      await ponto.solicitarHoraExtra({
+        motivo: heMotivo.trim() || null,
+        modo: heModo,
+        ate_horario: heModo === 'ate_horario' ? heAteHorario : null,
+        duracao_minutos: heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
+      })
+      toast.showSuccess('Pedido de hora extra enviado.')
+      setHeMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível solicitar hora extra.'))
+    } finally {
+      setEnviandoHe(false)
     }
   }
 
@@ -574,6 +621,97 @@ export function MeuPonto() {
             tone={resumoSemana && resumoSemana.saldo_segundos < 0 ? 'warn' : 'good'}
           />
         </div>
+      </Card>
+
+      <Card className="mt-4" title="Hora extra (WhatsApp)">
+        {heStatus?.he_ativa ? (
+          <p className="mb-3 text-sm text-emerald-800 dark:text-emerald-200">
+            Hora extra ativa
+            {heStatus.he_restante_minutos != null
+              ? ` — restam cerca de ${heStatus.he_restante_minutos} min`
+              : ''}
+            {heStatus.he_ativa.ate_em
+              ? ` (até ${formatarHora(heStatus.he_ativa.ate_em)})`
+              : ''}
+            .
+          </p>
+        ) : null}
+        {heStatus?.pedido_pendente ? (
+          <p className="mb-3 text-sm text-amber-800 dark:text-amber-200">
+            Pedido pendente de aprovação
+            {heStatus.pedido_pendente.modo ? ` (${heStatus.pedido_pendente.modo.replace(/_/g, ' ')})` : ''}
+            .
+          </p>
+        ) : null}
+        {heStatus?.ultimo_rejeitado ? (
+          <p className="mb-3 text-sm text-rose-800 dark:text-rose-200">
+            Último pedido negado
+            {heStatus.ultimo_rejeitado.decisao_motivo
+              ? `: ${heStatus.ultimo_rejeitado.decisao_motivo}`
+              : '.'}
+          </p>
+        ) : null}
+        {heStatus?.he_teto_mensal_minutos != null ? (
+          <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
+            Consumo no mês: {heStatus.he_consumido_mensal_minutos ?? 0} / {heStatus.he_teto_mensal_minutos}{' '}
+            min
+          </p>
+        ) : null}
+        {!heStatus?.he_ativa && !heStatus?.pedido_pendente ? (
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Janela desejada"
+              value={heModo}
+              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario' | 'duracao')}
+              options={[
+                { value: 'resto_do_dia', label: 'Resto do dia' },
+                { value: 'ate_horario', label: 'Até horário' },
+                { value: 'duracao', label: 'Duração (minutos)' },
+              ]}
+            />
+            {heModo === 'ate_horario' ? (
+              <Input
+                label="Até (HH:MM)"
+                type="time"
+                value={heAteHorario}
+                onChange={(e) => setHeAteHorario(e.target.value)}
+              />
+            ) : null}
+            {heModo === 'duracao' ? (
+              <Input
+                label="Minutos"
+                type="number"
+                min={15}
+                max={1440}
+                value={heDuracaoMin}
+                onChange={(e) => setHeDuracaoMin(e.target.value)}
+              />
+            ) : null}
+            <Input
+              label="Motivo"
+              value={heMotivo}
+              onChange={(e) => setHeMotivo(e.target.value)}
+              placeholder="Ex.: pico no WhatsApp"
+            />
+            <Button type="button" disabled={enviandoHe} onClick={() => void solicitarHe()}>
+              Solicitar HE
+            </Button>
+          </div>
+        ) : null}
+        {heHist.length > 0 ? (
+          <ul className="space-y-2 border-t border-slate-200 pt-3 dark:border-slate-700">
+            {heHist.slice(0, 8).map((h) => (
+              <li key={h.id} className="text-sm text-slate-600 dark:text-slate-300">
+                <span className="font-medium text-slate-800 dark:text-slate-100">{h.estado}</span>
+                {h.modo ? ` · ${h.modo.replace(/_/g, ' ')}` : ''}
+                {h.motivo ? ` — ${h.motivo}` : ''}
+                {h.decisao_motivo && h.estado === 'rejeitada' ? ` (${h.decisao_motivo})` : ''}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-slate-500">Nenhum pedido recente.</p>
+        )}
       </Card>
 
       <div className="mt-4 grid gap-4 lg:grid-cols-2">

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -12,6 +12,7 @@ import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
+import { useEventStream } from '../contexts/EventStreamContext'
 import {
   formatarDuracao,
   formatarHora,
@@ -42,6 +43,14 @@ function rotuloStatus(s: Ponto.HojeItem['status']): string {
   }
 }
 
+function extrairJanelaHeMotivo(motivo?: string | null): { ate?: string; duracao?: number } {
+  if (!motivo) return {}
+  const ate = motivo.match(/\[até\s+(\d{1,2}:\d{2})\]/i)?.[1]
+  const durRaw = motivo.match(/\[(\d+)\s*min\]/i)?.[1]
+  const duracao = durRaw ? Number(durRaw) : undefined
+  return { ate, duracao: Number.isFinite(duracao) ? duracao : undefined }
+}
+
 function toDatetimeLocalValue(d = new Date()): string {
   const pad = (n: number) => String(n).padStart(2, '0')
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
@@ -50,6 +59,7 @@ function toDatetimeLocalValue(d = new Date()): string {
 export function PontoEquipe() {
   const toast = useToast()
   const { user } = useAuth()
+  const { subscribe } = useEventStream()
   const [items, setItems] = useState<Ponto.BatidaAdmin[]>([])
   const [total, setTotal] = useState(0)
   const [hoje, setHoje] = useState<Ponto.HojeLista | null>(null)
@@ -149,6 +159,13 @@ export function PontoEquipe() {
   useEffect(() => {
     void carregar()
   }, [carregar])
+
+  useEffect(() => {
+    const unsub = subscribe('ponto.he_atualizada', () => {
+      void carregar(true)
+    })
+    return unsub
+  }, [subscribe, carregar])
 
   const carregarAjustesAudit = useCallback(async () => {
     setCarregandoAjustes(true)
@@ -320,12 +337,21 @@ export function PontoEquipe() {
   async function decidirHe(id: number, aprovar: boolean) {
     setDecidindoHeId(id)
     try {
+      const pend = hesPendentes.find((h) => h.id === id)
+      const hints = extrairJanelaHeMotivo(pend?.motivo)
+      const modoPed =
+        pend?.modo === 'resto_do_dia' || pend?.modo === 'ate_horario' || pend?.modo === 'duracao'
+          ? pend.modo
+          : null
+      const modo = aprovar ? modoPed || heModo : null
       await ponto.decidirHoraExtra(id, {
         aprovar,
-        modo: aprovar ? heModo : null,
-        ate_horario: aprovar && heModo === 'ate_horario' ? heAteHorario : null,
+        modo,
+        ate_horario: aprovar && modo === 'ate_horario' ? hints.ate || heAteHorario : null,
         duracao_minutos:
-          aprovar && heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
+          aprovar && modo === 'duracao'
+            ? Math.max(15, hints.duracao || Number(heDuracaoMin) || 60)
+            : null,
         decisao_motivo: aprovar ? null : 'Negado pelo administrador',
       })
       toast.showSuccess(aprovar ? 'Hora extra liberada.' : 'Pedido de hora extra negado.')
@@ -371,6 +397,7 @@ export function PontoEquipe() {
         fecho_apos_horas: settings.fecho_apos_horas,
         fecho_margem_pos_saida_minutos: settings.fecho_margem_pos_saida_minutos ?? 30,
         jornada_diaria_minutos: settings.jornada_diaria_minutos,
+        he_teto_mensal_minutos: settings.he_teto_mensal_minutos ?? null,
         politica_geolocalizacao: settings.politica_geolocalizacao,
       })
       setSettings(st)
@@ -432,7 +459,7 @@ export function PontoEquipe() {
             <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Digest de hoje
             </p>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
               <PontoMetricCard label="Faltas" value={String(digest?.faltas ?? 0)} tone="warn" />
               <PontoMetricCard label="Atrasos" value={String(digest?.atrasos ?? 0)} tone="warn" />
               <PontoMetricCard
@@ -449,6 +476,12 @@ export function PontoEquipe() {
                 label="Justificativas"
                 value={String(digest?.justificativas_pendentes ?? 0)}
                 hint="pendentes"
+              />
+              <PontoMetricCard
+                label="HE acima do teto"
+                value={String(digest?.he_acima_teto_mensal ?? 0)}
+                hint="mês (pessoas)"
+                tone={(digest?.he_acima_teto_mensal ?? 0) > 0 ? 'warn' : 'neutral'}
               />
             </div>
             {(digest?.itens ?? []).some((i) => i.status === 'falta' || i.atrasado) ? (
@@ -614,6 +647,9 @@ export function PontoEquipe() {
                   <div className="text-sm">
                     <p className="font-medium">{h.atendente_nome ?? h.atendente_id}</p>
                     <p className="text-slate-600 dark:text-slate-300">{h.motivo || 'Sem motivo informado'}</p>
+                    {h.modo ? (
+                      <p className="text-xs text-slate-500">Janela pedida: {h.modo.replace(/_/g, ' ')}</p>
+                    ) : null}
                   </div>
                   <div className="flex gap-2">
                     <Button
@@ -943,6 +979,27 @@ export function PontoEquipe() {
                   })
                 }
               />
+              <Input
+                label="Teto mensal de HE (minutos, global)"
+                type="number"
+                min={30}
+                max={44640}
+                value={
+                  settings.he_teto_mensal_minutos != null ? String(settings.he_teto_mensal_minutos) : ''
+                }
+                onChange={(e) => {
+                  const raw = e.target.value.trim()
+                  setSettings({
+                    ...settings,
+                    he_teto_mensal_minutos: raw ? Math.max(30, Number(raw) || 30) : null,
+                  })
+                }}
+                placeholder="Sem limite global"
+              />
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Vazio = sem teto global. Pode ser sobrescrito por pessoa no cadastro. Ao atingir o teto,
+                novas liberações são bloqueadas.
+              </p>
               <Select
                 label="Política de geolocalização"
                 value={settings.politica_geolocalizacao ?? 'opcional'}


### PR DESCRIPTION
## Summary
- Colaborador solicita hora extra com janela desejada (resto do dia / até horário / duração); admin aprova ou nega com feedback e histórico (#969)
- Teto mensal de HE (global em configurações do ponto e/ou por pessoa no cadastro); bloqueia novas liberações ao exceder; digest mostra quem está acima (#974)
- SSE `ponto.he_atualizada` atualiza admin e colaborador em tempo real (#982)

Closes #969
Closes #974
Closes #982

## Test plan
- [ ] Meu ponto: solicitar HE com cada modo; ver pedido pendente e histórico
- [ ] Admin em Ponto da equipe: liberar/negar pedido; colaborador recebe status sem F5
- [ ] Configurar teto mensal global e por pessoa; confirmar bloqueio ao exceder e card no digest
- [ ] `pytest`: `test_ponto_lote_d_969_974.py` e `test_ponto_he_sse_982.py`
- [ ] Migration `130_ponto_he_teto_mensal` sobe limpa (`alembic upgrade head`)

Made with [Cursor](https://cursor.com)