### PR TITLE
feat(ponto): Lote F — folha RH e cobertura (#975/#970)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas
+
 #### Correções
 
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta

--- a/backend/alembic/versions/130_ponto_lote_f.py
+++ b/backend/alembic/versions/130_ponto_lote_f.py
@@ -1,0 +1,66 @@
+"""Lote F: cobertura de plantão (#970).
+
+Revision ID: 130_ponto_lote_f
+Revises: 129_merge_he_teto_versao
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "130_ponto_lote_f"
+down_revision = "129_merge_he_teto_versao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_coberturas"):
+        return
+    op.create_table(
+        "ponto_coberturas",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False),
+        sa.Column(
+            "solicitante_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "cobertor_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("data_ref", sa.Date(), nullable=False),
+        sa.Column("motivo", sa.String(1000), nullable=True),
+        sa.Column("estado", sa.String(32), nullable=False, server_default="pendente_cobertor"),
+        sa.Column("origem", sa.String(20), nullable=False, server_default="solicitacao"),
+        sa.Column("resposta_cobertor", sa.String(20), nullable=True),
+        sa.Column("respondido_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "decidido_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("decidido_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("decisao_motivo", sa.String(1000), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_index("ix_ponto_coberturas_tenant_id", "ponto_coberturas", ["tenant_id"])
+    op.create_index("ix_ponto_coberturas_solicitante_id", "ponto_coberturas", ["solicitante_id"])
+    op.create_index("ix_ponto_coberturas_cobertor_id", "ponto_coberturas", ["cobertor_id"])
+    op.create_index("ix_ponto_coberturas_data_ref", "ponto_coberturas", ["data_ref"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_coberturas"):
+        op.drop_table("ponto_coberturas")

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -21,6 +21,12 @@ from app.schemas.ponto import (
     PontoBatidaRead,
     PontoBaterRequest,
     PontoCalendarioRead,
+    PontoCoberturaColega,
+    PontoCoberturaConceder,
+    PontoCoberturaCreate,
+    PontoCoberturaDecisao,
+    PontoCoberturaRead,
+    PontoCoberturaResposta,
     PontoDigestRead,
     PontoEstadoRead,
     PontoFeriadoCreate,
@@ -44,6 +50,8 @@ from app.schemas.ponto import (
     PontoSettingsUpdate,
 )
 from app.services import ponto as ponto_svc
+from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_folha as folha_svc
 from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
 from app.services import ponto_relatorio as ponto_relatorio_svc
@@ -184,6 +192,125 @@ def exportar_xlsx(
         content=xlsx,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         headers={"Content-Disposition": 'attachment; filename="ponto_relatorio.xlsx"'},
+    )
+
+
+@router.get("/export/folha.csv")
+def exportar_folha_csv(
+    atendente_id: int | None = Query(None),
+    desde: date = Query(...),
+    ate: date = Query(...),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    """Template contábil/folha RH (#975) — colunas documentadas no cabeçalho CSV."""
+    conteudo = folha_svc.export_folha_csv(
+        db, admin, atendente_id=atendente_id, desde=desde, ate=ate
+    )
+    return Response(
+        content=conteudo.encode("utf-8"),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="ponto_folha.csv"'},
+    )
+
+
+@router.get("/export/folha.xlsx")
+def exportar_folha_xlsx(
+    atendente_id: int | None = Query(None),
+    desde: date = Query(...),
+    ate: date = Query(...),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    xlsx = folha_svc.export_folha_xlsx(
+        db, admin, atendente_id=atendente_id, desde=desde, ate=ate
+    )
+    return Response(
+        content=xlsx,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": 'attachment; filename="ponto_folha.xlsx"'},
+    )
+
+
+@router.post("/coberturas", response_model=PontoCoberturaRead, status_code=201)
+def solicitar_cobertura(
+    data: PontoCoberturaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.solicitar(
+        db,
+        atendente,
+        cobertor_id=data.cobertor_id,
+        data_ref=data.data_ref,
+        motivo=data.motivo,
+    )
+
+
+@router.get("/coberturas/me", response_model=list[PontoCoberturaRead])
+def minhas_coberturas(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.listar_me(db, atendente)
+
+
+@router.get("/coberturas/colegas", response_model=list[PontoCoberturaColega])
+def colegas_cobertura(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.listar_colegas(db, atendente)
+
+
+@router.post("/coberturas/{cobertura_id}/responder", response_model=PontoCoberturaRead)
+def responder_cobertura(
+    cobertura_id: int,
+    data: PontoCoberturaResposta,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.responder_cobertor(db, atendente, cobertura_id, aceitar=data.aceitar)
+
+
+@router.get("/coberturas", response_model=list[PontoCoberturaRead])
+def listar_coberturas_admin(
+    estado: str | None = Query("pendente_admin"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return cob_svc.listar_admin(db, admin, estado=estado)
+
+
+@router.post("/coberturas/conceder", response_model=PontoCoberturaRead, status_code=201)
+def conceder_cobertura(
+    data: PontoCoberturaConceder,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return cob_svc.conceder_admin(
+        db,
+        admin,
+        solicitante_id=data.solicitante_id,
+        cobertor_id=data.cobertor_id,
+        data_ref=data.data_ref,
+        motivo=data.motivo,
+    )
+
+
+@router.post("/coberturas/{cobertura_id}/decidir", response_model=PontoCoberturaRead)
+def decidir_cobertura(
+    cobertura_id: int,
+    data: PontoCoberturaDecisao,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return cob_svc.decidir_admin(
+        db,
+        admin,
+        cobertura_id,
+        aprovar=data.aprovar,
+        decisao_motivo=data.decisao_motivo,
     )
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.atendente import Atendente, AtendenteSetor
 from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
+from app.models.ponto_cobertura import PontoCobertura
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
@@ -102,6 +103,7 @@ __all__ = [
     "PontoBatida",
     "PontoJustificativa",
     "PontoHoraExtra",
+    "PontoCobertura",
     "PontoSettings",
     "PontoLocal",
     "PontoFeriado",

--- a/backend/app/models/ponto_cobertura.py
+++ b/backend/app/models/ponto_cobertura.py
@@ -1,0 +1,32 @@
+"""Coberturas / troca de plantão (#970)."""
+
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoCobertura(Base):
+    __tablename__ = "ponto_coberturas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    solicitante_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    cobertor_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    data_ref = Column(Date, nullable=False, index=True)
+    motivo = Column(String(1000), nullable=True)
+    # pendente_cobertor | pendente_admin | aprovada | rejeitada | cancelada
+    estado = Column(String(32), nullable=False, default="pendente_cobertor", server_default="pendente_cobertor")
+    # solicitacao | admin
+    origem = Column(String(20), nullable=False, default="solicitacao", server_default="solicitacao")
+    resposta_cobertor = Column(String(20), nullable=True)  # aceita | recusa
+    respondido_em = Column(DateTime(timezone=True), nullable=True)
+    decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    decidido_em = Column(DateTime(timezone=True), nullable=True)
+    decisao_motivo = Column(String(1000), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    solicitante = relationship("Atendente", foreign_keys=[solicitante_id])
+    cobertor = relationship("Atendente", foreign_keys=[cobertor_id])
+    decidido_por = relationship("Atendente", foreign_keys=[decidido_por_id])

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -357,3 +357,50 @@ class PontoHoraExtraMeStatus(BaseModel):
     pedido_pendente: PontoHoraExtraRead | None = None
     he_teto_minutos: int | None = None
     he_restante_minutos: int | None = None
+
+
+class PontoCoberturaColega(BaseModel):
+    id: int
+    nome: str
+
+
+class PontoCoberturaCreate(BaseModel):
+    cobertor_id: int = Field(..., ge=1)
+    data_ref: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoCoberturaConceder(BaseModel):
+    solicitante_id: int = Field(..., ge=1)
+    cobertor_id: int = Field(..., ge=1)
+    data_ref: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoCoberturaResposta(BaseModel):
+    aceitar: bool
+
+
+class PontoCoberturaDecisao(BaseModel):
+    aprovar: bool
+    decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoCoberturaRead(BaseModel):
+    id: int
+    solicitante_id: int
+    solicitante_nome: str | None = None
+    cobertor_id: int
+    cobertor_nome: str | None = None
+    data_ref: date
+    motivo: str | None = None
+    estado: str
+    origem: str = "solicitacao"
+    resposta_cobertor: str | None = None
+    respondido_em: datetime | None = None
+    decidido_por_id: int | None = None
+    decidido_em: datetime | None = None
+    decisao_motivo: str | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -514,10 +514,20 @@ def calendario(
         por_dia.setdefault(d, []).append(b)
 
     usa = escala_svc.escala_configurada(atendente)
+    from app.services import ponto_cobertura as cob_svc
+
+    papeis = cob_svc.mapa_papeis_periodo(db, atendente.id, desde=desde, ate=ate)
     dias_out: list[PontoCalendarioDia] = []
     for d in dias_mes:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
-        esp = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
+        esp_escala = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
+        papel = papeis.get(d)
+        if papel == "solicitante":
+            esp = False
+        elif papel == "cobertor":
+            esp = True
+        else:
+            esp = esp_escala
         bats = por_dia.get(d, [])
         te = any(b.tipo == "entrada" for b in bats)
         ts = any(b.tipo == "saida" for b in bats)
@@ -525,7 +535,7 @@ def calendario(
         intervalos = _intervalos_de_batidas(bats)
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
         esperado_visual = bool(esp and not feriado)
-        if usa and esperado_visual:
+        if (usa or papel == "cobertor") and esperado_visual:
             esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
             esperados = meta_default
@@ -534,7 +544,7 @@ def calendario(
         else:
             esperados = 0
         # Sem jornada esperada: dia com batidas compara à meta; dia vazio fica neutro
-        esperado_para_cor = esperado_visual if usa else bool(te or ts)
+        esperado_para_cor = esperado_visual if (usa or papel) else bool(te or ts)
         dias_out.append(
             PontoCalendarioDia(
                 data=d,
@@ -542,7 +552,7 @@ def calendario(
                 tem_entrada=te,
                 tem_saida=ts,
                 status=_status_dia(  # type: ignore[arg-type]
-                    usa_escala=usa,
+                    usa_escala=usa or papel == "cobertor",
                     esperado=esp,
                     tem_entrada=te,
                     tem_saida=ts,
@@ -574,6 +584,7 @@ def calendario(
 
 
 def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
+    from app.services import ponto_cobertura as cob_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     hoje = datetime.now(PONTO_TZ).date()
@@ -593,7 +604,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     itens: list[PontoHojeItem] = []
     for a in atendentes:
         usa = escala_svc.escala_configurada(a)
-        esperado = escala_svc.eh_dia_de_trabalho(a, hoje) if usa else False
+        esperado = cob_svc.eh_dia_esperado_efetivo(db, a, hoje) if not feriado_hoje else False
         entrada = _entrada_da_jornada_aberta(db, a.id)
         inicio, fim = _bounds_periodo(hoje, hoje)
         bats = (
@@ -609,7 +620,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
         ts = any(b.tipo == "saida" for b in bats)
         atrasado = _atrasado_entrada(a, _primeira_entrada_do_dia(bats))
         st = _status_dia(
-            usa_escala=usa,
+            usa_escala=usa or esperado,
             esperado=esperado,
             tem_entrada=te,
             tem_saida=ts,
@@ -678,9 +689,13 @@ def banco_horas(
     desde: date,
     ate: date,
 ) -> PontoBancoHorasRead:
+    from app.services import ponto_cobertura as cob_svc
+
     if ate < desde:
         raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
     usa = escala_svc.escala_configurada(atendente)
+    settings = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
+    meta_default = int(getattr(settings, "jornada_diaria_minutos", None) or 480) * 60
     dias_escala = 0
     dias_feriado = 0
     esperado = 0
@@ -689,15 +704,15 @@ def banco_horas(
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
         if feriado:
             dias_feriado += 1
-        elif usa and escala_svc.eh_dia_de_trabalho(atendente, d):
+        elif cob_svc.eh_dia_esperado_efetivo(db, atendente, d):
             dias_escala += 1
-            esperado += escala_svc.segundos_esperados_dia(atendente, d)
+            seg = escala_svc.segundos_esperados_dia(atendente, d)
+            esperado += seg if seg > 0 else meta_default
         d += timedelta(days=1)
 
     hist = historico(db, atendente, desde=desde, ate=ate, offset=0, limit=10_000)
     realizado = hist.total_segundos_fechados
-    # Sem escala: não gera débito — saldo = realizado (crédito puro)
-    if not usa:
+    if not usa and dias_escala == 0:
         esperado = 0
     return PontoBancoHorasRead(
         atendente_id=atendente.id,
@@ -732,10 +747,14 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     lembrete_saida = False
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
-    jornada_ativa = escala_svc.escala_configurada(atendente)
+    from app.services import ponto_cobertura as cob_svc
+
+    jornada_ativa = escala_svc.escala_configurada(atendente) or (
+        cob_svc.papel_cobertura_aprovada(db, atendente.id, hoje) is not None
+    )
     esperado = None
-    if jornada_ativa and not feriado:
-        esperado = escala_svc.eh_dia_de_trabalho(atendente, hoje)
+    if not feriado:
+        esperado = cob_svc.eh_dia_esperado_efetivo(db, atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
     inicio, fim = _bounds_periodo(hoje, hoje)

--- a/backend/app/services/ponto_cobertura.py
+++ b/backend/app/services/ponto_cobertura.py
@@ -1,0 +1,384 @@
+"""Troca / cobertura de plantão (#970)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.ponto_cobertura import PontoCobertura
+from app.schemas.ponto import PontoCoberturaRead
+from app.services import escala as escala_svc
+from app.services import ponto as ponto_svc
+
+ESTADOS = frozenset(
+    {"pendente_cobertor", "pendente_admin", "aprovada", "rejeitada", "cancelada"}
+)
+
+
+def _to_read(row: PontoCobertura) -> PontoCoberturaRead:
+    return PontoCoberturaRead(
+        id=row.id,
+        solicitante_id=row.solicitante_id,
+        solicitante_nome=row.solicitante.nome if row.solicitante else None,
+        cobertor_id=row.cobertor_id,
+        cobertor_nome=row.cobertor.nome if row.cobertor else None,
+        data_ref=row.data_ref,
+        motivo=row.motivo,
+        estado=row.estado,
+        origem=row.origem or "solicitacao",
+        resposta_cobertor=row.resposta_cobertor,
+        respondido_em=row.respondido_em,
+        decidido_por_id=row.decidido_por_id,
+        decidido_em=row.decidido_em,
+        decisao_motivo=row.decisao_motivo,
+        created_at=row.created_at,
+    )
+
+
+def _carregar(db: Session, cobertura_id: int) -> PontoCobertura:
+    row = (
+        db.query(PontoCobertura)
+        .options(
+            joinedload(PontoCobertura.solicitante),
+            joinedload(PontoCobertura.cobertor),
+        )
+        .filter(PontoCobertura.id == cobertura_id)
+        .first()
+    )
+    assert row is not None
+    return row
+
+
+def papel_cobertura_aprovada(db: Session, atendente_id: int, dia: date) -> str | None:
+    """Retorna 'solicitante' | 'cobertor' se houver cobertura aprovada no dia."""
+    row = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.estado == "aprovada",
+            PontoCobertura.data_ref == dia,
+            or_(
+                PontoCobertura.solicitante_id == atendente_id,
+                PontoCobertura.cobertor_id == atendente_id,
+            ),
+        )
+        .order_by(PontoCobertura.id.desc())
+        .first()
+    )
+    if not row:
+        return None
+    if row.solicitante_id == atendente_id:
+        return "solicitante"
+    return "cobertor"
+
+
+def eh_dia_esperado_efetivo(db: Session, atendente: Atendente, dia: date) -> bool:
+    """Dia esperado após coberturas aprovadas (#970)."""
+    papel = papel_cobertura_aprovada(db, atendente.id, dia)
+    if papel == "solicitante":
+        return False
+    if papel == "cobertor":
+        return True
+    if not escala_svc.escala_configurada(atendente):
+        return False
+    return escala_svc.eh_dia_de_trabalho(atendente, dia)
+
+
+def mapa_papeis_periodo(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> dict[date, str]:
+    rows = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.estado == "aprovada",
+            PontoCobertura.data_ref >= desde,
+            PontoCobertura.data_ref <= ate,
+            or_(
+                PontoCobertura.solicitante_id == atendente_id,
+                PontoCobertura.cobertor_id == atendente_id,
+            ),
+        )
+        .all()
+    )
+    out: dict[date, str] = {}
+    for r in rows:
+        out[r.data_ref] = "solicitante" if r.solicitante_id == atendente_id else "cobertor"
+    return out
+
+
+def _atendente_tenant(db: Session, tenant_id: int, atendente_id: int) -> Atendente:
+    a = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == tenant_id,
+            Atendente.role != "saas_ops",
+            Atendente.ativo.is_(True),
+        )
+        .first()
+    )
+    if not a:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    return a
+
+
+def solicitar(
+    db: Session,
+    solicitante: Atendente,
+    *,
+    cobertor_id: int,
+    data_ref: date,
+    motivo: str | None = None,
+) -> PontoCoberturaRead:
+    ponto_svc.exigir_acesso_ponto(solicitante)
+    if cobertor_id == solicitante.id:
+        raise HTTPException(status_code=400, detail="Escolha outro colaborador para cobrir.")
+    cobertor = _atendente_tenant(db, solicitante.tenant_id, cobertor_id)
+    if data_ref < date.today():
+        raise HTTPException(status_code=400, detail="A data da cobertura deve ser hoje ou futura.")
+    existente = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.tenant_id == solicitante.tenant_id,
+            PontoCobertura.data_ref == data_ref,
+            PontoCobertura.estado.in_(("pendente_cobertor", "pendente_admin", "aprovada")),
+            or_(
+                PontoCobertura.solicitante_id.in_((solicitante.id, cobertor.id)),
+                PontoCobertura.cobertor_id.in_((solicitante.id, cobertor.id)),
+            ),
+        )
+        .first()
+    )
+    if existente:
+        raise HTTPException(
+            status_code=400,
+            detail="Já existe cobertura pendente ou aprovada envolvendo estes colaboradores nesta data.",
+        )
+    row = PontoCobertura(
+        tenant_id=solicitante.tenant_id,
+        solicitante_id=solicitante.id,
+        cobertor_id=cobertor.id,
+        data_ref=data_ref,
+        motivo=(motivo or "").strip()[:1000] or None,
+        estado="pendente_cobertor",
+        origem="solicitacao",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "create",
+        solicitante.id,
+        payload={
+            "cobertor_id": cobertor.id,
+            "data_ref": str(data_ref),
+            "estado": "pendente_cobertor",
+        },
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def responder_cobertor(
+    db: Session,
+    cobertor: Atendente,
+    cobertura_id: int,
+    *,
+    aceitar: bool,
+) -> PontoCoberturaRead:
+    ponto_svc.exigir_acesso_ponto(cobertor)
+    row = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.id == cobertura_id,
+            PontoCobertura.tenant_id == cobertor.tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Cobertura não encontrada")
+    if row.cobertor_id != cobertor.id:
+        raise HTTPException(status_code=403, detail="Só o cobertor pode responder este pedido.")
+    if row.estado != "pendente_cobertor":
+        raise HTTPException(status_code=400, detail="Este pedido já foi respondido.")
+    row.respondido_em = datetime.now(timezone.utc)
+    if aceitar:
+        row.resposta_cobertor = "aceita"
+        row.estado = "pendente_admin"
+    else:
+        row.resposta_cobertor = "recusa"
+        row.estado = "rejeitada"
+        row.decisao_motivo = "Recusado pelo cobertor"
+        row.decidido_em = row.respondido_em
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "responder_cobertor",
+        cobertor.id,
+        payload={"aceitar": aceitar, "estado": row.estado},
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def decidir_admin(
+    db: Session,
+    admin: Atendente,
+    cobertura_id: int,
+    *,
+    aprovar: bool,
+    decisao_motivo: str | None = None,
+) -> PontoCoberturaRead:
+    row = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.id == cobertura_id,
+            PontoCobertura.tenant_id == admin.tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Cobertura não encontrada")
+    if row.estado not in ("pendente_admin", "pendente_cobertor"):
+        raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
+    row.decidido_por_id = admin.id
+    row.decidido_em = datetime.now(timezone.utc)
+    row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
+    if aprovar:
+        row.estado = "aprovada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Homologado pelo administrador"
+        if row.resposta_cobertor is None:
+            row.resposta_cobertor = "aceita"
+            row.respondido_em = row.decidido_em
+    else:
+        row.estado = "rejeitada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Negado pelo administrador"
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "decidir",
+        admin.id,
+        payload={"estado": row.estado},
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def conceder_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    solicitante_id: int,
+    cobertor_id: int,
+    data_ref: date,
+    motivo: str | None = None,
+) -> PontoCoberturaRead:
+    if solicitante_id == cobertor_id:
+        raise HTTPException(status_code=400, detail="Solicitante e cobertor devem ser diferentes.")
+    sol = _atendente_tenant(db, admin.tenant_id, solicitante_id)
+    cob = _atendente_tenant(db, admin.tenant_id, cobertor_id)
+    agora = datetime.now(timezone.utc)
+    row = PontoCobertura(
+        tenant_id=admin.tenant_id,
+        solicitante_id=sol.id,
+        cobertor_id=cob.id,
+        data_ref=data_ref,
+        motivo=(motivo or "").strip()[:1000] or "Cobertura agendada pelo administrador.",
+        estado="aprovada",
+        origem="admin",
+        resposta_cobertor="aceita",
+        respondido_em=agora,
+        decidido_por_id=admin.id,
+        decidido_em=agora,
+        decisao_motivo="Agendamento direto",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "conceder",
+        admin.id,
+        payload={
+            "solicitante_id": sol.id,
+            "cobertor_id": cob.id,
+            "data_ref": str(data_ref),
+        },
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def listar_colegas(db: Session, atendente: Atendente) -> list[dict]:
+    """Colaboradores ativos do tenant (exceto eu) para pedir cobertura."""
+    ponto_svc.exigir_acesso_ponto(atendente)
+    rows = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == atendente.tenant_id,
+            Atendente.id != atendente.id,
+            Atendente.ativo.is_(True),
+            Atendente.role != "saas_ops",
+        )
+        .order_by(Atendente.nome.asc())
+        .limit(200)
+        .all()
+    )
+    return [{"id": a.id, "nome": a.nome} for a in rows]
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoCoberturaRead]:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    rows = (
+        db.query(PontoCobertura)
+        .options(
+            joinedload(PontoCobertura.solicitante),
+            joinedload(PontoCobertura.cobertor),
+        )
+        .filter(
+            or_(
+                PontoCobertura.solicitante_id == atendente.id,
+                PontoCobertura.cobertor_id == atendente.id,
+            )
+        )
+        .order_by(PontoCobertura.data_ref.desc(), PontoCobertura.id.desc())
+        .limit(100)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente_admin",
+) -> list[PontoCoberturaRead]:
+    q = (
+        db.query(PontoCobertura)
+        .options(
+            joinedload(PontoCobertura.solicitante),
+            joinedload(PontoCobertura.cobertor),
+        )
+        .filter(PontoCobertura.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        if estado == "pendente":
+            q = q.filter(PontoCobertura.estado.in_(("pendente_cobertor", "pendente_admin")))
+        else:
+            if estado not in ESTADOS:
+                raise HTTPException(status_code=400, detail="Estado inválido.")
+            q = q.filter(PontoCobertura.estado == estado)
+    rows = q.order_by(PontoCobertura.created_at.asc()).limit(200).all()
+    return [_to_read(r) for r in rows]

--- a/backend/app/services/ponto_folha.py
+++ b/backend/app/services/ponto_folha.py
@@ -1,0 +1,204 @@
+"""Export contábil / template folha RH (#975)."""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date, timedelta
+
+from fastapi import HTTPException
+from openpyxl import Workbook
+from sqlalchemy.orm import Session
+
+from app.core.auth import ROLES_ATENDENTE
+from app.models.atendente import Atendente
+from app.models.audit_log import AuditLog
+from app.models.ponto_batida import PontoBatida
+from app.services import escala as escala_svc
+from app.services import ponto as ponto_svc
+from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_settings as ponto_settings_svc
+from app.services.ponto_relatorio import _coletar_ajustes_audit, _rotulo_acao_ajuste
+
+COLUNAS = [
+    "matricula",
+    "nome",
+    "email",
+    "desde",
+    "ate",
+    "dias_escala",
+    "dias_feriado",
+    "previsto_horas",
+    "realizado_horas",
+    "banco_horas",
+    "atrasos",
+    "faltas",
+    "he_minutos",
+    "ajustes",
+]
+
+
+def _segundos_para_horas(seg: int) -> str:
+    return f"{(seg / 3600.0):.2f}".replace(".", ",")
+
+
+def _atendentes_folha(
+    db: Session, admin: Atendente, *, atendente_id: int | None
+) -> list[Atendente]:
+    q = db.query(Atendente).filter(
+        Atendente.tenant_id == admin.tenant_id,
+        Atendente.ativo.is_(True),
+        Atendente.role.in_(tuple(ROLES_ATENDENTE)),
+    )
+    if atendente_id is not None:
+        q = q.filter(Atendente.id == atendente_id)
+    return q.order_by(Atendente.nome.asc()).all()
+
+
+def _ajustes_por_atendente(ajustes: list[AuditLog]) -> dict[int, int]:
+    contagem: dict[int, int] = {}
+    for a in ajustes:
+        payload = a.payload if isinstance(getattr(a, "payload", None), dict) else {}
+        if not isinstance(payload, dict):
+            continue
+        aid = payload.get("atendente_id")
+        if aid is None:
+            continue
+        try:
+            aid_i = int(aid)
+        except (TypeError, ValueError):
+            continue
+        contagem[aid_i] = contagem.get(aid_i, 0) + 1
+    return contagem
+
+
+def _linha_folha(
+    db: Session,
+    atendente: Atendente,
+    *,
+    desde: date,
+    ate: date,
+    ajustes_n: int,
+) -> dict:
+    bh = ponto_svc.banco_horas(db, atendente, desde=desde, ate=ate)
+    faltas = 0
+    atrasos = 0
+    d = desde
+    usa = escala_svc.escala_configurada(atendente)
+    while d <= ate:
+        feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
+        esp = cob_svc.eh_dia_esperado_efetivo(db, atendente, d) if not feriado else False
+        ini, fim = ponto_svc._bounds_periodo(d, d)
+        bats = (
+            ponto_svc._q_ativas(db)
+            .filter(
+                PontoBatida.atendente_id == atendente.id,
+                PontoBatida.registrado_em >= ini,
+                PontoBatida.registrado_em < fim,
+            )
+            .all()
+        )
+        te = any(b.tipo == "entrada" for b in bats)
+        ts = any(b.tipo == "saida" for b in bats)
+        atrasado = ponto_svc._atrasado_entrada(atendente, ponto_svc._primeira_entrada_do_dia(bats))
+        st = ponto_svc._status_dia(
+            usa_escala=usa or esp,
+            esperado=esp,
+            tem_entrada=te,
+            tem_saida=ts,
+            feriado=feriado,
+            atrasado=atrasado,
+        )
+        if st == "falta":
+            faltas += 1
+        if atrasado or st == "atraso":
+            atrasos += 1
+        d += timedelta(days=1)
+
+    he = ponto_svc._he_minutos_periodo(db, atendente, desde=desde, ate=ate)
+    return {
+        "matricula": str(atendente.id),
+        "nome": atendente.nome,
+        "email": atendente.email or "",
+        "desde": desde.isoformat(),
+        "ate": ate.isoformat(),
+        "dias_escala": bh.dias_escala,
+        "dias_feriado": bh.dias_feriado,
+        "previsto_horas": _segundos_para_horas(bh.segundos_esperados),
+        "realizado_horas": _segundos_para_horas(bh.segundos_realizados),
+        "banco_horas": _segundos_para_horas(bh.saldo_segundos),
+        "atrasos": atrasos,
+        "faltas": faltas,
+        "he_minutos": he,
+        "ajustes": ajustes_n,
+    }
+
+
+def coletar_linhas(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date,
+    ate: date,
+) -> list[dict]:
+    if ate < desde:
+        raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
+    ajustes = _coletar_ajustes_audit(db, admin, desde=desde, ate=ate)
+    por_at = _ajustes_por_atendente(ajustes)
+    return [
+        _linha_folha(db, a, desde=desde, ate=ate, ajustes_n=por_at.get(a.id, 0))
+        for a in _atendentes_folha(db, admin, atendente_id=atendente_id)
+    ]
+
+
+def export_folha_csv(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date,
+    ate: date,
+) -> str:
+    linhas = coletar_linhas(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    buf = io.StringIO()
+    buf.write("\ufeff")
+    w = csv.DictWriter(buf, fieldnames=COLUNAS, delimiter=";")
+    w.writeheader()
+    for row in linhas:
+        w.writerow(row)
+    return buf.getvalue()
+
+
+def export_folha_xlsx(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date,
+    ate: date,
+) -> bytes:
+    linhas = coletar_linhas(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Folha"
+    ws.append(COLUNAS)
+    for row in linhas:
+        ws.append([row[c] for c in COLUNAS])
+    ws2 = wb.create_sheet("Ajustes")
+    ws2.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Payload"])
+    for a in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
+        payload = a.payload if isinstance(getattr(a, "payload", None), dict) else {}
+        ws2.append(
+            [
+                a.created_at.isoformat() if a.created_at else "",
+                a.atendente.nome if a.atendente else "",
+                _rotulo_acao_ajuste(a.action),
+                a.entity_id,
+                (payload or {}).get("motivo") or "",
+                str(payload or ""),
+            ]
+        )
+    out = io.BytesIO()
+    wb.save(out)
+    return out.getvalue()

--- a/backend/tests/test_ponto_lote_c_968_971_972.py
+++ b/backend/tests/test_ponto_lote_c_968_971_972.py
@@ -28,8 +28,13 @@ def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, 
     a1 = seed_base["a1"]
     agora = datetime.now(PONTO_TZ)
     # Coloca início da jornada 10 min no futuro e tol=30 → já estamos em inicio−tol
-    inicio = (agora + timedelta(minutes=10)).strftime("%H:%M")
-    fim = (agora + timedelta(hours=8)).strftime("%H:%M")
+    inicio_dt = agora + timedelta(minutes=10)
+    fim_dt = inicio_dt + timedelta(hours=8)
+    # Jornada semanal não pode cruzar meia-noite
+    if fim_dt.date() != inicio_dt.date():
+        fim_dt = inicio_dt.replace(hour=23, minute=59, second=0, microsecond=0)
+    inicio = inicio_dt.strftime("%H:%M")
+    fim = fim_dt.strftime("%H:%M")
     assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
     r = client.get("/v1/ponto/me/alertas", headers=user)
     assert r.status_code == 200, r.text
@@ -46,8 +51,12 @@ def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session
     a1 = seed_base["a1"]
     agora = datetime.now(PONTO_TZ)
     # fim daqui a 10 min, tol 30 → já na janela de saída
-    inicio = (agora - timedelta(hours=8)).strftime("%H:%M")
-    fim = (agora + timedelta(minutes=10)).strftime("%H:%M")
+    fim_dt = agora + timedelta(minutes=10)
+    inicio_dt = fim_dt - timedelta(hours=8)
+    if inicio_dt.date() != fim_dt.date():
+        inicio_dt = fim_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    inicio = inicio_dt.strftime("%H:%M")
+    fim = fim_dt.strftime("%H:%M")
     assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
     db_session.add(
         PontoBatida(

--- a/backend/tests/test_ponto_lote_f_975_970.py
+++ b/backend/tests/test_ponto_lote_f_975_970.py
@@ -1,0 +1,152 @@
+"""Lote F ponto: export folha RH (#975) e cobertura de plantão (#970)."""
+
+from datetime import date, timedelta
+
+
+def _patch_jornada_hoje(client, headers, atendente_id: int, *, ativo=True):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    # Semanal exige pelo menos um dia ativo
+    outro = keys[(date.today().weekday() + 1) % 7]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": ativo, "inicio": "08:00", "fim": "18:00"}
+    if not ativo:
+        hs[outro] = {"ativo": True, "inicio": "08:00", "fim": "18:00"}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 15,
+        },
+    )
+
+
+def test_export_folha_csv_colunas(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    desde = date.today().replace(day=1).isoformat()
+    ate = date.today().isoformat()
+    r = client.get(
+        "/v1/ponto/export/folha.csv",
+        headers=admin,
+        params={"desde": desde, "ate": ate},
+    )
+    assert r.status_code == 200, r.text
+    assert "text/csv" in r.headers.get("content-type", "")
+    text = r.content.decode("utf-8-sig")
+    header = text.splitlines()[0]
+    for col in (
+        "matricula",
+        "nome",
+        "previsto_horas",
+        "realizado_horas",
+        "atrasos",
+        "faltas",
+        "he_minutos",
+        "banco_horas",
+        "ajustes",
+    ):
+        assert col in header
+
+
+def test_export_folha_xlsx(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    desde = date.today().replace(day=1).isoformat()
+    ate = date.today().isoformat()
+    r = client.get(
+        "/v1/ponto/export/folha.xlsx",
+        headers=admin,
+        params={"desde": desde, "ate": ate},
+    )
+    assert r.status_code == 200, r.text
+    assert r.content[:2] == b"PK"  # zip/xlsx
+
+
+def test_cobertura_fluxo_solicitar_aceitar_homologar(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1h = auth_headers["a1"]
+    a2h = auth_headers["a2"]
+    a1 = seed_base["a1"]
+    a2 = seed_base["a2"]
+    assert _patch_jornada_hoje(client, admin, a1.id, ativo=True).status_code == 200
+    assert _patch_jornada_hoje(client, admin, a2.id, ativo=False).status_code == 200
+
+    data_ref = date.today().isoformat()
+    sol = client.post(
+        "/v1/ponto/coberturas",
+        headers=a1h,
+        json={"cobertor_id": a2.id, "data_ref": data_ref, "motivo": "Consulta médica"},
+    )
+    assert sol.status_code == 201, sol.text
+    cob_id = sol.json()["id"]
+    assert sol.json()["estado"] == "pendente_cobertor"
+
+    resp = client.post(
+        f"/v1/ponto/coberturas/{cob_id}/responder",
+        headers=a2h,
+        json={"aceitar": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["estado"] == "pendente_admin"
+
+    dec = client.post(
+        f"/v1/ponto/coberturas/{cob_id}/decidir",
+        headers=admin,
+        json={"aprovar": True},
+    )
+    assert dec.status_code == 200, dec.text
+    assert dec.json()["estado"] == "aprovada"
+
+    hoje = date.today()
+    cal1 = client.get(
+        "/v1/ponto/me/calendario",
+        headers=a1h,
+        params={"ano": hoje.year, "mes": hoje.month},
+    )
+    assert cal1.status_code == 200, cal1.text
+    dia1 = next(d for d in cal1.json()["dias"] if d["data"] == data_ref)
+    assert dia1["esperado"] is False
+    assert dia1["status"] != "falta"
+
+    cal2 = client.get(
+        "/v1/ponto/me/calendario",
+        headers=a2h,
+        params={"ano": hoje.year, "mes": hoje.month},
+    )
+    assert cal2.status_code == 200, cal2.text
+    dia2 = next(d for d in cal2.json()["dias"] if d["data"] == data_ref)
+    assert dia2["esperado"] is True
+
+
+def test_cobertura_admin_conceder(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    a2 = seed_base["a2"]
+    data_ref = (date.today() + timedelta(days=1)).isoformat()
+    r = client.post(
+        "/v1/ponto/coberturas/conceder",
+        headers=admin,
+        json={
+            "solicitante_id": a1.id,
+            "cobertor_id": a2.id,
+            "data_ref": data_ref,
+            "motivo": "Plantão urgente",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["estado"] == "aprovada"
+    assert r.json()["origem"] == "admin"
+
+
+def test_cobertura_colegas_e_me(client, seed_base, auth_headers):
+    a1h = auth_headers["a1"]
+    cols = client.get("/v1/ponto/coberturas/colegas", headers=a1h)
+    assert cols.status_code == 200, cols.text
+    ids = {c["id"] for c in cols.json()}
+    assert seed_base["a1"].id not in ids
+    assert seed_base["a2"].id in ids
+
+    me = client.get("/v1/ponto/coberturas/me", headers=a1h)
+    assert me.status_code == 200

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -838,6 +838,50 @@ export const ponto = {
     }
     return res.blob()
   },
+  exportFolha: async (
+    ext: 'csv' | 'xlsx',
+    params: { atendente_id?: number; desde: string; ate: string },
+  ) => {
+    const token = getAuthToken()
+    const headers: Record<string, string> = {}
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const path = ext === 'csv' ? '/ponto/export/folha.csv' : '/ponto/export/folha.xlsx'
+    const url = `${apiOrigin()}${API_VERSION_PREFIX}${withParams(path, params)}`
+    const res = await fetch(url, { headers })
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin()
+      throw new ApiError('Sessão expirada ou inválida.', 401, {})
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}))
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody)
+    }
+    return res.blob()
+  },
+  solicitarCobertura: (data: Ponto.CoberturaCreate) =>
+    api<Ponto.Cobertura>('/ponto/coberturas', { method: 'POST', body: JSON.stringify(data) }),
+  minhasCoberturas: () => api<Ponto.Cobertura[]>('/ponto/coberturas/me'),
+  colegasCobertura: () => api<Ponto.CoberturaColega[]>('/ponto/coberturas/colegas'),
+  responderCobertura: (id: number, data: Ponto.CoberturaResposta) =>
+    api<Ponto.Cobertura>(`/ponto/coberturas/${id}/responder`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  coberturasAdmin: (estado?: string) =>
+    api<Ponto.Cobertura[]>(withParams('/ponto/coberturas', { estado })),
+  concederCobertura: (data: Ponto.CoberturaConceder) =>
+    api<Ponto.Cobertura>('/ponto/coberturas/conceder', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  decidirCobertura: (id: number, data: Ponto.CoberturaDecisao) =>
+    api<Ponto.Cobertura>(`/ponto/coberturas/${id}/decidir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   meSettings: () => api<Ponto.SettingsPublic>('/ponto/me/settings'),
   locais: (params?: { atendente_id?: number; so_orfos?: boolean }) =>
     api<Ponto.Local[]>(withParams('/ponto/locais', params)),
@@ -5022,6 +5066,45 @@ export namespace Ponto {
     estado: 'aprovada' | 'rejeitada'
     decisao_motivo: string
     aplicar_batidas?: { tipo: Tipo; registrado_em: string; motivo: string }[]
+  }
+  export interface CoberturaCreate {
+    cobertor_id: number
+    data_ref: string
+    motivo?: string | null
+  }
+  export interface CoberturaColega {
+    id: number
+    nome: string
+  }
+  export interface CoberturaConceder {
+    solicitante_id: number
+    cobertor_id: number
+    data_ref: string
+    motivo?: string | null
+  }
+  export interface CoberturaResposta {
+    aceitar: boolean
+  }
+  export interface CoberturaDecisao {
+    aprovar: boolean
+    decisao_motivo?: string | null
+  }
+  export interface Cobertura {
+    id: number
+    solicitante_id: number
+    solicitante_nome?: string | null
+    cobertor_id: number
+    cobertor_nome?: string | null
+    data_ref: string
+    motivo?: string | null
+    estado: string
+    origem?: string
+    resposta_cobertor?: string | null
+    respondido_em?: string | null
+    decidido_por_id?: number | null
+    decidido_em?: string | null
+    decisao_motivo?: string | null
+    created_at?: string | null
   }
   export interface HoraExtra {
     id: number

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -10,6 +10,7 @@ import { Input } from '../components/ui/Input'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
+import { useAuth } from '../contexts/AuthContext'
 import { isCapacitorNative } from '../lib/capacitorNative'
 import { geolocationSupported, getCurrentPosition, type GeoError } from '../lib/geolocation'
 import {
@@ -46,6 +47,7 @@ type AcaoPrincipal = {
 
 export function MeuPonto() {
   const toast = useToast()
+  const { user } = useAuth()
   const [estado, setEstado] = useState<Ponto.EstadoMe | null>(null)
   const [historico, setHistorico] = useState<Ponto.Historico | null>(null)
   const [desde, setDesde] = useState(inicioMesIso)
@@ -57,6 +59,12 @@ export function MeuPonto() {
   const [justTipo, setJustTipo] = useState<Ponto.JustificativaCreate['tipo']>('esquecimento')
   const [justMotivo, setJustMotivo] = useState('')
   const [enviandoJust, setEnviandoJust] = useState(false)
+  const [coberturas, setCoberturas] = useState<Ponto.Cobertura[]>([])
+  const [colegasCob, setColegasCob] = useState<Ponto.CoberturaColega[]>([])
+  const [cobCobertor, setCobCobertor] = useState('')
+  const [cobData, setCobData] = useState(hojeIso)
+  const [cobMotivo, setCobMotivo] = useState('')
+  const [enviandoCob, setEnviandoCob] = useState(false)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
   const [refSemana, setRefSemana] = useState(hojeIso)
   const [resumoSemana, setResumoSemana] = useState<Ponto.ResumoSemana | null>(null)
@@ -88,18 +96,22 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs] = await Promise.all([
+        const [me, hist, js, bh, gs, cobs, cols] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
           ponto.meuBancoHoras(desde, ate),
           ponto.meSettings(),
+          ponto.minhasCoberturas(),
+          ponto.colegasCobertura(),
         ])
         setEstado(me)
         setHistorico(hist)
         setJustifs(js)
         setBanco(bh)
         setGeoSettings(gs)
+        setCoberturas(cobs)
+        setColegasCob(cols)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -284,6 +296,38 @@ export function MeuPonto() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a justificativa.'))
     } finally {
       setEnviandoJust(false)
+    }
+  }
+
+  async function solicitarCobertura() {
+    if (!cobCobertor) {
+      toast.showWarning('Selecione quem vai cobrir o plantão.')
+      return
+    }
+    setEnviandoCob(true)
+    try {
+      await ponto.solicitarCobertura({
+        cobertor_id: Number(cobCobertor),
+        data_ref: cobData,
+        motivo: cobMotivo.trim() || null,
+      })
+      toast.showSuccess('Pedido de cobertura enviado. Aguarde o cobertor e o admin.')
+      setCobMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível solicitar a cobertura.'))
+    } finally {
+      setEnviandoCob(false)
+    }
+  }
+
+  async function responderCob(id: number, aceitar: boolean) {
+    try {
+      await ponto.responderCobertura(id, { aceitar })
+      toast.showSuccess(aceitar ? 'Cobertura aceita — aguarda homologação do admin.' : 'Pedido recusado.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível responder.'))
     }
   }
 
@@ -733,6 +777,68 @@ export function MeuPonto() {
                   ) : null}
                 </li>
               ))
+            )}
+          </ul>
+        </Card>
+      </div>
+
+      <div className="mt-4">
+        <Card
+          title="Cobertura de plantão"
+          description="Peça para um colega cobrir seu dia; ele aceita e o admin homologa."
+        >
+          <div className="flex flex-wrap items-end gap-3">
+            <Select
+              label="Quem cobre"
+              value={cobCobertor}
+              onChange={(v) => setCobCobertor(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...colegasCob.map((c) => ({ value: String(c.id), label: c.nome })),
+              ]}
+            />
+            <Input label="Data" type="date" value={cobData} onChange={(e) => setCobData(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={cobMotivo}
+              onChange={(e) => setCobMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={enviandoCob} onClick={() => void solicitarCobertura()}>
+              Solicitar
+            </Button>
+          </div>
+          <ul className="mt-4 space-y-2 text-sm">
+            {coberturas.length === 0 ? (
+              <li className="text-slate-500">Nenhuma cobertura neste histórico.</li>
+            ) : (
+              coberturas.map((c) => {
+                const souCobertor = user?.id === c.cobertor_id
+                const pendenteMim = souCobertor && c.estado === 'pendente_cobertor'
+                return (
+                  <li
+                    key={c.id}
+                    className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                  >
+                    <div>
+                      <p className="font-medium">
+                        {c.solicitante_nome} → {c.cobertor_nome} · {c.data_ref}
+                      </p>
+                      <p className="capitalize text-slate-500">{c.estado.replace(/_/g, ' ')}</p>
+                      {c.motivo ? <p className="text-slate-600 dark:text-slate-300">{c.motivo}</p> : null}
+                    </div>
+                    {pendenteMim ? (
+                      <div className="flex gap-2">
+                        <Button type="button" variant="secondary" onClick={() => void responderCob(c.id, true)}>
+                          Aceitar
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void responderCob(c.id, false)}>
+                          Recusar
+                        </Button>
+                      </div>
+                    ) : null}
+                  </li>
+                )
+              })
             )}
           </ul>
         </Card>

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -70,6 +70,12 @@ export function PontoEquipe() {
   const [ajusteAuditAte, setAjusteAuditAte] = useState(hojeIso)
   const [carregandoAjustes, setCarregandoAjustes] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
+  const [cobPendentes, setCobPendentes] = useState<Ponto.Cobertura[]>([])
+  const [cobSolicitante, setCobSolicitante] = useState('')
+  const [cobCobertor, setCobCobertor] = useState('')
+  const [cobData, setCobData] = useState(hojeIso)
+  const [cobMotivo, setCobMotivo] = useState('')
+  const [concedendoCob, setConcedendoCob] = useState(false)
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
@@ -96,7 +102,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, cobs] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -109,6 +115,7 @@ export function PontoEquipe() {
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
           ponto.horaExtraAdmin('pendente'),
+          ponto.coberturasAdmin('pendente'),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -118,6 +125,7 @@ export function PontoEquipe() {
         setSettings(st)
         setFeriados(fer)
         setHesPendentes(hes)
+        setCobPendentes(cobs)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -243,6 +251,24 @@ export function PontoEquipe() {
     }
   }
 
+  async function exportarFolha(ext: 'csv' | 'xlsx') {
+    try {
+      const blob = await ponto.exportFolha(ext, {
+        atendente_id: atendenteId ? Number(atendenteId) : undefined,
+        desde,
+        ate,
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = ext === 'csv' ? 'ponto_folha.csv' : 'ponto_folha.xlsx'
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível exportar a folha RH.'))
+    }
+  }
+
   async function salvarAjuste() {
     if (!ajusteAtendente) {
       toast.showWarning('Selecione o atendente.')
@@ -314,6 +340,46 @@ export function PontoEquipe() {
       await carregar(true)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir.'))
+    }
+  }
+
+  async function decidirCob(id: number, aprovar: boolean) {
+    try {
+      await ponto.decidirCobertura(id, {
+        aprovar,
+        decisao_motivo: aprovar ? null : 'Negado pelo administrador',
+      })
+      toast.showSuccess(aprovar ? 'Cobertura homologada.' : 'Cobertura negada.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a cobertura.'))
+    }
+  }
+
+  async function concederCob() {
+    if (!cobSolicitante || !cobCobertor) {
+      toast.showWarning('Selecione solicitante e cobertor.')
+      return
+    }
+    if (cobSolicitante === cobCobertor) {
+      toast.showWarning('Solicitante e cobertor devem ser diferentes.')
+      return
+    }
+    setConcedendoCob(true)
+    try {
+      await ponto.concederCobertura({
+        solicitante_id: Number(cobSolicitante),
+        cobertor_id: Number(cobCobertor),
+        data_ref: cobData,
+        motivo: cobMotivo.trim() || null,
+      })
+      toast.showSuccess('Cobertura agendada.')
+      setCobMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar a cobertura.'))
+    } finally {
+      setConcedendoCob(false)
     }
   }
 
@@ -549,6 +615,71 @@ export function PontoEquipe() {
           )}
         </Card>
 
+        <Card title="Cobertura de plantão">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Agende direto ou homologue pedidos (A pede, B aceita, admin confirma). No dia, A não gera falta e B
+            passa a ter jornada esperada.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Solicitante (folga)"
+              value={cobSolicitante}
+              onChange={(v) => setCobSolicitante(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Select
+              label="Cobertor"
+              value={cobCobertor}
+              onChange={(v) => setCobCobertor(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Input label="Data" type="date" value={cobData} onChange={(e) => setCobData(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={cobMotivo}
+              onChange={(e) => setCobMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={concedendoCob} onClick={() => void concederCob()}>
+              Agendar
+            </Button>
+          </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Pedidos pendentes</p>
+          {cobPendentes.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
+          ) : (
+            <ul className="space-y-3">
+              {cobPendentes.map((c) => (
+                <li
+                  key={c.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">
+                      {c.solicitante_nome} → {c.cobertor_nome} · {c.data_ref}
+                    </p>
+                    <p className="text-slate-500">{c.estado.replace(/_/g, ' ')}</p>
+                    {c.motivo ? <p className="text-slate-600 dark:text-slate-300">{c.motivo}</p> : null}
+                  </div>
+                  <div className="flex gap-2">
+                    <Button type="button" variant="secondary" onClick={() => void decidirCob(c.id, true)}>
+                      Homologar
+                    </Button>
+                    <Button type="button" variant="ghost" onClick={() => void decidirCob(c.id, false)}>
+                      Negar
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
         <Card title="Hora extra (WhatsApp após jornada)">
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
             Conceda HE com antecedência ou libere pedidos após o fim da jornada. Modos: resto do dia, até um horário ou
@@ -775,6 +906,12 @@ export function PontoEquipe() {
             </Button>
             <Button type="button" variant="secondary" onClick={() => void exportarRelatorio('xlsx')}>
               Excel mensal
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarFolha('csv')}>
+              Folha RH (CSV)
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarFolha('xlsx')}>
+              Folha RH (Excel)
             </Button>
           </div>
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">


### PR DESCRIPTION
## Summary

- Closes #975 — export contábil/folha RH (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes
- Closes #970 — cobertura de plantão: A pede → B aceita → admin homologa (ou admin agenda direto); calendário/faltas respeitam o papel
- UI em **Meu ponto** (pedir/responder) e **Ponto da equipe** (agendar/homologar + export folha)
- Teste do Lote C: evita falha flaky quando a jornada de teste cruzaria meia-noite

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` Lote F + ponto + Lote C (26 passed)
- [x] `tsc -b` no frontend
- [ ] Admin: exportar folha CSV/Excel no período
- [ ] Colaborador: solicitar cobertura; cobertor aceita; admin homologa
- [ ] Calendário: solicitante sem falta esperada; cobertor com dia esperado
- [ ] Admin: agendar cobertura direto

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Matrícula na folha v1 = `atendente.id` — follow-up se RH exigir matrícula própria
- [x] Próximo lote G do épico #967: #981, #980, #978, #979
