### PR TITLE
feat(ponto): Lote E — ausências, anexo e pausa mínima (#976/#977/#973)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
+
 #### Correções
 
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta

--- a/backend/alembic/versions/130_ponto_lote_e.py
+++ b/backend/alembic/versions/130_ponto_lote_e.py
@@ -1,0 +1,94 @@
+"""Lote E: ausências programadas, pausa mínima, anexo justificativa (#976/#973/#977).
+
+Revision ID: 130_ponto_lote_e
+Revises: 129_merge_he_teto_versao
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "130_ponto_lote_e"
+down_revision = "129_merge_he_teto_versao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("ponto_ausencias"):
+        op.create_table(
+            "ponto_ausencias",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("tipo", sa.String(32), nullable=False),
+            sa.Column("desde", sa.Date(), nullable=False),
+            sa.Column("ate", sa.Date(), nullable=False),
+            sa.Column("motivo", sa.String(1000), nullable=True),
+            sa.Column("estado", sa.String(20), nullable=False, server_default="pendente"),
+            sa.Column("origem", sa.String(20), nullable=False, server_default="solicitacao"),
+            sa.Column(
+                "decidido_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("decidido_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("decisao_motivo", sa.String(1000), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        )
+        op.create_index("ix_ponto_ausencias_tenant_id", "ponto_ausencias", ["tenant_id"])
+        op.create_index("ix_ponto_ausencias_atendente_id", "ponto_ausencias", ["atendente_id"])
+        op.create_index("ix_ponto_ausencias_desde", "ponto_ausencias", ["desde"])
+        op.create_index("ix_ponto_ausencias_ate", "ponto_ausencias", ["ate"])
+
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "pausa_minima_minutos" not in cols:
+            op.add_column(
+                "ponto_settings",
+                sa.Column("pausa_minima_minutos", sa.Integer(), nullable=False, server_default="0"),
+            )
+
+    if insp.has_table("ponto_justificativas"):
+        cols = {c["name"] for c in insp.get_columns("ponto_justificativas")}
+        if "anexo_nome" not in cols:
+            op.add_column("ponto_justificativas", sa.Column("anexo_nome", sa.String(255), nullable=True))
+        if "anexo_content_type" not in cols:
+            op.add_column(
+                "ponto_justificativas", sa.Column("anexo_content_type", sa.String(128), nullable=True)
+            )
+        if "anexo_storage_key" not in cols:
+            op.add_column(
+                "ponto_justificativas", sa.Column("anexo_storage_key", sa.String(255), nullable=True)
+            )
+        if "anexo_tamanho_bytes" not in cols:
+            op.add_column(
+                "ponto_justificativas", sa.Column("anexo_tamanho_bytes", sa.Integer(), nullable=True)
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_justificativas"):
+        cols = {c["name"] for c in insp.get_columns("ponto_justificativas")}
+        for col in ("anexo_tamanho_bytes", "anexo_storage_key", "anexo_content_type", "anexo_nome"):
+            if col in cols:
+                op.drop_column("ponto_justificativas", col)
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "pausa_minima_minutos" in cols:
+            op.drop_column("ponto_settings", "pausa_minima_minutos")
+    if insp.has_table("ponto_ausencias"):
+        op.drop_table("ponto_ausencias")

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import date
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.core.auth import exigir_admin, obter_atendente_atual
@@ -16,6 +17,10 @@ from app.schemas.ponto import (
     PontoAjusteUpdate,
     PontoAlertasMe,
     PontoAnularBody,
+    PontoAusenciaConceder,
+    PontoAusenciaCreate,
+    PontoAusenciaDecisao,
+    PontoAusenciaRead,
     PontoBancoHorasRead,
     PontoBatidaAdminItem,
     PontoBatidaRead,
@@ -44,8 +49,10 @@ from app.schemas.ponto import (
     PontoSettingsUpdate,
 )
 from app.services import ponto as ponto_svc
+from app.services import ponto_ausencia as ausencia_svc
 from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
+from app.services import ponto_justificativa_storage as just_anexo_svc
 from app.services import ponto_relatorio as ponto_relatorio_svc
 from app.services import ponto_settings as ponto_settings_svc
 
@@ -430,6 +437,58 @@ def criar_justificativa(
     )
 
 
+@router.post("/justificativas/upload", response_model=PontoJustificativaRead, status_code=201)
+async def criar_justificativa_com_anexo(
+    data_ref: date = Form(...),
+    tipo: str = Form(...),
+    motivo: str = Form(...),
+    arquivo: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    raw = await arquivo.read()
+    try:
+        nome, mime = just_anexo_svc.validar_anexo_justificativa(
+            arquivo.filename, arquivo.content_type, len(raw)
+        )
+        key = just_anexo_svc.gravar_bytes(raw, mimetype=mime, nome_original=nome)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return just_svc.criar(
+        db,
+        atendente,
+        data_ref=data_ref,
+        tipo=tipo,
+        motivo=motivo,
+        anexo_nome=nome,
+        anexo_content_type=mime,
+        anexo_storage_key=key,
+        anexo_tamanho_bytes=len(raw),
+    )
+
+
+@router.get("/justificativas/{justificativa_id}/anexo")
+def baixar_anexo_justificativa(
+    justificativa_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    row = just_svc.obter_para_anexo(
+        db,
+        justificativa_id=justificativa_id,
+        tenant_id=atendente.tenant_id,
+        solicitante=atendente,
+    )
+    path = just_anexo_svc.caminho_absoluto(row.anexo_storage_key)
+    if path is None:
+        raise HTTPException(status_code=404, detail="Arquivo do anexo não encontrado")
+    return FileResponse(
+        path,
+        media_type=row.anexo_content_type or "application/octet-stream",
+        filename=row.anexo_nome or path.name,
+    )
+
+
 @router.get("/justificativas/me", response_model=list[PontoJustificativaRead])
 def minhas_justificativas(
     db: Session = Depends(get_db),
@@ -462,6 +521,82 @@ def decidir_justificativa(
         decisao_motivo=data.decisao_motivo,
         aplicar_batidas=data.aplicar_batidas,
     )
+
+
+@router.post("/ausencias", response_model=PontoAusenciaRead, status_code=201)
+def solicitar_ausencia(
+    data: PontoAusenciaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return ausencia_svc.solicitar(
+        db,
+        atendente,
+        tipo=data.tipo,
+        desde=data.desde,
+        ate=data.ate,
+        motivo=data.motivo,
+    )
+
+
+@router.get("/ausencias/me", response_model=list[PontoAusenciaRead])
+def minhas_ausencias(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return ausencia_svc.listar_me(db, atendente)
+
+
+@router.get("/ausencias", response_model=list[PontoAusenciaRead])
+def listar_ausencias_admin(
+    estado: str | None = Query("pendente"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ausencia_svc.listar_admin(db, admin, estado=estado)
+
+
+@router.post("/ausencias/conceder", response_model=PontoAusenciaRead, status_code=201)
+def conceder_ausencia(
+    data: PontoAusenciaConceder,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ausencia_svc.conceder_admin(
+        db,
+        admin,
+        atendente_id=data.atendente_id,
+        tipo=data.tipo,
+        desde=data.desde,
+        ate=data.ate,
+        motivo=data.motivo,
+    )
+
+
+@router.post("/ausencias/{ausencia_id}/decidir", response_model=PontoAusenciaRead)
+def decidir_ausencia(
+    ausencia_id: int,
+    data: PontoAusenciaDecisao,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ausencia_svc.decidir(
+        db,
+        admin,
+        ausencia_id,
+        aprovar=data.aprovar,
+        decisao_motivo=data.decisao_motivo,
+    )
+
+
+@router.delete("/ausencias/{ausencia_id}", status_code=204)
+def remover_ausencia(
+    ausencia_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    ausencia_svc.remover_admin(db, admin, ausencia_id)
+    return Response(status_code=204)
 
 
 @router.get("/hora-extra/me/status", response_model=PontoHoraExtraMeStatus)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -56,6 +56,10 @@ class Settings(BaseSettings):
     # Tamanho máximo (bytes) para cada anexo de ticket.
     TICKET_ANEXOS_MAX_BYTES: int = 25 * 1024 * 1024
 
+    # Anexos de justificativa de ponto (#977) — mesmos limites de tamanho.
+    PONTO_JUSTIFICATIVA_ANEXOS_DIR: str = "data/ponto_justificativa_anexos"
+    PONTO_JUSTIFICATIVA_ANEXOS_MAX_BYTES: int = 25 * 1024 * 1024
+
     # Mídia de sugestões/problemas (#856+): prints no texto + PDF/vídeo em anexo.
     SOLICITACAO_MEDIA_DIR: str = "data/solicitacao_media"
     SOLICITACAO_MEDIA_MAX_BYTES: int = 25 * 1024 * 1024

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.atendente import Atendente, AtendenteSetor
 from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
+from app.models.ponto_ausencia import PontoAusencia
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
@@ -102,6 +103,7 @@ __all__ = [
     "PontoBatida",
     "PontoJustificativa",
     "PontoHoraExtra",
+    "PontoAusencia",
     "PontoSettings",
     "PontoLocal",
     "PontoFeriado",

--- a/backend/app/models/ponto_ausencia.py
+++ b/backend/app/models/ponto_ausencia.py
@@ -1,4 +1,4 @@
-"""Justificativas de ponto (#774)."""
+"""Ausências programadas de ponto (#976)."""
 
 from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
@@ -7,24 +7,24 @@ from sqlalchemy.sql import func
 from app.database import Base
 
 
-class PontoJustificativa(Base):
-    __tablename__ = "ponto_justificativas"
+class PontoAusencia(Base):
+    __tablename__ = "ponto_ausencias"
 
     id = Column(Integer, primary_key=True, index=True)
     tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
-    data_ref = Column(Date, nullable=False, index=True)
-    tipo = Column(String(32), nullable=False)  # falta | esquecimento | folga_com_ponto | outro
-    motivo = Column(String(1000), nullable=False)
-    estado = Column(String(20), nullable=False, default="pendente")  # pendente | aprovada | rejeitada
-    decisao_motivo = Column(String(1000), nullable=True)
+    # ferias | folga_programada
+    tipo = Column(String(32), nullable=False)
+    desde = Column(Date, nullable=False, index=True)
+    ate = Column(Date, nullable=False, index=True)
+    motivo = Column(String(1000), nullable=True)
+    # pendente | aprovada | rejeitada
+    estado = Column(String(20), nullable=False, default="pendente", server_default="pendente")
+    # solicitacao | admin
+    origem = Column(String(20), nullable=False, default="solicitacao", server_default="solicitacao")
     decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
     decidido_em = Column(DateTime(timezone=True), nullable=True)
-    # Anexo opcional (#977)
-    anexo_nome = Column(String(255), nullable=True)
-    anexo_content_type = Column(String(128), nullable=True)
-    anexo_storage_key = Column(String(255), nullable=True)
-    anexo_tamanho_bytes = Column(Integer, nullable=True)
+    decisao_motivo = Column(String(1000), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     atendente = relationship("Atendente", foreign_keys=[atendente_id])

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -17,6 +17,8 @@ class PontoSettings(Base):
     # Margem após saída prevista do dia (#961); fecho = min(N horas, saída+margem).
     fecho_margem_pos_saida_minutos = Column(Integer, nullable=False, default=30, server_default="30")
     jornada_diaria_minutos = Column(Integer, nullable=False, default=480, server_default="480")
+    # 0 = desligado (#973)
+    pausa_minima_minutos = Column(Integer, nullable=False, default=0, server_default="0")
     # opcional | recomendada | obrigatoria (#844)
     politica_geolocalizacao = Column(String(20), nullable=False, default="opcional", server_default="opcional")
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -130,6 +130,8 @@ StatusDiaPonto = Literal[
     "parcial",
     "folga",
     "folga_com_ponto",
+    "folga_programada",
+    "ferias",
     "livre",
     "atraso",
     "feriado",
@@ -144,10 +146,13 @@ class PontoCalendarioDia(BaseModel):
     status: StatusDiaPonto
     atrasado: bool = False
     feriado: bool = False
+    ausencia_tipo: str | None = None  # ferias | folga_programada
+    pausa_abaixo_minimo: bool = False
     # #842 — meta de jornada × realizado (cores do calendário)
     segundos_trabalhados: int = 0
     segundos_esperados: int = 0
-    classe_visual: Literal["abaixo", "ok", "he", "feriado", "neutro"] = "neutro"
+    segundos_pausa: int = 0
+    classe_visual: Literal["abaixo", "ok", "he", "feriado", "ausencia", "neutro"] = "neutro"
 
 
 class PontoCalendarioRead(BaseModel):
@@ -207,6 +212,7 @@ class PontoSettingsRead(BaseModel):
     fecho_apos_horas: int = 14
     fecho_margem_pos_saida_minutos: int = 30
     jornada_diaria_minutos: int = 480
+    pausa_minima_minutos: int = 0
     politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
 
     model_config = ConfigDict(from_attributes=True)
@@ -218,6 +224,7 @@ class PontoSettingsUpdate(BaseModel):
     fecho_apos_horas: int | None = Field(default=None, ge=4, le=48)
     fecho_margem_pos_saida_minutos: int | None = Field(default=None, ge=0, le=240)
     jornada_diaria_minutos: int | None = Field(default=None, ge=60, le=1440)
+    pausa_minima_minutos: int | None = Field(default=None, ge=0, le=240)
     politica_geolocalizacao: PoliticaGeolocalizacao | None = None
 
 
@@ -262,6 +269,7 @@ class PontoAlertasMe(BaseModel):
     horas_jornada_aberta: float | None = None
     lembrete_entrada_tolerancia: bool = False
     lembrete_saida_tolerancia: bool = False
+    pausa_abaixo_minimo: bool = False
     mensagens: list[str] = []
 
 
@@ -296,6 +304,48 @@ class PontoJustificativaRead(BaseModel):
     decisao_motivo: str | None = None
     decidido_por_id: int | None = None
     decidido_em: datetime | None = None
+    tem_anexo: bool = False
+    anexo_nome: str | None = None
+    anexo_content_type: str | None = None
+    anexo_tamanho_bytes: int | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PontoAusenciaCreate(BaseModel):
+    tipo: Literal["ferias", "folga_programada"]
+    desde: date
+    ate: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoAusenciaConceder(BaseModel):
+    atendente_id: int = Field(..., ge=1)
+    tipo: Literal["ferias", "folga_programada"]
+    desde: date
+    ate: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoAusenciaDecisao(BaseModel):
+    aprovar: bool
+    decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoAusenciaRead(BaseModel):
+    id: int
+    atendente_id: int
+    atendente_nome: str | None = None
+    tipo: str
+    desde: date
+    ate: date
+    motivo: str | None = None
+    estado: str
+    origem: str = "solicitacao"
+    decidido_por_id: int | None = None
+    decidido_em: datetime | None = None
+    decisao_motivo: str | None = None
     created_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -432,7 +432,14 @@ def _status_dia(
     tem_saida: bool,
     feriado: bool = False,
     atrasado: bool = False,
+    ausencia_tipo: str | None = None,
 ) -> str:
+    if ausencia_tipo in ("ferias", "folga_programada"):
+        if tem_entrada and tem_saida:
+            return "ok"
+        if tem_entrada or tem_saida:
+            return "folga_com_ponto"
+        return ausencia_tipo
     if feriado:
         if tem_entrada and tem_saida:
             return "ok"
@@ -462,8 +469,11 @@ def _classe_visual_dia(
     esperado: bool,
     segundos_trabalhados: int,
     segundos_esperados: int,
+    ausencia_tipo: str | None = None,
 ) -> str:
-    """Paleta #842: vermelho abaixo / verde ok / azul HE / laranja feriado."""
+    """Paleta #842: vermelho abaixo / verde ok / azul HE / laranja feriado / violeta ausência."""
+    if ausencia_tipo in ("ferias", "folga_programada"):
+        return "ausencia"
     if feriado:
         return "feriado"
     meta = segundos_esperados if segundos_esperados > 0 else 0
@@ -476,6 +486,32 @@ def _classe_visual_dia(
     if segundos_trabalhados > meta:
         return "he"
     return "ok"
+
+
+def _segundos_pausas_do_dia(batidas: list[PontoBatida]) -> int:
+    """Soma todas as pausas fechadas do dia (fora dos blocos entrada→saída)."""
+    ordenadas = sorted(batidas, key=lambda b: (_as_utc(b.registrado_em), b.id))
+    total = 0
+    pendente: PontoBatida | None = None
+    for b in ordenadas:
+        if b.tipo == "pausa_inicio":
+            pendente = b
+        elif b.tipo == "pausa_fim" and pendente is not None:
+            total += max(0, int((_as_utc(b.registrado_em) - _as_utc(pendente.registrado_em)).total_seconds()))
+            pendente = None
+    return total
+
+
+def _pausa_abaixo_minimo(
+    *,
+    tem_entrada: bool,
+    segundos_pausa: int,
+    pausa_minima_minutos: int,
+) -> bool:
+    """#973 — sinaliza se iniciou jornada e a pausa total ficou abaixo do mínimo."""
+    if pausa_minima_minutos <= 0 or not tem_entrada:
+        return False
+    return segundos_pausa < pausa_minima_minutos * 60
 
 
 def calendario(
@@ -514,9 +550,14 @@ def calendario(
         por_dia.setdefault(d, []).append(b)
 
     usa = escala_svc.escala_configurada(atendente)
+    from app.services import ponto_ausencia as ausencia_svc
+
+    ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
+    pausa_min = int(getattr(settings, "pausa_minima_minutos", None) or 0)
     dias_out: list[PontoCalendarioDia] = []
     for d in dias_mes:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
+        ausencia_tipo = ausencias.get(d)
         esp = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
         bats = por_dia.get(d, [])
         te = any(b.tipo == "entrada" for b in bats)
@@ -524,7 +565,8 @@ def calendario(
         atrasado = _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats))
         intervalos = _intervalos_de_batidas(bats)
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
-        esperado_visual = bool(esp and not feriado)
+        pausas = _segundos_pausas_do_dia(bats)
+        esperado_visual = bool(esp and not feriado and not ausencia_tipo)
         if usa and esperado_visual:
             esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
@@ -548,16 +590,23 @@ def calendario(
                     tem_saida=ts,
                     feriado=feriado,
                     atrasado=atrasado,
+                    ausencia_tipo=ausencia_tipo,
                 ),
                 atrasado=atrasado,
                 feriado=feriado,
+                ausencia_tipo=ausencia_tipo,
+                pausa_abaixo_minimo=_pausa_abaixo_minimo(
+                    tem_entrada=te, segundos_pausa=pausas, pausa_minima_minutos=pausa_min
+                ),
                 segundos_trabalhados=trabalhados,
                 segundos_esperados=esperados,
+                segundos_pausa=pausas,
                 classe_visual=_classe_visual_dia(  # type: ignore[arg-type]
                     feriado=feriado,
                     esperado=esperado_para_cor,
                     segundos_trabalhados=trabalhados,
                     segundos_esperados=esperados,
+                    ausencia_tipo=ausencia_tipo,
                 ),
             )
         )
@@ -574,6 +623,7 @@ def calendario(
 
 
 def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
+    from app.services import ponto_ausencia as ausencia_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     hoje = datetime.now(PONTO_TZ).date()
@@ -593,6 +643,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     itens: list[PontoHojeItem] = []
     for a in atendentes:
         usa = escala_svc.escala_configurada(a)
+        ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, a.id, hoje)
         esperado = escala_svc.eh_dia_de_trabalho(a, hoje) if usa else False
         entrada = _entrada_da_jornada_aberta(db, a.id)
         inicio, fim = _bounds_periodo(hoje, hoje)
@@ -615,6 +666,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
             tem_saida=ts,
             feriado=feriado_hoje,
             atrasado=atrasado,
+            ausencia_tipo=ausencia_tipo,
         )
         hb = a.presenca_heartbeat_em
         if hb is not None and hb.tzinfo is None:
@@ -625,7 +677,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
             PontoHojeItem(
                 atendente_id=a.id,
                 nome=a.nome,
-                esperado=esperado and not feriado_hoje,
+                esperado=bool(esperado and not feriado_hoje and not ausencia_tipo),
                 em_jornada=entrada is not None,
                 em_pausa=em_pausa_aberta(db, a.id),
                 entrada_em=entrada.registrado_em if entrada else None,
@@ -678,17 +730,22 @@ def banco_horas(
     desde: date,
     ate: date,
 ) -> PontoBancoHorasRead:
+    from app.services import ponto_ausencia as ausencia_svc
+
     if ate < desde:
         raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
     usa = escala_svc.escala_configurada(atendente)
+    ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
     dias_escala = 0
     dias_feriado = 0
     esperado = 0
     d = desde
     while d <= ate:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
-        if feriado:
-            dias_feriado += 1
+        if feriado or d in ausencias:
+            if feriado:
+                dias_feriado += 1
+            # ausência/feriado: não soma esperado
         elif usa and escala_svc.eh_dia_de_trabalho(atendente, d):
             dias_escala += 1
             esperado += escala_svc.segundos_esperados_dia(atendente, d)
@@ -717,6 +774,7 @@ JORNADA_ALERTA_HORAS = 12.0
 
 def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     from app.schemas.ponto import PontoAlertasMe
+    from app.services import ponto_ausencia as ausencia_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     exigir_acesso_ponto(atendente)
@@ -730,11 +788,13 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     horas_aberta: float | None = None
     lembrete_entrada = False
     lembrete_saida = False
+    pausa_baixa = False
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
+    ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, atendente.id, hoje)
     jornada_ativa = escala_svc.escala_configurada(atendente)
     esperado = None
-    if jornada_ativa and not feriado:
+    if jornada_ativa and not feriado and not ausencia_tipo:
         esperado = escala_svc.eh_dia_de_trabalho(atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
@@ -750,6 +810,18 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     )
     tem_entrada_hoje = any(b.tipo == "entrada" for b in bats_hoje)
     primeira = _primeira_entrada_do_dia(bats_hoje)
+
+    settings = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
+    pausa_min = int(getattr(settings, "pausa_minima_minutos", None) or 0)
+    if pausa_min > 0 and tem_entrada_hoje:
+        pausas = _segundos_pausas_do_dia(bats_hoje)
+        if _pausa_abaixo_minimo(
+            tem_entrada=True, segundos_pausa=pausas, pausa_minima_minutos=pausa_min
+        ):
+            pausa_baixa = True
+            msgs.append(
+                f"Pausa de hoje abaixo do mínimo configurado ({pausa_min} min)."
+            )
 
     hb = atendente.presenca_heartbeat_em
     if hb is not None and hb.tzinfo is None:
@@ -805,6 +877,7 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
         horas_jornada_aberta=horas_aberta,
         lembrete_entrada_tolerancia=lembrete_entrada,
         lembrete_saida_tolerancia=lembrete_saida,
+        pausa_abaixo_minimo=pausa_baixa,
         mensagens=msgs,
     )
 

--- a/backend/app/services/ponto_ausencia.py
+++ b/backend/app/services/ponto_ausencia.py
@@ -1,0 +1,288 @@
+"""Ausências programadas: férias / folga (#976)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.ponto_ausencia import PontoAusencia
+from app.schemas.ponto import PontoAusenciaRead
+from app.services import ponto as ponto_svc
+
+TIPOS = frozenset({"ferias", "folga_programada"})
+ESTADOS = frozenset({"pendente", "aprovada", "rejeitada"})
+
+
+def _to_read(row: PontoAusencia) -> PontoAusenciaRead:
+    return PontoAusenciaRead(
+        id=row.id,
+        atendente_id=row.atendente_id,
+        atendente_nome=row.atendente.nome if row.atendente else None,
+        tipo=row.tipo,
+        desde=row.desde,
+        ate=row.ate,
+        motivo=row.motivo,
+        estado=row.estado,
+        origem=row.origem or "solicitacao",
+        decidido_por_id=row.decidido_por_id,
+        decidido_em=row.decidido_em,
+        decisao_motivo=row.decisao_motivo,
+        created_at=row.created_at,
+    )
+
+
+def _validar_periodo(desde: date, ate: date) -> None:
+    if ate < desde:
+        raise HTTPException(status_code=400, detail="A data final deve ser igual ou posterior à inicial.")
+    if (ate - desde).days > 366:
+        raise HTTPException(status_code=400, detail="Período máximo de 366 dias.")
+
+
+def _validar_tipo(tipo: str) -> str:
+    t = (tipo or "").strip().lower()
+    if t not in TIPOS:
+        raise HTTPException(status_code=400, detail="Tipo deve ser ferias ou folga_programada.")
+    return t
+
+
+def tipo_ausencia_aprovada_no_dia(db: Session, atendente_id: int, dia: date) -> str | None:
+    """Retorna tipo (ferias|folga_programada) se houver ausência aprovada cobrindo o dia."""
+    row = (
+        db.query(PontoAusencia)
+        .filter(
+            PontoAusencia.atendente_id == atendente_id,
+            PontoAusencia.estado == "aprovada",
+            PontoAusencia.desde <= dia,
+            PontoAusencia.ate >= dia,
+        )
+        .order_by(PontoAusencia.id.desc())
+        .first()
+    )
+    return row.tipo if row else None
+
+
+def mapa_ausencias_aprovadas(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> dict[date, str]:
+    """Mapa dia → tipo para o período (útil no calendário)."""
+    rows = (
+        db.query(PontoAusencia)
+        .filter(
+            PontoAusencia.atendente_id == atendente_id,
+            PontoAusencia.estado == "aprovada",
+            PontoAusencia.ate >= desde,
+            PontoAusencia.desde <= ate,
+        )
+        .all()
+    )
+    out: dict[date, str] = {}
+    for r in rows:
+        d = max(r.desde, desde)
+        fim = min(r.ate, ate)
+        cur = d
+        while cur <= fim:
+            out[cur] = r.tipo
+            cur = date.fromordinal(cur.toordinal() + 1)
+    return out
+
+
+def solicitar(
+    db: Session,
+    atendente: Atendente,
+    *,
+    tipo: str,
+    desde: date,
+    ate: date,
+    motivo: str | None = None,
+) -> PontoAusenciaRead:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    t = _validar_tipo(tipo)
+    _validar_periodo(desde, ate)
+    row = PontoAusencia(
+        tenant_id=atendente.tenant_id,
+        atendente_id=atendente.id,
+        tipo=t,
+        desde=desde,
+        ate=ate,
+        motivo=(motivo or "").strip()[:1000] or None,
+        estado="pendente",
+        origem="solicitacao",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "create",
+        atendente.id,
+        payload={"tipo": t, "desde": str(desde), "ate": str(ate), "estado": "pendente"},
+    )
+    db.commit()
+    db.refresh(row)
+    row = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.id == row.id)
+        .first()
+    )
+    assert row is not None
+    return _to_read(row)
+
+
+def conceder_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int,
+    tipo: str,
+    desde: date,
+    ate: date,
+    motivo: str | None = None,
+) -> PontoAusenciaRead:
+    t = _validar_tipo(tipo)
+    _validar_periodo(desde, ate)
+    alvo = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.role != "saas_ops",
+        )
+        .first()
+    )
+    if not alvo:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    agora = datetime.now(timezone.utc)
+    row = PontoAusencia(
+        tenant_id=admin.tenant_id,
+        atendente_id=alvo.id,
+        tipo=t,
+        desde=desde,
+        ate=ate,
+        motivo=(motivo or "").strip()[:1000] or "Ausência agendada pelo administrador.",
+        estado="aprovada",
+        origem="admin",
+        decidido_por_id=admin.id,
+        decidido_em=agora,
+        decisao_motivo="Agendamento direto",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "conceder",
+        admin.id,
+        payload={"atendente_id": alvo.id, "tipo": t, "desde": str(desde), "ate": str(ate)},
+    )
+    db.commit()
+    db.refresh(row)
+    row = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.id == row.id)
+        .first()
+    )
+    assert row is not None
+    return _to_read(row)
+
+
+def decidir(
+    db: Session,
+    admin: Atendente,
+    ausencia_id: int,
+    *,
+    aprovar: bool,
+    decisao_motivo: str | None = None,
+) -> PontoAusenciaRead:
+    row = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.id == ausencia_id, PontoAusencia.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Ausência não encontrada")
+    if row.estado != "pendente":
+        raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
+    row.decidido_por_id = admin.id
+    row.decidido_em = datetime.now(timezone.utc)
+    row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
+    if aprovar:
+        row.estado = "aprovada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Aprovado pelo administrador"
+    else:
+        row.estado = "rejeitada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Negado pelo administrador"
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "decidir",
+        admin.id,
+        payload={"estado": row.estado},
+    )
+    db.commit()
+    db.refresh(row)
+    return _to_read(row)
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoAusenciaRead]:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    rows = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.atendente_id == atendente.id)
+        .order_by(PontoAusencia.desde.desc(), PontoAusencia.id.desc())
+        .limit(100)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente",
+) -> list[PontoAusenciaRead]:
+    q = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        if estado not in ESTADOS:
+            raise HTTPException(status_code=400, detail="Estado inválido.")
+        q = q.filter(PontoAusencia.estado == estado)
+    rows = q.order_by(PontoAusencia.created_at.asc()).limit(200).all()
+    return [_to_read(r) for r in rows]
+
+
+def remover_admin(db: Session, admin: Atendente, ausencia_id: int) -> None:
+    """Remove ausência aprovada/agendada (correção)."""
+    row = (
+        db.query(PontoAusencia)
+        .filter(PontoAusencia.id == ausencia_id, PontoAusencia.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Ausência não encontrada")
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "delete",
+        admin.id,
+        payload={"tipo": row.tipo, "desde": str(row.desde), "ate": str(row.ate)},
+    )
+    db.delete(row)
+    db.commit()

--- a/backend/app/services/ponto_justificativa.py
+++ b/backend/app/services/ponto_justificativa.py
@@ -18,6 +18,7 @@ TIPOS = frozenset({"falta", "esquecimento", "folga_com_ponto", "outro"})
 
 def _to_read(j: PontoJustificativa) -> PontoJustificativaRead:
     nome = j.atendente.nome if j.atendente else None
+    tem = bool(getattr(j, "anexo_storage_key", None))
     return PontoJustificativaRead(
         id=j.id,
         atendente_id=j.atendente_id,
@@ -29,6 +30,10 @@ def _to_read(j: PontoJustificativa) -> PontoJustificativaRead:
         decisao_motivo=j.decisao_motivo,
         decidido_por_id=j.decidido_por_id,
         decidido_em=j.decidido_em,
+        tem_anexo=tem,
+        anexo_nome=getattr(j, "anexo_nome", None) if tem else None,
+        anexo_content_type=getattr(j, "anexo_content_type", None) if tem else None,
+        anexo_tamanho_bytes=getattr(j, "anexo_tamanho_bytes", None) if tem else None,
         created_at=j.created_at,
     )
 
@@ -40,6 +45,10 @@ def criar(
     data_ref,
     tipo: str,
     motivo: str,
+    anexo_nome: str | None = None,
+    anexo_content_type: str | None = None,
+    anexo_storage_key: str | None = None,
+    anexo_tamanho_bytes: int | None = None,
 ) -> PontoJustificativaRead:
     ponto_svc.exigir_acesso_ponto(atendente)
     if tipo not in TIPOS:
@@ -51,6 +60,10 @@ def criar(
         tipo=tipo,
         motivo=motivo.strip(),
         estado="pendente",
+        anexo_nome=anexo_nome,
+        anexo_content_type=anexo_content_type,
+        anexo_storage_key=anexo_storage_key,
+        anexo_tamanho_bytes=anexo_tamanho_bytes,
     )
     db.add(row)
     db.flush()
@@ -60,7 +73,12 @@ def criar(
         row.id,
         "create",
         atendente.id,
-        payload={"data_ref": str(data_ref), "tipo": tipo, "motivo": motivo.strip()},
+        payload={
+            "data_ref": str(data_ref),
+            "tipo": tipo,
+            "motivo": motivo.strip(),
+            "tem_anexo": bool(anexo_storage_key),
+        },
     )
     db.commit()
     db.refresh(row)
@@ -102,6 +120,30 @@ def listar_admin(
         q = q.filter(PontoJustificativa.estado == estado)
     rows = q.order_by(PontoJustificativa.created_at.asc()).limit(200).all()
     return [_to_read(r) for r in rows]
+
+
+def obter_para_anexo(
+    db: Session,
+    *,
+    justificativa_id: int,
+    tenant_id: int,
+    solicitante: Atendente,
+) -> PontoJustificativa:
+    row = (
+        db.query(PontoJustificativa)
+        .filter(
+            PontoJustificativa.id == justificativa_id,
+            PontoJustificativa.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Justificativa não encontrada")
+    if solicitante.role != "admin" and row.atendente_id != solicitante.id:
+        raise HTTPException(status_code=403, detail="Sem permissão para este anexo")
+    if not row.anexo_storage_key:
+        raise HTTPException(status_code=404, detail="Esta justificativa não tem anexo")
+    return row
 
 
 def decidir(

--- a/backend/app/services/ponto_justificativa_storage.py
+++ b/backend/app/services/ponto_justificativa_storage.py
@@ -1,0 +1,70 @@
+"""Storage de anexos de justificativa de ponto (#977)."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+
+from app.config import settings
+from app.services.ticket_anexo_storage import validar_upload as _validar_ticket
+
+# Allowlist mais restrita para RH: imagem + PDF
+_ALLOW_EXT = {".pdf", ".png", ".jpg", ".jpeg", ".webp", ".gif", ".heic"}
+_ALLOW_MIME_PREFIX = ("image/",)
+_ALLOW_MIME = {"application/pdf"}
+
+
+def validar_anexo_justificativa(
+    nome_original: str | None, content_type: str | None, tamanho_bytes: int
+) -> tuple[str, str | None]:
+    if tamanho_bytes > settings.PONTO_JUSTIFICATIVA_ANEXOS_MAX_BYTES:
+        raise ValueError("Arquivo excede o tamanho máximo permitido (25 MB).")
+    nome, mime = _validar_ticket(nome_original, content_type, tamanho_bytes)
+    ext = Path(nome).suffix.lower()
+    if ext not in _ALLOW_EXT:
+        raise ValueError("Anexo deve ser imagem ou PDF.")
+    if mime and not (mime in _ALLOW_MIME or mime.startswith(_ALLOW_MIME_PREFIX)):
+        raise ValueError("Anexo deve ser imagem ou PDF.")
+    return nome, mime
+
+
+def diretorio_anexos() -> Path:
+    p = Path(settings.PONTO_JUSTIFICATIVA_ANEXOS_DIR)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def gravar_bytes(data: bytes, *, mimetype: str | None, nome_original: str) -> str:
+    if len(data) == 0:
+        raise ValueError("Arquivo vazio.")
+    if len(data) > settings.PONTO_JUSTIFICATIVA_ANEXOS_MAX_BYTES:
+        raise ValueError("Arquivo excede o tamanho máximo permitido (25 MB).")
+    ext = Path(nome_original).suffix.lower()
+    if ext not in _ALLOW_EXT:
+        ext = ".bin"
+        if mimetype == "application/pdf":
+            ext = ".pdf"
+        elif mimetype and mimetype.startswith("image/"):
+            ext = ".img"
+    name = f"{uuid.uuid4().hex}{ext}"
+    path = diretorio_anexos() / name
+    path.write_bytes(data)
+    return name
+
+
+def caminho_absoluto(storage_key: str | None) -> Path | None:
+    if not storage_key or not str(storage_key).strip():
+        return None
+    base = diretorio_anexos()
+    s = str(storage_key).strip()
+    if re.search(r"[\\/]", s):
+        return None
+    p = (base / s).resolve()
+    try:
+        p.relative_to(base.resolve())
+    except ValueError:
+        return None
+    return p if p.is_file() else None

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -69,6 +69,13 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="jornada_diaria_minutos deve estar entre 60 e 1440.",
             )
+    if "pausa_minima_minutos" in payload:
+        m = payload["pausa_minima_minutos"]
+        if m is None or m < 0 or m > 240:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="pausa_minima_minutos deve estar entre 0 e 240.",
+            )
     if "politica_geolocalizacao" in payload:
         p = (payload["politica_geolocalizacao"] or "").strip().lower()
         if p not in POLITICAS_VALIDAS:

--- a/backend/tests/test_ponto_lote_e_976_977_973.py
+++ b/backend/tests/test_ponto_lote_e_976_977_973.py
@@ -1,0 +1,147 @@
+"""Lote E: ausências (#976), pausa mínima (#973), anexo justificativa (#977)."""
+
+from datetime import date, datetime, timedelta, timezone
+from io import BytesIO
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="18:00"):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def test_ausencia_admin_agenda_sem_falta(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _patch_jornada_semanal(client, admin, a1.id).status_code == 200
+    hoje = date.today()
+    r = client.post(
+        "/v1/ponto/ausencias/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "ferias",
+            "desde": hoje.isoformat(),
+            "ate": hoje.isoformat(),
+            "motivo": "Recesso",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["estado"] == "aprovada"
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={hoje.year}&mes={hoje.month}",
+        headers=user,
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == hoje.isoformat())
+    assert dia["status"] == "ferias"
+    assert dia["esperado"] is False
+    assert dia["classe_visual"] == "ausencia"
+
+
+def test_colaborador_solicita_folga_admin_aprova(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    amanha = date.today() + timedelta(days=1)
+    sol = client.post(
+        "/v1/ponto/ausencias",
+        headers=user,
+        json={
+            "tipo": "folga_programada",
+            "desde": amanha.isoformat(),
+            "ate": amanha.isoformat(),
+            "motivo": "Compromisso",
+        },
+    )
+    assert sol.status_code == 201, sol.text
+    assert sol.json()["estado"] == "pendente"
+    pend = client.get("/v1/ponto/ausencias?estado=pendente", headers=admin)
+    assert any(x["id"] == sol.json()["id"] for x in pend.json())
+    dec = client.post(
+        f"/v1/ponto/ausencias/{sol.json()['id']}/decidir",
+        headers=admin,
+        json={"aprovar": True},
+    )
+    assert dec.status_code == 200
+    assert dec.json()["estado"] == "aprovada"
+
+
+def test_pausa_minima_flag_calendario(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        "/v1/ponto/settings",
+        headers=admin,
+        json={"pausa_minima_minutos": 60},
+    ).status_code == 200
+    agora = datetime.now(PONTO_TZ)
+    t0 = agora.replace(hour=8, minute=0, second=0, microsecond=0)
+    if t0.tzinfo is None:
+        t0 = t0.replace(tzinfo=PONTO_TZ)
+    if t0 > agora:
+        t0 = agora - timedelta(hours=5)
+    seq = [
+        ("entrada", t0),
+        ("pausa_inicio", t0 + timedelta(hours=2)),
+        ("pausa_fim", t0 + timedelta(hours=2, minutes=10)),
+        ("saida", t0 + timedelta(hours=4)),
+    ]
+    for tipo, when in seq:
+        r = client.post(
+            "/v1/ponto/batidas",
+            headers=admin,
+            json={
+                "atendente_id": a1.id,
+                "tipo": tipo,
+                "registrado_em": when.astimezone(timezone.utc).isoformat(),
+                "motivo": "teste pausa mínima",
+            },
+        )
+        assert r.status_code == 201, f"{tipo}: {r.text}"
+    hoje = date.today()
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={hoje.year}&mes={hoje.month}",
+        headers=user,
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == hoje.isoformat())
+    assert dia["pausa_abaixo_minimo"] is True
+    assert dia["segundos_pausa"] < 60 * 60
+
+
+def test_justificativa_com_anexo_pdf(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    pdf = b"%PDF-1.4 fake test content"
+    r = client.post(
+        "/v1/ponto/justificativas/upload",
+        headers=user,
+        data={
+            "data_ref": date.today().isoformat(),
+            "tipo": "falta",
+            "motivo": "Atestado médico",
+        },
+        files={"arquivo": ("atestado.pdf", BytesIO(pdf), "application/pdf")},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["tem_anexo"] is True
+    assert body["anexo_nome"]
+    dl = client.get(f"/v1/ponto/justificativas/{body['id']}/anexo", headers=admin)
+    assert dl.status_code == 200
+    assert dl.content == pdf

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -754,6 +754,14 @@ export const ponto = {
     }),
   criarJustificativa: (data: Ponto.JustificativaCreate) =>
     api<Ponto.Justificativa>('/ponto/justificativas', { method: 'POST', body: JSON.stringify(data) }),
+  criarJustificativaComAnexo: (data: Ponto.JustificativaCreate, arquivo: File) => {
+    const fd = new FormData()
+    fd.append('data_ref', data.data_ref)
+    fd.append('tipo', data.tipo)
+    fd.append('motivo', data.motivo)
+    fd.append('arquivo', arquivo)
+    return api<Ponto.Justificativa>('/ponto/justificativas/upload', { method: 'POST', body: fd })
+  },
   minhasJustificativas: () => api<Ponto.Justificativa[]>('/ponto/justificativas/me'),
   justificativasAdmin: (estado?: string) =>
     api<Ponto.Justificativa[]>(withParams('/ponto/justificativas', { estado })),
@@ -762,6 +770,43 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  justificativaAnexoUrl: (id: number) =>
+    `${apiOrigin()}${API_VERSION_PREFIX}/ponto/justificativas/${id}/anexo`,
+  baixarJustificativaAnexo: async (id: number, nome?: string | null) => {
+    const token = getAuthToken()
+    const headers: Record<string, string> = {}
+    if (token) headers.Authorization = `Bearer ${token}`
+    if (isMultiTenantMode()) {
+      const tid = resolveTenantIdFromHostname()
+      if (tid) headers['X-Dx-Tenant-Id'] = String(tid)
+    }
+    const res = await fetch(
+      `${apiOrigin()}${API_VERSION_PREFIX}/ponto/justificativas/${id}/anexo`,
+      { headers },
+    )
+    if (!res.ok) throw new ApiError('Falha ao baixar anexo', res.status, await res.text())
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = nome || `justificativa-${id}`
+    a.click()
+    URL.revokeObjectURL(url)
+  },
+  solicitarAusencia: (data: Ponto.AusenciaCreate) =>
+    api<Ponto.Ausencia>('/ponto/ausencias', { method: 'POST', body: JSON.stringify(data) }),
+  minhasAusencias: () => api<Ponto.Ausencia[]>('/ponto/ausencias/me'),
+  ausenciasAdmin: (estado?: string) =>
+    api<Ponto.Ausencia[]>(withParams('/ponto/ausencias', { estado })),
+  concederAusencia: (data: Ponto.AusenciaConceder) =>
+    api<Ponto.Ausencia>('/ponto/ausencias/conceder', { method: 'POST', body: JSON.stringify(data) }),
+  decidirAusencia: (id: number, data: Ponto.AusenciaDecisao) =>
+    api<Ponto.Ausencia>(`/ponto/ausencias/${id}/decidir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  removerAusencia: (id: number) =>
+    api<void>(`/ponto/ausencias/${id}`, { method: 'DELETE' }),
   horaExtraMeStatus: () => api<Ponto.HoraExtraMeStatus>('/ponto/hora-extra/me/status'),
   minhasHoraExtra: () => api<Ponto.HoraExtra[]>('/ponto/hora-extra/me'),
   solicitarHoraExtra: (data?: Ponto.HoraExtraCreate) =>
@@ -4783,6 +4828,8 @@ export namespace Ponto {
     | 'parcial'
     | 'folga'
     | 'folga_com_ponto'
+    | 'folga_programada'
+    | 'ferias'
     | 'livre'
     | 'atraso'
     | 'feriado'
@@ -4859,11 +4906,14 @@ export namespace Ponto {
     status: StatusDia
     atrasado?: boolean
     feriado?: boolean
+    ausencia_tipo?: string | null
+    pausa_abaixo_minimo?: boolean
     segundos_trabalhados?: number
     segundos_esperados?: number
+    segundos_pausa?: number
     classe_visual?: ClasseVisualDia
   }
-  export type ClasseVisualDia = 'abaixo' | 'ok' | 'he' | 'feriado' | 'neutro'
+  export type ClasseVisualDia = 'abaixo' | 'ok' | 'he' | 'feriado' | 'ausencia' | 'neutro'
   export interface Calendario {
     atendente_id: number
     ano: number
@@ -4916,6 +4966,7 @@ export namespace Ponto {
     fecho_apos_horas: number
     fecho_margem_pos_saida_minutos: number
     jornada_diaria_minutos: number
+    pausa_minima_minutos?: number
     politica_geolocalizacao: PoliticaGeolocalizacao
   }
   export interface SettingsPublic {
@@ -4928,6 +4979,7 @@ export namespace Ponto {
     fecho_apos_horas?: number
     fecho_margem_pos_saida_minutos?: number
     jornada_diaria_minutos?: number
+    pausa_minima_minutos?: number
     politica_geolocalizacao?: PoliticaGeolocalizacao
   }
   export interface Local {
@@ -5016,12 +5068,48 @@ export namespace Ponto {
     decisao_motivo?: string | null
     decidido_por_id?: number | null
     decidido_em?: string | null
+    tem_anexo?: boolean
+    anexo_nome?: string | null
+    anexo_content_type?: string | null
+    anexo_tamanho_bytes?: number | null
     created_at?: string | null
   }
   export interface JustificativaDecisao {
     estado: 'aprovada' | 'rejeitada'
     decisao_motivo: string
     aplicar_batidas?: { tipo: Tipo; registrado_em: string; motivo: string }[]
+  }
+  export interface AusenciaCreate {
+    tipo: 'ferias' | 'folga_programada'
+    desde: string
+    ate: string
+    motivo?: string | null
+  }
+  export interface AusenciaConceder {
+    atendente_id: number
+    tipo: 'ferias' | 'folga_programada'
+    desde: string
+    ate: string
+    motivo?: string | null
+  }
+  export interface AusenciaDecisao {
+    aprovar: boolean
+    decisao_motivo?: string | null
+  }
+  export interface Ausencia {
+    id: number
+    atendente_id: number
+    atendente_nome?: string | null
+    tipo: string
+    desde: string
+    ate: string
+    motivo?: string | null
+    estado: string
+    origem?: string
+    decidido_por_id?: number | null
+    decidido_em?: string | null
+    decisao_motivo?: string | null
+    created_at?: string | null
   }
   export interface HoraExtra {
     id: number

--- a/frontend/src/components/PontoCalendarioMes.tsx
+++ b/frontend/src/components/PontoCalendarioMes.tsx
@@ -30,6 +30,8 @@ function classeCss(classe: Ponto.ClasseVisualDia | undefined): string {
       return 'bg-sky-100/90 text-sky-900 ring-sky-200/80 hover:bg-sky-200/90 dark:bg-sky-950/45 dark:text-sky-100 dark:ring-sky-900 dark:hover:bg-sky-950/70'
     case 'feriado':
       return 'bg-orange-100/90 text-orange-900 ring-orange-200/80 hover:bg-orange-200/90 dark:bg-orange-950/45 dark:text-orange-100 dark:ring-orange-900 dark:hover:bg-orange-950/70'
+    case 'ausencia':
+      return 'bg-violet-100/90 text-violet-900 ring-violet-200/80 hover:bg-violet-200/90 dark:bg-violet-950/45 dark:text-violet-100 dark:ring-violet-900 dark:hover:bg-violet-950/70'
     default:
       return 'bg-slate-50 text-slate-600 ring-slate-200/80 hover:bg-slate-100 dark:bg-slate-800/40 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800/70'
   }
@@ -45,6 +47,8 @@ function rotuloClasse(classe: Ponto.ClasseVisualDia | undefined): string {
       return 'Hora extra'
     case 'feriado':
       return 'Feriado'
+    case 'ausencia':
+      return 'Férias / folga'
     default:
       return 'Sem jornada'
   }
@@ -179,6 +183,7 @@ export function PontoCalendarioMes({
             ['ok', 'Dentro da meta'],
             ['he', 'Hora extra'],
             ['feriado', 'Feriado'],
+            ['ausencia', 'Férias / folga'],
             ['neutro', 'Sem jornada'],
           ] as const
         ).map(([k, label]) => (
@@ -213,6 +218,12 @@ export function PontoCalendarioMes({
             Entrada: {detalhe.tem_entrada ? 'sim' : 'não'} · Saída: {detalhe.tem_saida ? 'sim' : 'não'}
             {detalhe.atrasado ? ' · Atraso' : ''}
             {detalhe.feriado ? ' · Feriado' : ''}
+            {detalhe.ausencia_tipo === 'ferias'
+              ? ' · Férias'
+              : detalhe.ausencia_tipo === 'folga_programada'
+                ? ' · Folga programada'
+                : ''}
+            {detalhe.pausa_abaixo_minimo ? ' · Pausa abaixo do mínimo' : ''}
           </p>
           <p className="mt-2 text-xs text-cyan-700 dark:text-cyan-300">
             O histórico ao lado filtra este dia automaticamente.

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -79,6 +79,13 @@ export function MeuPonto() {
     lon: number
     label: string
   } | null>(null)
+  const [justAnexo, setJustAnexo] = useState<File | null>(null)
+  const [ausencias, setAusencias] = useState<Ponto.Ausencia[]>([])
+  const [ausTipo, setAusTipo] = useState<'ferias' | 'folga_programada'>('folga_programada')
+  const [ausDesde, setAusDesde] = useState(hojeIso)
+  const [ausAte, setAusAte] = useState(hojeIso)
+  const [ausMotivo, setAusMotivo] = useState('')
+  const [enviandoAus, setEnviandoAus] = useState(false)
 
   const politicaGeo = geoSettings?.politica_geolocalizacao ?? 'opcional'
   const geoObrigatoria = politicaGeo === 'obrigatoria' && !!geoSettings?.tem_locais_ativos
@@ -88,18 +95,20 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs] = await Promise.all([
+        const [me, hist, js, bh, gs, aus] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
           ponto.meuBancoHoras(desde, ate),
           ponto.meSettings(),
+          ponto.minhasAusencias(),
         ])
         setEstado(me)
         setHistorico(hist)
         setJustifs(js)
         setBanco(bh)
         setGeoSettings(gs)
+        setAusencias(aus)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -272,18 +281,48 @@ export function MeuPonto() {
     }
     setEnviandoJust(true)
     try {
-      await ponto.criarJustificativa({
+      const payload = {
         data_ref: justData,
         tipo: justTipo,
         motivo: justMotivo.trim(),
-      })
+      }
+      if (justAnexo) {
+        await ponto.criarJustificativaComAnexo(payload, justAnexo)
+      } else {
+        await ponto.criarJustificativa(payload)
+      }
       toast.showSuccess('Justificativa enviada para aprovação.')
       setJustMotivo('')
+      setJustAnexo(null)
       await carregar(true)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a justificativa.'))
     } finally {
       setEnviandoJust(false)
+    }
+  }
+
+  async function solicitarAusencia() {
+    if (ausAte < ausDesde) {
+      toast.showWarning('A data final deve ser igual ou posterior à inicial.')
+      return
+    }
+    setEnviandoAus(true)
+    try {
+      await ponto.solicitarAusencia({
+        tipo: ausTipo,
+        desde: ausDesde,
+        ate: ausAte,
+        motivo: ausMotivo.trim() || null,
+      })
+      toast.showSuccess('Pedido de ausência enviado.')
+      setAusMotivo('')
+      await carregar(true)
+      await carregarCalendario(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível solicitar a ausência.'))
+    } finally {
+      setEnviandoAus(false)
     }
   }
 
@@ -711,6 +750,17 @@ export function MeuPonto() {
                 onChange={(e) => setJustMotivo(e.target.value)}
                 placeholder="Descreva o ocorrido"
               />
+              <div className="min-w-[12rem]">
+                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  Anexo (opcional)
+                </label>
+                <input
+                  type="file"
+                  accept="image/*,.pdf,application/pdf"
+                  className="block w-full text-sm text-slate-600 file:mr-2 file:rounded-md file:border-0 file:bg-slate-100 file:px-2 file:py-1 dark:text-slate-300 dark:file:bg-slate-800"
+                  onChange={(e) => setJustAnexo(e.target.files?.[0] ?? null)}
+                />
+              </div>
               <Button type="button" disabled={enviandoJust} onClick={() => void enviarJustificativa()}>
                 Enviar
               </Button>
@@ -728,8 +778,80 @@ export function MeuPonto() {
                   <span className="font-medium">{j.data_ref}</span> · {j.tipo} ·{' '}
                   <span className="capitalize">{j.estado}</span>
                   <p className="text-slate-600 dark:text-slate-300">{j.motivo}</p>
+                  {j.tem_anexo ? (
+                    <button
+                      type="button"
+                      className="mt-1 text-xs text-cyan-700 underline dark:text-cyan-300"
+                      onClick={() =>
+                        void ponto
+                          .baixarJustificativaAnexo(j.id, j.anexo_nome)
+                          .catch((err) =>
+                            toast.showError(
+                              mensagemFalhaParaToast(err, 'Não foi possível baixar o anexo.'),
+                            ),
+                          )
+                      }
+                    >
+                      Baixar anexo{j.anexo_nome ? ` (${j.anexo_nome})` : ''}
+                    </button>
+                  ) : null}
                   {j.decisao_motivo ? (
                     <p className="text-xs text-slate-500">Decisão: {j.decisao_motivo}</p>
+                  ) : null}
+                </li>
+              ))
+            )}
+          </ul>
+        </Card>
+      </div>
+
+      <div className="mt-4">
+        <Card
+          title="Férias / folga programada"
+          description="Solicite um período; o admin aprova. Dias aprovados não geram falta automática."
+        >
+          <div className="flex flex-wrap items-end gap-3">
+            <Select
+              label="Tipo"
+              value={ausTipo}
+              onChange={(v) => setAusTipo(String(v) as 'ferias' | 'folga_programada')}
+              options={[
+                { value: 'folga_programada', label: 'Folga programada' },
+                { value: 'ferias', label: 'Férias' },
+              ]}
+            />
+            <Input
+              label="De"
+              type="date"
+              value={ausDesde}
+              onChange={(e) => setAusDesde(e.target.value)}
+            />
+            <Input label="Até" type="date" value={ausAte} onChange={(e) => setAusAte(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={ausMotivo}
+              onChange={(e) => setAusMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={enviandoAus} onClick={() => void solicitarAusencia()}>
+              Solicitar
+            </Button>
+          </div>
+          <ul className="mt-4 space-y-2 text-sm">
+            {ausencias.length === 0 ? (
+              <li className="text-slate-500">Nenhum pedido de ausência.</li>
+            ) : (
+              ausencias.map((a) => (
+                <li
+                  key={a.id}
+                  className="rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <span className="font-medium">
+                    {a.tipo === 'ferias' ? 'Férias' : 'Folga programada'}
+                  </span>{' '}
+                  · {a.desde} → {a.ate} · <span className="capitalize">{a.estado}</span>
+                  {a.motivo ? <p className="text-slate-600 dark:text-slate-300">{a.motivo}</p> : null}
+                  {a.decisao_motivo ? (
+                    <p className="text-xs text-slate-500">Decisão: {a.decisao_motivo}</p>
                   ) : null}
                 </li>
               ))

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -35,6 +35,10 @@ function rotuloStatus(s: Ponto.HojeItem['status']): string {
       return 'Atraso'
     case 'feriado':
       return 'Feriado'
+    case 'ferias':
+      return 'Férias'
+    case 'folga_programada':
+      return 'Folga programada'
     case 'ok':
       return 'Ok'
     default:
@@ -71,6 +75,13 @@ export function PontoEquipe() {
   const [carregandoAjustes, setCarregandoAjustes] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
+  const [ausPendentes, setAusPendentes] = useState<Ponto.Ausencia[]>([])
+  const [ausTipo, setAusTipo] = useState<'ferias' | 'folga_programada'>('folga_programada')
+  const [ausAtendente, setAusAtendente] = useState('')
+  const [ausDesde, setAusDesde] = useState(hojeIso)
+  const [ausAte, setAusAte] = useState(hojeIso)
+  const [ausMotivo, setAusMotivo] = useState('')
+  const [concedendoAus, setConcedendoAus] = useState(false)
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
   const [heDuracaoMin, setHeDuracaoMin] = useState('60')
@@ -96,7 +107,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, aus] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -109,6 +120,7 @@ export function PontoEquipe() {
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
           ponto.horaExtraAdmin('pendente'),
+          ponto.ausenciasAdmin('pendente'),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -118,6 +130,7 @@ export function PontoEquipe() {
         setSettings(st)
         setFeriados(fer)
         setHesPendentes(hes)
+        setAusPendentes(aus)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -317,6 +330,47 @@ export function PontoEquipe() {
     }
   }
 
+  async function decidirAus(id: number, aprovar: boolean) {
+    try {
+      await ponto.decidirAusencia(id, {
+        aprovar,
+        decisao_motivo: aprovar ? null : 'Negado pelo administrador',
+      })
+      toast.showSuccess(aprovar ? 'Ausência aprovada.' : 'Ausência negada.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a ausência.'))
+    }
+  }
+
+  async function concederAus() {
+    if (!ausAtendente) {
+      toast.showWarning('Selecione o atendente.')
+      return
+    }
+    if (ausAte < ausDesde) {
+      toast.showWarning('A data final deve ser igual ou posterior à inicial.')
+      return
+    }
+    setConcedendoAus(true)
+    try {
+      await ponto.concederAusencia({
+        atendente_id: Number(ausAtendente),
+        tipo: ausTipo,
+        desde: ausDesde,
+        ate: ausAte,
+        motivo: ausMotivo.trim() || null,
+      })
+      toast.showSuccess('Ausência agendada.')
+      setAusMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar a ausência.'))
+    } finally {
+      setConcedendoAus(false)
+    }
+  }
+
   async function decidirHe(id: number, aprovar: boolean) {
     setDecidindoHeId(id)
     try {
@@ -371,6 +425,7 @@ export function PontoEquipe() {
         fecho_apos_horas: settings.fecho_apos_horas,
         fecho_margem_pos_saida_minutos: settings.fecho_margem_pos_saida_minutos ?? 30,
         jornada_diaria_minutos: settings.jornada_diaria_minutos,
+        pausa_minima_minutos: settings.pausa_minima_minutos ?? 0,
         politica_geolocalizacao: settings.politica_geolocalizacao,
       })
       setSettings(st)
@@ -534,6 +589,23 @@ export function PontoEquipe() {
                       {j.atendente_nome ?? j.atendente_id} · {j.data_ref} · {j.tipo}
                     </p>
                     <p className="text-slate-600 dark:text-slate-300">{j.motivo}</p>
+                    {j.tem_anexo ? (
+                      <button
+                        type="button"
+                        className="mt-1 text-xs text-cyan-700 underline dark:text-cyan-300"
+                        onClick={() =>
+                          void ponto
+                            .baixarJustificativaAnexo(j.id, j.anexo_nome)
+                            .catch((err) =>
+                              toast.showError(
+                                mensagemFalhaParaToast(err, 'Não foi possível baixar o anexo.'),
+                              ),
+                            )
+                        }
+                      >
+                        Baixar anexo{j.anexo_nome ? ` (${j.anexo_nome})` : ''}
+                      </button>
+                    ) : null}
                   </div>
                   <div className="flex gap-2">
                     <Button type="button" variant="secondary" onClick={() => void decidirJust(j.id, 'aprovada')}>
@@ -541,6 +613,71 @@ export function PontoEquipe() {
                     </Button>
                     <Button type="button" variant="ghost" onClick={() => void decidirJust(j.id, 'rejeitada')}>
                       Rejeitar
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
+        <Card title="Férias / folga programada">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Agende direto ou aprove pedidos dos colaboradores. Dias aprovados não geram falta automática.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Colaborador"
+              value={ausAtendente}
+              onChange={(v) => setAusAtendente(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Select
+              label="Tipo"
+              value={ausTipo}
+              onChange={(v) => setAusTipo(String(v) as 'ferias' | 'folga_programada')}
+              options={[
+                { value: 'folga_programada', label: 'Folga programada' },
+                { value: 'ferias', label: 'Férias' },
+              ]}
+            />
+            <Input label="De" type="date" value={ausDesde} onChange={(e) => setAusDesde(e.target.value)} />
+            <Input label="Até" type="date" value={ausAte} onChange={(e) => setAusAte(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={ausMotivo}
+              onChange={(e) => setAusMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={concedendoAus} onClick={() => void concederAus()}>
+              Agendar
+            </Button>
+          </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Pedidos pendentes</p>
+          {ausPendentes.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
+          ) : (
+            <ul className="space-y-3">
+              {ausPendentes.map((a) => (
+                <li
+                  key={a.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">{a.atendente_nome ?? a.atendente_id}</p>
+                    <p className="text-slate-600 dark:text-slate-300">
+                      {a.tipo === 'ferias' ? 'Férias' : 'Folga programada'} · {a.desde} → {a.ate}
+                    </p>
+                    {a.motivo ? <p className="text-slate-500">{a.motivo}</p> : null}
+                  </div>
+                  <div className="flex gap-2">
+                    <Button type="button" variant="secondary" onClick={() => void decidirAus(a.id, true)}>
+                      Aprovar
+                    </Button>
+                    <Button type="button" variant="ghost" onClick={() => void decidirAus(a.id, false)}>
+                      Negar
                     </Button>
                   </div>
                 </li>
@@ -943,6 +1080,23 @@ export function PontoEquipe() {
                   })
                 }
               />
+              <Input
+                label="Pausa mínima (minutos)"
+                type="number"
+                min={0}
+                max={240}
+                value={String(settings.pausa_minima_minutos ?? 0)}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    pausa_minima_minutos: Math.max(0, Number(e.target.value) || 0),
+                  })
+                }
+              />
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                0 = desligado. Se a soma das pausas do dia ficar abaixo do mínimo (com jornada iniciada), o
+                calendário e os alertas sinalizam — sem bloquear batidas.
+              </p>
               <Select
                 label="Política de geolocalização"
                 value={settings.politica_geolocalizacao ?? 'opcional'}


### PR DESCRIPTION
## Summary
- Férias e folga programada: colaborador solicita ou admin agenda; calendário sem falta automática e esperado do dia zerado (#976)
- Justificativa com anexo (imagem/PDF) na criação; admin e colaborador baixam na decisão (#977)
- Setting `pausa_minima_minutos` (0 = off): flag no calendário/alertas se a pausa do dia ficar abaixo do mínimo, sem bloquear batidas (#973)

Closes #976
Closes #977
Closes #973

## Test plan
- [ ] Meu ponto: solicitar férias/folga; ver status pendente e calendário após aprovação
- [ ] Ponto da equipe: agendar direto e aprovar/negar pedidos
- [ ] Enviar justificativa com PDF/imagem; baixar anexo como admin
- [ ] Configurar pausa mínima > 0; dia com pausa curta mostra alerta no calendário
- [ ] `pytest` `test_ponto_lote_e_976_977_973.py` + migration `130_ponto_lote_e`

Made with [Cursor](https://cursor.com)