### PR TITLE
feat(ponto): Lote G — ajuda, checklist, competência e ciência (#981/#980/#978/#979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento
 - Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas
 
 #### Correções

--- a/backend/alembic/versions/131_ponto_lote_g.py
+++ b/backend/alembic/versions/131_ponto_lote_g.py
@@ -1,0 +1,104 @@
+"""Lote G: competência mensal e ciência do espelho (#978 / #979).
+
+Revision ID: 131_ponto_lote_g
+Revises: 130_ponto_lote_f
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "131_ponto_lote_g"
+down_revision = "130_ponto_lote_f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("ponto_competencias"):
+        op.create_table(
+            "ponto_competencias",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "tenant_id",
+                sa.Integer(),
+                sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("ano", sa.Integer(), nullable=False),
+            sa.Column("mes", sa.Integer(), nullable=False),
+            sa.Column("fechada", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("fechado_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "fechado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("reaberto_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "reaberto_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("reabrir_motivo", sa.String(1000), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+            sa.UniqueConstraint("tenant_id", "ano", "mes", name="uq_ponto_competencias_tenant_ano_mes"),
+        )
+        op.create_index("ix_ponto_competencias_tenant_id", "ponto_competencias", ["tenant_id"])
+
+    if not insp.has_table("ponto_espelho_ciencias"):
+        op.create_table(
+            "ponto_espelho_ciencias",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "tenant_id",
+                sa.Integer(),
+                sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("ano", sa.Integer(), nullable=False),
+            sa.Column("mes", sa.Integer(), nullable=False),
+            sa.Column(
+                "confirmado_em",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column("ativa", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("invalidada_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("invalidada_motivo", sa.String(500), nullable=True),
+            sa.UniqueConstraint(
+                "tenant_id",
+                "atendente_id",
+                "ano",
+                "mes",
+                name="uq_ponto_espelho_ciencias_atendente_ano_mes",
+            ),
+        )
+        op.create_index("ix_ponto_espelho_ciencias_tenant_id", "ponto_espelho_ciencias", ["tenant_id"])
+        op.create_index(
+            "ix_ponto_espelho_ciencias_atendente_id",
+            "ponto_espelho_ciencias",
+            ["atendente_id"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_espelho_ciencias"):
+        op.drop_table("ponto_espelho_ciencias")
+    if insp.has_table("ponto_competencias"):
+        op.drop_table("ponto_competencias")

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -21,12 +21,16 @@ from app.schemas.ponto import (
     PontoBatidaRead,
     PontoBaterRequest,
     PontoCalendarioRead,
+    PontoCienciaItem,
+    PontoCienciaMe,
     PontoCoberturaColega,
     PontoCoberturaConceder,
     PontoCoberturaCreate,
     PontoCoberturaDecisao,
     PontoCoberturaRead,
     PontoCoberturaResposta,
+    PontoCompetenciaRead,
+    PontoCompetenciaReabrir,
     PontoDigestRead,
     PontoEstadoRead,
     PontoFeriadoCreate,
@@ -48,9 +52,11 @@ from app.schemas.ponto import (
     PontoSettingsPublicRead,
     PontoSettingsRead,
     PontoSettingsUpdate,
+    PontoSetupStatus,
 )
 from app.services import ponto as ponto_svc
 from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_competencia as comp_svc
 from app.services import ponto_folha as folha_svc
 from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
@@ -312,6 +318,85 @@ def decidir_cobertura(
         aprovar=data.aprovar,
         decisao_motivo=data.decisao_motivo,
     )
+
+
+@router.get("/setup-status", response_model=PontoSetupStatus)
+def ponto_setup_status(
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    """Checklist de configuração do módulo ponto (#981)."""
+    return comp_svc.setup_status(db, admin)
+
+
+@router.get("/competencias", response_model=list[PontoCompetenciaRead])
+def listar_competencias(
+    ano: int | None = Query(None),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.listar_competencias(db, admin, ano=ano)
+
+
+@router.get("/competencias/{ano}/{mes}", response_model=PontoCompetenciaRead)
+def obter_competencia(
+    ano: int,
+    mes: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.obter_competencia(db, admin, ano=ano, mes=mes)
+
+
+@router.post("/competencias/{ano}/{mes}/fechar", response_model=PontoCompetenciaRead)
+def fechar_competencia(
+    ano: int,
+    mes: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.fechar_competencia(db, admin, ano=ano, mes=mes)
+
+
+@router.post("/competencias/{ano}/{mes}/reabrir", response_model=PontoCompetenciaRead)
+def reabrir_competencia(
+    ano: int,
+    mes: int,
+    data: PontoCompetenciaReabrir,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.reabrir_competencia(db, admin, ano=ano, mes=mes, motivo=data.motivo)
+
+
+@router.get("/competencias/{ano}/{mes}/ciencias", response_model=list[PontoCienciaItem])
+def listar_ciencias(
+    ano: int,
+    mes: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.listar_ciencias_admin(db, admin, ano=ano, mes=mes)
+
+
+@router.get("/me/ciencia", response_model=PontoCienciaMe)
+def minha_ciencia(
+    ano: int = Query(...),
+    mes: int = Query(..., ge=1, le=12),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return comp_svc.ciencia_me(db, atendente, ano=ano, mes=mes)
+
+
+@router.post("/me/ciencia", response_model=PontoCienciaMe)
+def confirmar_ciencia(
+    ano: int = Query(...),
+    mes: int = Query(..., ge=1, le=12),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return comp_svc.confirmar_ciencia(db, atendente, ano=ano, mes=mes)
 
 
 @router.get("/batidas", response_model=ListaPaginada[PontoBatidaAdminItem])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
 from app.models.ponto_cobertura import PontoCobertura
+from app.models.ponto_competencia import PontoCompetencia, PontoEspelhoCiencia
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin

--- a/backend/app/models/ponto_competencia.py
+++ b/backend/app/models/ponto_competencia.py
@@ -1,0 +1,63 @@
+"""Competência mensal e ciência do espelho (#978 / #979)."""
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoCompetencia(Base):
+    __tablename__ = "ponto_competencias"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "ano", "mes", name="uq_ponto_competencias_tenant_ano_mes"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    ano = Column(Integer, nullable=False)
+    mes = Column(Integer, nullable=False)
+    fechada = Column(Boolean, nullable=False, default=False, server_default="false")
+    fechado_em = Column(DateTime(timezone=True), nullable=True)
+    fechado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    reaberto_em = Column(DateTime(timezone=True), nullable=True)
+    reaberto_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    reabrir_motivo = Column(String(1000), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    fechado_por = relationship("Atendente", foreign_keys=[fechado_por_id])
+    reaberto_por = relationship("Atendente", foreign_keys=[reaberto_por_id])
+
+
+class PontoEspelhoCiencia(Base):
+    __tablename__ = "ponto_espelho_ciencias"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "atendente_id",
+            "ano",
+            "mes",
+            name="uq_ponto_espelho_ciencias_atendente_ano_mes",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    ano = Column(Integer, nullable=False)
+    mes = Column(Integer, nullable=False)
+    confirmado_em = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    # Se ajuste pós-ciência invalidar, fica False e confirmado_em permanece histórico no audit
+    ativa = Column(Boolean, nullable=False, default=True, server_default="true")
+    invalidada_em = Column(DateTime(timezone=True), nullable=True)
+    invalidada_motivo = Column(String(500), nullable=True)
+
+    atendente = relationship("Atendente", foreign_keys=[atendente_id])

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -404,3 +404,52 @@ class PontoCoberturaRead(BaseModel):
     created_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class PontoSetupItem(BaseModel):
+    codigo: str
+    titulo: str
+    detalhe: str
+    destino: str
+    ok: bool
+    informativo: bool = False
+
+
+class PontoSetupStatus(BaseModel):
+    defaults_fecho_off: bool
+    tolerancia_sugerida_minutos: int = 15
+    pendentes: int
+    itens: list[PontoSetupItem]
+
+
+class PontoCompetenciaRead(BaseModel):
+    id: int
+    ano: int
+    mes: int
+    fechada: bool
+    fechado_em: datetime | None = None
+    fechado_por_id: int | None = None
+    fechado_por_nome: str | None = None
+    reaberto_em: datetime | None = None
+    reaberto_por_id: int | None = None
+    reabrir_motivo: str | None = None
+
+
+class PontoCompetenciaReabrir(BaseModel):
+    motivo: str = Field(..., min_length=3, max_length=1000)
+
+
+class PontoCienciaMe(BaseModel):
+    ano: int
+    mes: int
+    competencia_fechada: bool
+    confirmada: bool
+    confirmado_em: datetime | None = None
+    pode_confirmar: bool
+
+
+class PontoCienciaItem(BaseModel):
+    atendente_id: int
+    atendente_nome: str
+    confirmada: bool
+    confirmado_em: datetime | None = None

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -944,6 +944,8 @@ def admin_criar_batida(
     motivo: str,
     commit: bool = True,
 ) -> PontoBatida:
+    from app.services import ponto_competencia as comp_svc
+
     alvo = _atendente_do_tenant(db, admin.tenant_id, atendente_id)
     if tipo not in TIPOS_VALIDOS:
         raise HTTPException(status_code=400, detail="Tipo inválido")
@@ -953,11 +955,14 @@ def admin_criar_batida(
             status_code=400,
             detail="Informe o motivo do ajuste (mínimo 3 caracteres).",
         )
+    quando = _as_utc(registrado_em)
+    dia = _data_negocio(quando)
+    pos_fechamento = comp_svc.competencia_fechada_para_data(db, admin.tenant_id, dia)
     batida = PontoBatida(
         tenant_id=admin.tenant_id,
         atendente_id=alvo.id,
         tipo=tipo,
-        registrado_em=_as_utc(registrado_em),
+        registrado_em=quando,
         origem="admin",
         anulada=False,
     )
@@ -973,9 +978,19 @@ def admin_criar_batida(
             "motivo": motivo_limpo,
             "atendente_id": alvo.id,
             "tipo": tipo,
-            "registrado_em": _as_utc(registrado_em).isoformat(),
+            "registrado_em": quando.isoformat(),
+            "pos_fechamento": pos_fechamento,
         },
     )
+    if pos_fechamento:
+        comp_svc.invalidar_ciencias_mes(
+            db,
+            tenant_id=admin.tenant_id,
+            atendente_id=alvo.id,
+            ano=dia.year,
+            mes=dia.month,
+            motivo="Ajuste administrativo após fechamento da competência",
+        )
     if commit:
         db.commit()
         db.refresh(batida)
@@ -991,6 +1006,8 @@ def admin_atualizar_batida(
     registrado_em: datetime | None,
     motivo: str,
 ) -> PontoBatida:
+    from app.services import ponto_competencia as comp_svc
+
     batida = (
         db.query(PontoBatida)
         .filter(PontoBatida.id == batida_id, PontoBatida.tenant_id == admin.tenant_id)
@@ -1012,6 +1029,8 @@ def admin_atualizar_batida(
     if registrado_em is not None:
         batida.registrado_em = _as_utc(registrado_em)
     batida.origem = batida.origem or "admin"
+    dia = _data_negocio(batida.registrado_em)
+    pos_fechamento = comp_svc.competencia_fechada_para_data(db, admin.tenant_id, dia)
     registrar_audit(
         db,
         "ponto_batida",
@@ -1022,14 +1041,27 @@ def admin_atualizar_batida(
             "motivo": motivo_limpo,
             "antes": antes,
             "depois": {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()},
+            "pos_fechamento": pos_fechamento,
+            "atendente_id": batida.atendente_id,
         },
     )
+    if pos_fechamento:
+        comp_svc.invalidar_ciencias_mes(
+            db,
+            tenant_id=admin.tenant_id,
+            atendente_id=batida.atendente_id,
+            ano=dia.year,
+            mes=dia.month,
+            motivo="Ajuste administrativo após fechamento da competência",
+        )
     db.commit()
     db.refresh(batida)
     return batida
 
 
 def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo: str) -> PontoBatida:
+    from app.services import ponto_competencia as comp_svc
+
     batida = (
         db.query(PontoBatida)
         .filter(PontoBatida.id == batida_id, PontoBatida.tenant_id == admin.tenant_id)
@@ -1044,6 +1076,8 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
             detail="Informe o motivo da anulação (mínimo 3 caracteres).",
         )
     batida.anulada = True
+    dia = _data_negocio(batida.registrado_em)
+    pos_fechamento = comp_svc.competencia_fechada_para_data(db, admin.tenant_id, dia)
     registrar_audit(
         db,
         "ponto_batida",
@@ -1055,8 +1089,18 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
             "tipo": batida.tipo,
             "registrado_em": batida.registrado_em.isoformat(),
             "atendente_id": batida.atendente_id,
+            "pos_fechamento": pos_fechamento,
         },
     )
+    if pos_fechamento:
+        comp_svc.invalidar_ciencias_mes(
+            db,
+            tenant_id=admin.tenant_id,
+            atendente_id=batida.atendente_id,
+            ano=dia.year,
+            mes=dia.month,
+            motivo="Anulação após fechamento da competência",
+        )
     db.commit()
     db.refresh(batida)
     return batida

--- a/backend/app/services/ponto_competencia.py
+++ b/backend/app/services/ponto_competencia.py
@@ -1,0 +1,427 @@
+"""Setup checklist (#981), competência (#978) e ciência do espelho (#979)."""
+
+from __future__ import annotations
+
+from calendar import monthrange
+from datetime import date, datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.core.auth import ROLES_ATENDENTE
+from app.models.atendente import Atendente
+from app.models.ponto_competencia import PontoCompetencia, PontoEspelhoCiencia
+from app.models.ponto_settings import PontoLocal
+from app.schemas.ponto import (
+    PontoCienciaItem,
+    PontoCienciaMe,
+    PontoCompetenciaRead,
+    PontoSetupItem,
+    PontoSetupStatus,
+)
+from app.services import ponto as ponto_svc
+from app.services import ponto_settings as ponto_settings_svc
+from app.services.escala import escala_configurada
+
+
+def _validar_ano_mes(ano: int, mes: int) -> None:
+    if ano < 2000 or ano > 2100 or mes < 1 or mes > 12:
+        raise HTTPException(status_code=400, detail="Competência inválida (ano/mês).")
+
+
+def competencia_fechada(db: Session, tenant_id: int, *, ano: int, mes: int) -> bool:
+    row = (
+        db.query(PontoCompetencia)
+        .filter(
+            PontoCompetencia.tenant_id == tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+            PontoCompetencia.fechada.is_(True),
+        )
+        .first()
+    )
+    return row is not None
+
+
+def competencia_fechada_para_data(db: Session, tenant_id: int, dia: date) -> bool:
+    return competencia_fechada(db, tenant_id, ano=dia.year, mes=dia.month)
+
+
+def setup_status(db: Session, admin: Atendente) -> PontoSetupStatus:
+    st = ponto_settings_svc.get_or_create_settings(db, admin.tenant_id)
+    ativos = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role.in_(tuple(ROLES_ATENDENTE)),
+        )
+        .all()
+    )
+    sem_jornada = sum(1 for a in ativos if not escala_configurada(a))
+    locais_ativos = (
+        db.query(PontoLocal)
+        .filter(
+            PontoLocal.tenant_id == admin.tenant_id,
+            PontoLocal.ativo.is_(True),
+            PontoLocal.atendente_id.isnot(None),
+        )
+        .count()
+    )
+    itens: list[PontoSetupItem] = []
+    if sem_jornada > 0:
+        itens.append(
+            PontoSetupItem(
+                codigo="jornada_colaboradores",
+                titulo="Configure a jornada dos colaboradores",
+                detalhe=f"{sem_jornada} colaborador(es) ainda sem jornada (modo nenhum).",
+                destino="cadastro_atendentes",
+                ok=False,
+            )
+        )
+    else:
+        itens.append(
+            PontoSetupItem(
+                codigo="jornada_colaboradores",
+                titulo="Jornada dos colaboradores",
+                detalhe="Todos os ativos têm jornada configurada.",
+                destino="cadastro_atendentes",
+                ok=True,
+            )
+        )
+
+    itens.append(
+        PontoSetupItem(
+            codigo="fecho_automatico",
+            titulo="Revise o fecho automático",
+            detalhe=(
+                "Fecho automático ativo."
+                if st.fecho_automatico_ativo
+                else "Fecho por esquecimento está desligado (padrão até o admin ativar)."
+            ),
+            destino="ponto_settings",
+            ok=True,  # informativo; não bloqueia
+            informativo=True,
+        )
+    )
+    itens.append(
+        PontoSetupItem(
+            codigo="feriados",
+            titulo="Feriados",
+            detalhe=(
+                "Feriados nacionais ligados."
+                if st.usar_feriados_nacionais
+                else "Feriados nacionais desligados — confira feriados custom."
+            ),
+            destino="ponto_feriados",
+            ok=True,
+            informativo=True,
+        )
+    )
+    if st.politica_geolocalizacao != "opcional" and locais_ativos == 0:
+        itens.append(
+            PontoSetupItem(
+                codigo="locais_geo",
+                titulo="Locais de geolocalização",
+                detalhe="Política de geo exige locais, mas nenhum local ativo está vinculado a colaboradores.",
+                destino="cadastro_atendentes",
+                ok=False,
+            )
+        )
+    else:
+        itens.append(
+            PontoSetupItem(
+                codigo="locais_geo",
+                titulo="Locais de geolocalização",
+                detalhe=(
+                    f"Política: {st.politica_geolocalizacao}; {locais_ativos} local(is) ativo(s)."
+                ),
+                destino="cadastro_atendentes",
+                ok=True,
+                informativo=st.politica_geolocalizacao == "opcional",
+            )
+        )
+
+    pendentes = sum(1 for i in itens if not i.ok)
+    return PontoSetupStatus(
+        defaults_fecho_off=not st.fecho_automatico_ativo,
+        tolerancia_sugerida_minutos=15,
+        pendentes=pendentes,
+        itens=itens,
+    )
+
+
+def _to_comp_read(row: PontoCompetencia) -> PontoCompetenciaRead:
+    return PontoCompetenciaRead(
+        id=row.id,
+        ano=row.ano,
+        mes=row.mes,
+        fechada=row.fechada,
+        fechado_em=row.fechado_em,
+        fechado_por_id=row.fechado_por_id,
+        fechado_por_nome=row.fechado_por.nome if row.fechado_por else None,
+        reaberto_em=row.reaberto_em,
+        reaberto_por_id=row.reaberto_por_id,
+        reabrir_motivo=row.reabrir_motivo,
+    )
+
+
+def _get_or_create_comp(db: Session, tenant_id: int, ano: int, mes: int) -> PontoCompetencia:
+    row = (
+        db.query(PontoCompetencia)
+        .filter(
+            PontoCompetencia.tenant_id == tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+        )
+        .first()
+    )
+    if row:
+        return row
+    row = PontoCompetencia(tenant_id=tenant_id, ano=ano, mes=mes, fechada=False)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def obter_competencia(db: Session, admin: Atendente, *, ano: int, mes: int) -> PontoCompetenciaRead:
+    _validar_ano_mes(ano, mes)
+    row = (
+        db.query(PontoCompetencia)
+        .options(joinedload(PontoCompetencia.fechado_por))
+        .filter(
+            PontoCompetencia.tenant_id == admin.tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+        )
+        .first()
+    )
+    if not row:
+        return PontoCompetenciaRead(id=0, ano=ano, mes=mes, fechada=False)
+    return _to_comp_read(row)
+
+
+def fechar_competencia(db: Session, admin: Atendente, *, ano: int, mes: int) -> PontoCompetenciaRead:
+    _validar_ano_mes(ano, mes)
+    row = _get_or_create_comp(db, admin.tenant_id, ano, mes)
+    if row.fechada:
+        raise HTTPException(status_code=400, detail="Esta competência já está fechada.")
+    agora = datetime.now(timezone.utc)
+    row.fechada = True
+    row.fechado_em = agora
+    row.fechado_por_id = admin.id
+    row.reaberto_em = None
+    row.reaberto_por_id = None
+    row.reabrir_motivo = None
+    registrar_audit(
+        db,
+        "ponto_competencia",
+        row.id,
+        "fechar",
+        admin.id,
+        payload={"ano": ano, "mes": mes},
+    )
+    db.commit()
+    return obter_competencia(db, admin, ano=ano, mes=mes)
+
+
+def reabrir_competencia(
+    db: Session,
+    admin: Atendente,
+    *,
+    ano: int,
+    mes: int,
+    motivo: str,
+) -> PontoCompetenciaRead:
+    _validar_ano_mes(ano, mes)
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(status_code=400, detail="Informe o motivo da reabertura (mín. 3 caracteres).")
+    row = (
+        db.query(PontoCompetencia)
+        .filter(
+            PontoCompetencia.tenant_id == admin.tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+        )
+        .first()
+    )
+    if not row or not row.fechada:
+        raise HTTPException(status_code=400, detail="Competência não está fechada.")
+    row.fechada = False
+    row.reaberto_em = datetime.now(timezone.utc)
+    row.reaberto_por_id = admin.id
+    row.reabrir_motivo = motivo_limpo[:1000]
+    registrar_audit(
+        db,
+        "ponto_competencia",
+        row.id,
+        "reabrir",
+        admin.id,
+        payload={"ano": ano, "mes": mes, "motivo": motivo_limpo},
+    )
+    db.commit()
+    return obter_competencia(db, admin, ano=ano, mes=mes)
+
+
+def listar_competencias(db: Session, admin: Atendente, *, ano: int | None = None) -> list[PontoCompetenciaRead]:
+    q = (
+        db.query(PontoCompetencia)
+        .options(joinedload(PontoCompetencia.fechado_por))
+        .filter(PontoCompetencia.tenant_id == admin.tenant_id)
+    )
+    if ano is not None:
+        q = q.filter(PontoCompetencia.ano == ano)
+    rows = q.order_by(PontoCompetencia.ano.desc(), PontoCompetencia.mes.desc()).limit(36).all()
+    return [_to_comp_read(r) for r in rows]
+
+
+def invalidar_ciencias_mes(
+    db: Session,
+    *,
+    tenant_id: int,
+    atendente_id: int,
+    ano: int,
+    mes: int,
+    motivo: str,
+) -> None:
+    row = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == tenant_id,
+            PontoEspelhoCiencia.atendente_id == atendente_id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+            PontoEspelhoCiencia.ativa.is_(True),
+        )
+        .first()
+    )
+    if not row:
+        return
+    row.ativa = False
+    row.invalidada_em = datetime.now(timezone.utc)
+    row.invalidada_motivo = motivo[:500]
+
+
+def confirmar_ciencia(db: Session, atendente: Atendente, *, ano: int, mes: int) -> PontoCienciaMe:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    _validar_ano_mes(ano, mes)
+    if not competencia_fechada(db, atendente.tenant_id, ano=ano, mes=mes):
+        raise HTTPException(
+            status_code=400,
+            detail="Só é possível confirmar ciência após o admin fechar a competência do mês.",
+        )
+    existente = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == atendente.tenant_id,
+            PontoEspelhoCiencia.atendente_id == atendente.id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+        )
+        .first()
+    )
+    agora = datetime.now(timezone.utc)
+    if existente and existente.ativa:
+        raise HTTPException(status_code=400, detail="Ciência deste mês já confirmada.")
+    if existente:
+        existente.ativa = True
+        existente.confirmado_em = agora
+        existente.invalidada_em = None
+        existente.invalidada_motivo = None
+        row = existente
+    else:
+        row = PontoEspelhoCiencia(
+            tenant_id=atendente.tenant_id,
+            atendente_id=atendente.id,
+            ano=ano,
+            mes=mes,
+            confirmado_em=agora,
+            ativa=True,
+        )
+        db.add(row)
+        db.flush()
+    registrar_audit(
+        db,
+        "ponto_espelho_ciencia",
+        row.id,
+        "confirmar",
+        atendente.id,
+        payload={"ano": ano, "mes": mes, "confirmado_em": agora.isoformat()},
+    )
+    db.commit()
+    return ciencia_me(db, atendente, ano=ano, mes=mes)
+
+
+def ciencia_me(db: Session, atendente: Atendente, *, ano: int, mes: int) -> PontoCienciaMe:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    _validar_ano_mes(ano, mes)
+    fechada = competencia_fechada(db, atendente.tenant_id, ano=ano, mes=mes)
+    row = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == atendente.tenant_id,
+            PontoEspelhoCiencia.atendente_id == atendente.id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+        )
+        .first()
+    )
+    return PontoCienciaMe(
+        ano=ano,
+        mes=mes,
+        competencia_fechada=fechada,
+        confirmada=bool(row and row.ativa),
+        confirmado_em=row.confirmado_em if row and row.ativa else None,
+        pode_confirmar=fechada and not (row and row.ativa),
+    )
+
+
+def listar_ciencias_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    ano: int,
+    mes: int,
+) -> list[PontoCienciaItem]:
+    _validar_ano_mes(ano, mes)
+    ativos = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role.in_(tuple(ROLES_ATENDENTE)),
+        )
+        .order_by(Atendente.nome.asc())
+        .all()
+    )
+    rows = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == admin.tenant_id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+            PontoEspelhoCiencia.ativa.is_(True),
+        )
+        .all()
+    )
+    por_id = {r.atendente_id: r for r in rows}
+    out: list[PontoCienciaItem] = []
+    for a in ativos:
+        c = por_id.get(a.id)
+        out.append(
+            PontoCienciaItem(
+                atendente_id=a.id,
+                atendente_nome=a.nome,
+                confirmada=c is not None,
+                confirmado_em=c.confirmado_em if c else None,
+            )
+        )
+    return out
+
+
+def periodo_competencia(ano: int, mes: int) -> tuple[date, date]:
+    _validar_ano_mes(ano, mes)
+    ultimo = monthrange(ano, mes)[1]
+    return date(ano, mes, 1), date(ano, mes, ultimo)

--- a/backend/app/services/ponto_relatorio.py
+++ b/backend/app/services/ponto_relatorio.py
@@ -125,6 +125,12 @@ def export_pdf_mensal(
     linhas = _coletar_intervalos(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
     titulo = _titulo_periodo(desde, ate)
     gerado = datetime.now(timezone.utc).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
+    from app.services import ponto_competencia as comp_svc
+
+    selo_comp = ""
+    if desde and desde.year and desde.month:
+        if comp_svc.competencia_fechada(db, admin.tenant_id, ano=desde.year, mes=desde.month):
+            selo_comp = " · Competência FECHADA"
 
     rows_html = ""
     total_min = 0.0
@@ -152,6 +158,7 @@ def export_pdf_mensal(
     for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
         payload = log.payload_json or {}
         motivo = escape(str(payload.get("motivo") or "—"))
+        pos = "sim" if payload.get("pos_fechamento") else "não"
         quando = (
             _as_utc(log.created_at).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
             if log.created_at
@@ -165,6 +172,7 @@ def export_pdf_mensal(
             f"<td>{escape(_rotulo_acao_ajuste(log.action))}</td>"
             f"<td>{log.entity_id}</td>"
             f"<td>{motivo}</td>"
+            f"<td>{pos}</td>"
             "</tr>"
         )
 
@@ -184,7 +192,7 @@ def export_pdf_mensal(
 </head>
 <body>
   <h1>Relatório de ponto — {escape(titulo)}</h1>
-  <p class="meta">Gerado em {gerado} · DeskRudder</p>
+  <p class="meta">Gerado em {gerado} · DeskRudder{selo_comp}</p>
   <table>
     <thead><tr>
       <th>Atendente</th><th>Data</th><th>Entrada</th><th>Saída</th>
@@ -196,9 +204,9 @@ def export_pdf_mensal(
   <h2>Ajustes administrativos</h2>
   <table>
     <thead><tr>
-      <th>Quando</th><th>Autor</th><th>Ação</th><th>Batida</th><th>Motivo</th>
+      <th>Quando</th><th>Autor</th><th>Ação</th><th>Batida</th><th>Motivo</th><th>Pós-fechamento</th>
     </tr></thead>
-    <tbody>{ajustes_html or '<tr><td colspan="5">Sem ajustes no período.</td></tr>'}</tbody>
+    <tbody>{ajustes_html or '<tr><td colspan="6">Sem ajustes no período.</td></tr>'}</tbody>
   </table>
 </body>
 </html>"""
@@ -224,9 +232,14 @@ def export_xlsx_mensal(
         ) from exc
 
     linhas = _coletar_intervalos(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    from app.services import ponto_competencia as comp_svc
+
     wb = Workbook()
     ws = wb.active
     ws.title = "Ponto"
+    if desde and comp_svc.competencia_fechada(db, admin.tenant_id, ano=desde.year, mes=desde.month):
+        ws.append([f"Competência FECHADA — {_titulo_periodo(desde, ate)}"])
+        ws.append([])
     ws.append(
         ["Atendente", "Data", "Entrada", "Saída", "Pausas (min)", "Trabalhado (min)", "Aberto"]
     )
@@ -250,7 +263,7 @@ def export_xlsx_mensal(
     ws.append(["Total trabalhado (h)", round(total_min / 60, 2)])
 
     ws_aj = wb.create_sheet("Ajustes")
-    ws_aj.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Payload"])
+    ws_aj.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Pós-fechamento", "Payload"])
     for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
         payload = log.payload_json or {}
         ws_aj.append(
@@ -262,6 +275,7 @@ def export_xlsx_mensal(
                 _rotulo_acao_ajuste(log.action),
                 log.entity_id,
                 payload.get("motivo") or "",
+                "sim" if payload.get("pos_fechamento") else "não",
                 str(payload),
             ]
         )

--- a/backend/tests/test_ponto_lote_g_981_978_979.py
+++ b/backend/tests/test_ponto_lote_g_981_978_979.py
@@ -1,0 +1,78 @@
+"""Lote G ponto: setup (#981), competência (#978), ciência (#979)."""
+
+from datetime import date, datetime, timezone
+
+
+def test_setup_status_admin(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    r = client.get("/v1/ponto/setup-status", headers=admin)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "itens" in body
+    assert body["defaults_fecho_off"] is True
+    assert body["tolerancia_sugerida_minutos"] == 15
+    assert any(i["codigo"] == "jornada_colaboradores" for i in body["itens"])
+
+
+def test_competencia_fechar_reabrir_e_ajuste_pos(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    hoje = date.today()
+    ano, mes = hoje.year, hoje.month
+
+    fech = client.post(f"/v1/ponto/competencias/{ano}/{mes}/fechar", headers=admin)
+    assert fech.status_code == 200, fech.text
+    assert fech.json()["fechada"] is True
+
+    getc = client.get(f"/v1/ponto/competencias/{ano}/{mes}", headers=admin)
+    assert getc.json()["fechada"] is True
+
+    ajuste = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": datetime.now(timezone.utc).isoformat(),
+            "motivo": "Correção pós-fechamento",
+        },
+    )
+    assert ajuste.status_code == 201, ajuste.text
+
+    reab = client.post(
+        f"/v1/ponto/competencias/{ano}/{mes}/reabrir",
+        headers=admin,
+        json={"motivo": "Erro no fechamento"},
+    )
+    assert reab.status_code == 200, reab.text
+    assert reab.json()["fechada"] is False
+
+
+def test_ciencia_somente_apos_fechamento(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    hoje = date.today()
+    # Usa mês passado para não conflitar com teste anterior no mesmo worker
+    if hoje.month == 1:
+        ano, mes = hoje.year - 1, 12
+    else:
+        ano, mes = hoje.year, hoje.month - 1
+
+    bloqueado = client.post(f"/v1/ponto/me/ciencia?ano={ano}&mes={mes}", headers=user)
+    assert bloqueado.status_code == 400
+
+    assert client.post(f"/v1/ponto/competencias/{ano}/{mes}/fechar", headers=admin).status_code == 200
+
+    ok = client.post(f"/v1/ponto/me/ciencia?ano={ano}&mes={mes}", headers=user)
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["confirmada"] is True
+
+    lista = client.get(f"/v1/ponto/competencias/{ano}/{mes}/ciencias", headers=admin)
+    assert lista.status_code == 200
+    a1 = seed_base["a1"]
+    item = next(i for i in lista.json() if i["atendente_id"] == a1.id)
+    assert item["confirmada"] is True
+
+    me = client.get(f"/v1/ponto/me/ciencia?ano={ano}&mes={mes}", headers=user)
+    assert me.json()["confirmada"] is True
+    assert me.json()["pode_confirmar"] is False

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -882,6 +882,22 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  setupStatus: () => api<Ponto.SetupStatus>('/ponto/setup-status'),
+  competencia: (ano: number, mes: number) =>
+    api<Ponto.Competencia>(`/ponto/competencias/${ano}/${mes}`),
+  fecharCompetencia: (ano: number, mes: number) =>
+    api<Ponto.Competencia>(`/ponto/competencias/${ano}/${mes}/fechar`, { method: 'POST' }),
+  reabrirCompetencia: (ano: number, mes: number, data: { motivo: string }) =>
+    api<Ponto.Competencia>(`/ponto/competencias/${ano}/${mes}/reabrir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  cienciasAdmin: (ano: number, mes: number) =>
+    api<Ponto.CienciaItem[]>(`/ponto/competencias/${ano}/${mes}/ciencias`),
+  minhaCiencia: (ano: number, mes: number) =>
+    api<Ponto.CienciaMe>(withParams('/ponto/me/ciencia', { ano, mes })),
+  confirmarCiencia: (ano: number, mes: number) =>
+    api<Ponto.CienciaMe>(withParams('/ponto/me/ciencia', { ano, mes }), { method: 'POST' }),
   meSettings: () => api<Ponto.SettingsPublic>('/ponto/me/settings'),
   locais: (params?: { atendente_id?: number; so_orfos?: boolean }) =>
     api<Ponto.Local[]>(withParams('/ponto/locais', params)),
@@ -5105,6 +5121,46 @@ export namespace Ponto {
     decidido_em?: string | null
     decisao_motivo?: string | null
     created_at?: string | null
+  }
+  export interface SetupItem {
+    codigo: string
+    titulo: string
+    detalhe: string
+    destino: string
+    ok: boolean
+    informativo?: boolean
+  }
+  export interface SetupStatus {
+    defaults_fecho_off: boolean
+    tolerancia_sugerida_minutos: number
+    pendentes: number
+    itens: SetupItem[]
+  }
+  export interface Competencia {
+    id: number
+    ano: number
+    mes: number
+    fechada: boolean
+    fechado_em?: string | null
+    fechado_por_id?: number | null
+    fechado_por_nome?: string | null
+    reaberto_em?: string | null
+    reaberto_por_id?: number | null
+    reabrir_motivo?: string | null
+  }
+  export interface CienciaMe {
+    ano: number
+    mes: number
+    competencia_fechada: boolean
+    confirmada: boolean
+    confirmado_em?: string | null
+    pode_confirmar: boolean
+  }
+  export interface CienciaItem {
+    atendente_id: number
+    atendente_nome: string
+    confirmada: boolean
+    confirmado_em?: string | null
   }
   export interface HoraExtra {
     id: number

--- a/frontend/src/components/PontoAjudaModal.tsx
+++ b/frontend/src/components/PontoAjudaModal.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { Button } from './ui/Button'
+import { PONTO_AJUDA_SECOES, PONTO_AJUDA_TITULO } from '../lib/pontoAjuda'
+
+type Props = {
+  open: boolean
+  onClose: () => void
+}
+
+export function PontoAjudaModal({ open, onClose }: Props) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[700] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ponto-ajuda-modal-title"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/50 backdrop-blur-[1px]"
+        onClick={onClose}
+        aria-label="Fechar ajuda"
+      />
+      <div className="relative max-h-[min(85vh,720px)] w-full max-w-lg overflow-y-auto rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-600 dark:bg-slate-900 md:max-w-2xl">
+        <h2 id="ponto-ajuda-modal-title" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          {PONTO_AJUDA_TITULO}
+        </h2>
+        <div className="mt-4 space-y-5">
+          {PONTO_AJUDA_SECOES.map((sec) => (
+            <section key={sec.titulo}>
+              <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">{sec.titulo}</h3>
+              <ul className="mt-2 list-disc space-y-1.5 pl-5 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                {sec.paragrafos.map((p) => (
+                  <li key={p.slice(0, 40)}>{p}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <div className="mt-6 flex justify-end">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Fechar
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/lib/pontoAjuda.ts
+++ b/frontend/src/lib/pontoAjuda.ts
@@ -1,0 +1,55 @@
+/** Textos de ajuda do módulo ponto (#980) — pt-BR para o usuário final. */
+
+export const PONTO_AJUDA_TITULO = 'Como funciona o ponto'
+
+export type PontoAjudaSecao = {
+  titulo: string
+  paragrafos: string[]
+}
+
+export const PONTO_AJUDA_SECOES: PontoAjudaSecao[] = [
+  {
+    titulo: 'Modos de jornada',
+    paragrafos: [
+      'Nenhum: o sistema não espera dias de trabalho; o calendário fica neutro e faltas automáticas não se aplicam.',
+      'Semanal: cada dia da semana tem horário de início e fim (como uma grade). Só nesses dias há jornada esperada.',
+      'Ciclo: padrão X dias de trabalho × Y de folga, a partir de uma data de referência definida no cadastro.',
+    ],
+  },
+  {
+    titulo: 'Tolerância e atraso',
+    paragrafos: [
+      'A tolerância vale nos dois lados: você pode entrar a partir de (início − tolerância) e o atraso só conta depois de (início + tolerância).',
+      'Se o admin não configurou jornada, essas regras de atraso/falta não entram em jogo.',
+    ],
+  },
+  {
+    titulo: 'Falta, parcial e folga',
+    paragrafos: [
+      'Falta: dia esperado sem entrada registrada.',
+      'Parcial: houve entrada, mas a saída ainda não fechou a jornada do dia.',
+      'Folga: dia fora da escala; se mesmo assim houver batidas, aparece como folga com ponto.',
+    ],
+  },
+  {
+    titulo: 'Fecho por esquecimento',
+    paragrafos: [
+      'Por padrão o fecho automático fica desligado até o admin ativar nas configurações do ponto.',
+      'Quando ativo, o sistema pode fechar uma jornada aberta após N horas ou após a saída prevista + margem — o que ocorrer primeiro.',
+    ],
+  },
+  {
+    titulo: 'Hora extra e WhatsApp',
+    paragrafos: [
+      'Depois do fim da jornada, pegar chat WhatsApp novo pode exigir liberação de hora extra pelo admin.',
+      'O admin pode liberar o resto do dia, até um horário ou por uma duração em minutos; há teto opcional por colaborador.',
+    ],
+  },
+  {
+    titulo: 'Cobertura e competência',
+    paragrafos: [
+      'Cobertura de plantão: você pede a um colega, ele aceita e o admin homologa (ou o admin agenda direto). No dia, quem pediu não gera falta e quem cobre passa a ter jornada esperada.',
+      'Quando o admin fecha o mês (competência), ajustes posteriores ficam marcados como pós-fechamento. Você pode confirmar ciência no espelho mensal depois do fechamento.',
+    ],
+  },
+]

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ponto, type Ponto } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { PontoAjudaModal } from '../components/PontoAjudaModal'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
 import { PontoBatidaMapaModal } from '../components/PontoBatidaMapaModal'
 import { PontoMetricCard } from '../components/PontoMetricCard'
@@ -65,6 +66,13 @@ export function MeuPonto() {
   const [cobData, setCobData] = useState(hojeIso)
   const [cobMotivo, setCobMotivo] = useState('')
   const [enviandoCob, setEnviandoCob] = useState(false)
+  const [ajudaAberta, setAjudaAberta] = useState(false)
+  const [ciencia, setCiencia] = useState<Ponto.CienciaMe | null>(null)
+  const cienciaRef = useMemo(() => {
+    const d = new Date()
+    const prev = new Date(d.getFullYear(), d.getMonth() - 1, 1)
+    return { ano: prev.getFullYear(), mes: prev.getMonth() + 1 }
+  }, [])
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
   const [refSemana, setRefSemana] = useState(hojeIso)
   const [resumoSemana, setResumoSemana] = useState<Ponto.ResumoSemana | null>(null)
@@ -96,7 +104,7 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs, cobs, cols] = await Promise.all([
+        const [me, hist, js, bh, gs, cobs, cols, cin] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
@@ -104,6 +112,7 @@ export function MeuPonto() {
           ponto.meSettings(),
           ponto.minhasCoberturas(),
           ponto.colegasCobertura(),
+          ponto.minhaCiencia(cienciaRef.ano, cienciaRef.mes),
         ])
         setEstado(me)
         setHistorico(hist)
@@ -112,6 +121,7 @@ export function MeuPonto() {
         setGeoSettings(gs)
         setCoberturas(cobs)
         setColegasCob(cols)
+        setCiencia(cin)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -123,7 +133,7 @@ export function MeuPonto() {
         setLoading(false)
       }
     },
-    [ate, desde, toast],
+    [ate, cienciaRef.ano, cienciaRef.mes, desde, toast],
   )
 
   const carregarCalendario = useCallback(
@@ -375,7 +385,54 @@ export function MeuPonto() {
       <PageHeader
         title="Meu ponto"
         subtitle="Registre a jornada com um toque. Pausas e histórico ficam à mão — presença online do painel é independente."
+        actions={
+          <Button type="button" variant="secondary" onClick={() => setAjudaAberta(true)}>
+            Como funciona o ponto
+          </Button>
+        }
       />
+
+      {ciencia ? (
+        <Card className="mb-4" title={`Ciência do espelho — ${String(cienciaRef.mes).padStart(2, '0')}/${cienciaRef.ano}`}>
+          {ciencia.confirmada ? (
+            <p className="text-sm text-emerald-700 dark:text-emerald-300">
+              Você confirmou ciência
+              {ciencia.confirmado_em
+                ? ` em ${new Date(ciencia.confirmado_em).toLocaleString('pt-BR')}`
+                : ''}
+              .
+            </p>
+          ) : ciencia.pode_confirmar ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                O mês foi fechado pelo admin. Confirme que leu e concorda com o espelho.
+              </p>
+              <Button
+                type="button"
+                onClick={() => {
+                  void (async () => {
+                    try {
+                      await ponto.confirmarCiencia(cienciaRef.ano, cienciaRef.mes)
+                      toast.showSuccess('Ciência confirmada.')
+                      await carregar(true)
+                    } catch (err) {
+                      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível confirmar.'))
+                    }
+                  })()
+                }}
+              >
+                Li e concordo
+              </Button>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500">
+              {ciencia.competencia_fechada
+                ? 'Ciência indisponível.'
+                : 'Aguarde o fechamento da competência para confirmar.'}
+            </p>
+          )}
+        </Card>
+      ) : null}
 
       {/* Hero — inspirado no dx-ponto: relógio + CTA principal */}
       <Card className="overflow-hidden border-cyan-200/60 bg-gradient-to-br from-slate-50 via-white to-cyan-50/40 dark:border-cyan-900/40 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">
@@ -844,6 +901,7 @@ export function MeuPonto() {
         </Card>
       </div>
 
+      <PontoAjudaModal open={ajudaAberta} onClose={() => setAjudaAberta(false)} />
       <PontoBatidaMapaModal
         open={mapaAberto != null}
         onClose={() => setMapaAberto(null)}

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { ApiError, atendentes, audit, ponto, type Atendentes, type Audit, type Ponto } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { PontoAjudaModal } from '../components/PontoAjudaModal'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
 import { PontoBatidaMapaModal } from '../components/PontoBatidaMapaModal'
 import { PontoMetricCard } from '../components/PontoMetricCard'
@@ -76,6 +78,12 @@ export function PontoEquipe() {
   const [cobData, setCobData] = useState(hojeIso)
   const [cobMotivo, setCobMotivo] = useState('')
   const [concedendoCob, setConcedendoCob] = useState(false)
+  const [setup, setSetup] = useState<Ponto.SetupStatus | null>(null)
+  const [compAno, setCompAno] = useState(() => new Date().getFullYear())
+  const [compMes, setCompMes] = useState(() => new Date().getMonth() + 1)
+  const [competencia, setCompetencia] = useState<Ponto.Competencia | null>(null)
+  const [ciencias, setCiencias] = useState<Ponto.CienciaItem[]>([])
+  const [ajudaAberta, setAjudaAberta] = useState(false)
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
@@ -102,7 +110,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes, cobs] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, cobs, setupSt, comp, cins] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -116,6 +124,9 @@ export function PontoEquipe() {
           ponto.feriados(new Date().getFullYear()),
           ponto.horaExtraAdmin('pendente'),
           ponto.coberturasAdmin('pendente'),
+          ponto.setupStatus(),
+          ponto.competencia(compAno, compMes),
+          ponto.cienciasAdmin(compAno, compMes),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -126,6 +137,9 @@ export function PontoEquipe() {
         setFeriados(fer)
         setHesPendentes(hes)
         setCobPendentes(cobs)
+        setSetup(setupSt)
+        setCompetencia(comp)
+        setCiencias(cins)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -145,7 +159,7 @@ export function PontoEquipe() {
         setLoading(false)
       }
     },
-    [ate, atendenteId, desde, toast],
+    [ate, atendenteId, compAno, compMes, desde, toast],
   )
 
   useEffect(() => {
@@ -488,7 +502,121 @@ export function PontoEquipe() {
       <PageHeader
         title="Ponto da equipe"
         subtitle="Visão do dia, batidas, ajustes auditados e relatórios mensais."
+        actions={
+          <Button type="button" variant="secondary" onClick={() => setAjudaAberta(true)}>
+            Como funciona o ponto
+          </Button>
+        }
       />
+
+      {setup && setup.pendentes > 0 ? (
+        <Card className="mb-4 border-amber-200 bg-amber-50/80 dark:border-amber-900/50 dark:bg-amber-950/30" title="Checklist de configuração">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Defaults: fecho automático desligado até ativar; tolerância sugerida{' '}
+            {setup.tolerancia_sugerida_minutos} min no cadastro do colaborador.
+          </p>
+          <ul className="space-y-2 text-sm">
+            {setup.itens
+              .filter((i) => !i.ok)
+              .map((i) => (
+                <li key={i.codigo} className="flex flex-wrap items-center justify-between gap-2">
+                  <span>
+                    <strong>{i.titulo}</strong> — {i.detalhe}
+                  </span>
+                  {i.destino === 'cadastro_atendentes' ? (
+                    <Link to="/atendentes" className="text-cyan-700 underline dark:text-cyan-300">
+                      Abrir cadastro
+                    </Link>
+                  ) : (
+                    <a href="#ponto-settings" className="text-cyan-700 underline dark:text-cyan-300">
+                      Ir às configurações
+                    </a>
+                  )}
+                </li>
+              ))}
+          </ul>
+        </Card>
+      ) : null}
+
+      <Card className="mb-4" title="Competência mensal">
+        <div className="mb-3 flex flex-wrap items-end gap-3">
+          <Input
+            label="Ano"
+            type="number"
+            value={String(compAno)}
+            onChange={(e) => setCompAno(Number(e.target.value) || new Date().getFullYear())}
+          />
+          <Input
+            label="Mês"
+            type="number"
+            min={1}
+            max={12}
+            value={String(compMes)}
+            onChange={(e) => setCompMes(Math.min(12, Math.max(1, Number(e.target.value) || 1)))}
+          />
+          <Button
+            type="button"
+            disabled={competencia?.fechada}
+            onClick={() => {
+              void (async () => {
+                try {
+                  await ponto.fecharCompetencia(compAno, compMes)
+                  toast.showSuccess('Competência fechada.')
+                  await carregar(true)
+                } catch (err) {
+                  toast.showError(mensagemFalhaParaToast(err, 'Não foi possível fechar.'))
+                }
+              })()
+            }}
+          >
+            Fechar mês
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!competencia?.fechada}
+            onClick={() => {
+              const motivo = window.prompt('Motivo da reabertura:')
+              if (!motivo || motivo.trim().length < 3) return
+              void (async () => {
+                try {
+                  await ponto.reabrirCompetencia(compAno, compMes, { motivo: motivo.trim() })
+                  toast.showSuccess('Competência reaberta.')
+                  await carregar(true)
+                } catch (err) {
+                  toast.showError(mensagemFalhaParaToast(err, 'Não foi possível reabrir.'))
+                }
+              })()
+            }}
+          >
+            Reabrir
+          </Button>
+        </div>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          {competencia?.fechada
+            ? `Fechada${competencia.fechado_por_nome ? ` por ${competencia.fechado_por_nome}` : ''}${
+                competencia.fechado_em ? ` em ${new Date(competencia.fechado_em).toLocaleString('pt-BR')}` : ''
+              }. Ajustes passam a ser marcados como pós-fechamento.`
+            : 'Competência aberta — ajustes normais.'}
+        </p>
+        <p className="mt-3 mb-1 text-sm font-medium text-slate-800 dark:text-slate-100">Ciência da equipe</p>
+        {ciencias.length === 0 ? (
+          <p className="text-sm text-slate-500">Sem colaboradores ativos.</p>
+        ) : (
+          <ul className="max-h-48 space-y-1 overflow-y-auto text-sm">
+            {ciencias.map((c) => (
+              <li key={c.atendente_id} className="flex justify-between gap-2 border-b border-slate-100 py-1 dark:border-slate-800">
+                <span>{c.atendente_nome}</span>
+                <span className={c.confirmada ? 'text-emerald-700 dark:text-emerald-300' : 'text-amber-700 dark:text-amber-300'}>
+                  {c.confirmada
+                    ? `Confirmou${c.confirmado_em ? ` · ${new Date(c.confirmado_em).toLocaleString('pt-BR')}` : ''}`
+                    : 'Pendente'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
 
       <Card className="overflow-hidden border-cyan-200/60 bg-gradient-to-br from-slate-50 via-white to-cyan-50/40 dark:border-cyan-900/40 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">
         {loading && !digest ? (
@@ -1017,6 +1145,7 @@ export function PontoEquipe() {
           </Card>
         ) : null}
 
+        <div id="ponto-settings">
         <Card title="Configurações do ponto">
           {settings ? (
             <div className="space-y-3">
@@ -1107,6 +1236,7 @@ export function PontoEquipe() {
             <p className="text-sm text-slate-500">Carregando…</p>
           )}
         </Card>
+        </div>
 
         <Card title="Feriados da instância">
           <div className="mb-4 flex flex-wrap items-end gap-3">
@@ -1148,6 +1278,7 @@ export function PontoEquipe() {
         </Card>
       </div>
 
+      <PontoAjudaModal open={ajudaAberta} onClose={() => setAjudaAberta(false)} />
       <PontoBatidaMapaModal
         open={mapaBatida != null && mapaBatida.latitude != null && mapaBatida.longitude != null}
         onClose={() => setMapaBatida(null)}


### PR DESCRIPTION
## Summary

- Closes #980 — ajuda in-app **Como funciona o ponto** (Meu ponto + Ponto da equipe)
- Closes #981 — checklist de configuração pós-deploy com links para cadastro e settings
- Closes #978 — fechamento/reabertura de competência mensal; ajustes pós-fechamento marcados no audit e nos exports
- Closes #979 — ciência do colaborador no espelho após fechamento; lista admin; invalidação se houver ajuste posterior

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest tests/test_ponto_lote_g_981_978_979.py` (3 passed)
- [x] `tsc -b` no frontend
- [ ] Admin: ver checklist pendente e links
- [ ] Admin: fechar/reabrir competência; export PDF/Excel com selo e coluna pós-fechamento
- [ ] Colaborador: confirmar ciência após fechamento
- [ ] Modal de ajuda em Meu ponto e Ponto da equipe

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Épico #967 — próximos itens fora deste lote já mapeados (#985 dia convocado, etc.)
- [x] Sem stubs críticos sem issue neste lote
