### PR TITLE
release: main → staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
+- Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
 - Sobre: deixa de listar itens **Interno / Infra** (deploy, LICENSE, docs internos) — só Melhorias e Correções de produto
 - Sobre: versão **26.08.015** sem repetir notas já publicadas em releases anteriores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento
 - Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas
 
 #### Correções

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
+
 #### Correções
 
 - Sobre: deixa de listar itens **Interno / Infra** (deploy, LICENSE, docs internos) — só Melhorias e Correções de produto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
-# Changelog
+﻿# Changelog
 
 Formato baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
 Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging`.
 
 ## [Unreleased]
+
+### DeskRudder
+
+#### Melhorias
+
+- Ponto (#968 / #972 / #971): lembrete in-app de entrada/saída na janela de tolerância; resumo semanal em Meu ponto (previsto × feito, atrasos, HE, banco); motivo obrigatório reforçado e histórico/export de ajustes admin (também no PDF/Excel mensal)
+- Ponto (#966): admin **concede hora extra** com antecedência (resto do dia, até horário ou duração em minutos); teto opcional por colaborador no cadastro; liberações respeitam o teto
+- Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
+- Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
+- Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento
+- Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas
+
+#### Correções
+
+- Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
+- Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
 
 ## [26.08.016] - 2026-08-26
 
@@ -17,17 +33,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
-#### Melhorias
-
-- Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
-- Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
-- Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento
-- Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas
-
 #### Correções
 
-- Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
-- Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
 - Sobre: deixa de listar itens **Interno / Infra** (deploy, LICENSE, docs internos) — só Melhorias e Correções de produto
 - Sobre: versão **26.08.015** sem repetir notas já publicadas em releases anteriores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas
+
 #### Correções
 
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#966): admin **concede hora extra** com antecedência (resto do dia, até horário ou duração em minutos); teto opcional por colaborador no cadastro; liberações respeitam o teto
 - Ponto (#965): após o fim da jornada, **pegar** chat WhatsApp novo fica bloqueado até um admin liberar **hora extra** (resto do dia ou até um horário); pedidos aparecem em Ponto da equipe e no sino de pendências
 - Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe
 - Chat interno (#941 / #S202608-0008): no canal de **setor**, clicar no nome abre modal com membros vinculados e quem está **online**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
+
 #### Correções
 
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#968 / #972 / #971): lembrete in-app de entrada/saída na janela de tolerância; resumo semanal em Meu ponto (previsto × feito, atrasos, HE, banco); motivo obrigatório reforçado e histórico/export de ajustes admin (também no PDF/Excel mensal)
 - Ponto (#966): admin **concede hora extra** com antecedência (resto do dia, até horário ou duração em minutos); teto opcional por colaborador no cadastro; liberações respeitam o teto
 - Ponto (#965): após o fim da jornada, **pegar** chat WhatsApp novo fica bloqueado até um admin liberar **hora extra** (resto do dia ou até um horário); pedidos aparecem em Ponto da equipe e no sino de pendências
 - Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe

--- a/backend/alembic/versions/127_ponto_he_teto.py
+++ b/backend/alembic/versions/127_ponto_he_teto.py
@@ -1,0 +1,50 @@
+"""HE antecipada + teto por atendente (#966).
+
+Revision ID: 127_ponto_he_teto
+Revises: 126_ponto_hora_extra
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "127_ponto_he_teto"
+down_revision = "126_ponto_hora_extra"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_minutos" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("he_teto_minutos", sa.Integer(), nullable=True),
+            )
+
+    if insp.has_table("ponto_hora_extra"):
+        cols = {c["name"] for c in insp.get_columns("ponto_hora_extra")}
+        if "origem" not in cols:
+            op.add_column(
+                "ponto_hora_extra",
+                sa.Column("origem", sa.String(20), nullable=False, server_default="solicitacao"),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_hora_extra"):
+        cols = {c["name"] for c in insp.get_columns("ponto_hora_extra")}
+        if "origem" in cols:
+            op.drop_column("ponto_hora_extra", "origem")
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_minutos" in cols:
+            op.drop_column("atendentes", "he_teto_minutos")

--- a/backend/alembic/versions/129_merge_he_teto_versao.py
+++ b/backend/alembic/versions/129_merge_he_teto_versao.py
@@ -1,0 +1,21 @@
+"""Merge heads: HE teto (#966) + versao_alvo solic (#955).
+
+Revision ID: 129_merge_he_teto_versao
+Revises: 127_ponto_he_teto, 128_versao_alvo_solic
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+revision = "129_merge_he_teto_versao"
+down_revision = ("127_ponto_he_teto", "128_versao_alvo_solic")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/130_ponto_he_teto_mensal.py
+++ b/backend/alembic/versions/130_ponto_he_teto_mensal.py
@@ -1,0 +1,50 @@
+"""Teto mensal de HE (#974).
+
+Revision ID: 130_ponto_he_teto_mensal
+Revises: 129_merge_he_teto_versao
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "130_ponto_he_teto_mensal"
+down_revision = "129_merge_he_teto_versao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "he_teto_mensal_minutos" not in cols:
+            op.add_column(
+                "ponto_settings",
+                sa.Column("he_teto_mensal_minutos", sa.Integer(), nullable=True),
+            )
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_mensal_minutos" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("he_teto_mensal_minutos", sa.Integer(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_mensal_minutos" in cols:
+            op.drop_column("atendentes", "he_teto_mensal_minutos")
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "he_teto_mensal_minutos" in cols:
+            op.drop_column("ponto_settings", "he_teto_mensal_minutos")

--- a/backend/alembic/versions/130_ponto_lote_e.py
+++ b/backend/alembic/versions/130_ponto_lote_e.py
@@ -1,0 +1,94 @@
+"""Lote E: ausências programadas, pausa mínima, anexo justificativa (#976/#973/#977).
+
+Revision ID: 130_ponto_lote_e
+Revises: 129_merge_he_teto_versao
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "130_ponto_lote_e"
+down_revision = "129_merge_he_teto_versao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("ponto_ausencias"):
+        op.create_table(
+            "ponto_ausencias",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("tipo", sa.String(32), nullable=False),
+            sa.Column("desde", sa.Date(), nullable=False),
+            sa.Column("ate", sa.Date(), nullable=False),
+            sa.Column("motivo", sa.String(1000), nullable=True),
+            sa.Column("estado", sa.String(20), nullable=False, server_default="pendente"),
+            sa.Column("origem", sa.String(20), nullable=False, server_default="solicitacao"),
+            sa.Column(
+                "decidido_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("decidido_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("decisao_motivo", sa.String(1000), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        )
+        op.create_index("ix_ponto_ausencias_tenant_id", "ponto_ausencias", ["tenant_id"])
+        op.create_index("ix_ponto_ausencias_atendente_id", "ponto_ausencias", ["atendente_id"])
+        op.create_index("ix_ponto_ausencias_desde", "ponto_ausencias", ["desde"])
+        op.create_index("ix_ponto_ausencias_ate", "ponto_ausencias", ["ate"])
+
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "pausa_minima_minutos" not in cols:
+            op.add_column(
+                "ponto_settings",
+                sa.Column("pausa_minima_minutos", sa.Integer(), nullable=False, server_default="0"),
+            )
+
+    if insp.has_table("ponto_justificativas"):
+        cols = {c["name"] for c in insp.get_columns("ponto_justificativas")}
+        if "anexo_nome" not in cols:
+            op.add_column("ponto_justificativas", sa.Column("anexo_nome", sa.String(255), nullable=True))
+        if "anexo_content_type" not in cols:
+            op.add_column(
+                "ponto_justificativas", sa.Column("anexo_content_type", sa.String(128), nullable=True)
+            )
+        if "anexo_storage_key" not in cols:
+            op.add_column(
+                "ponto_justificativas", sa.Column("anexo_storage_key", sa.String(255), nullable=True)
+            )
+        if "anexo_tamanho_bytes" not in cols:
+            op.add_column(
+                "ponto_justificativas", sa.Column("anexo_tamanho_bytes", sa.Integer(), nullable=True)
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_justificativas"):
+        cols = {c["name"] for c in insp.get_columns("ponto_justificativas")}
+        for col in ("anexo_tamanho_bytes", "anexo_storage_key", "anexo_content_type", "anexo_nome"):
+            if col in cols:
+                op.drop_column("ponto_justificativas", col)
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "pausa_minima_minutos" in cols:
+            op.drop_column("ponto_settings", "pausa_minima_minutos")
+    if insp.has_table("ponto_ausencias"):
+        op.drop_table("ponto_ausencias")

--- a/backend/alembic/versions/130_ponto_lote_f.py
+++ b/backend/alembic/versions/130_ponto_lote_f.py
@@ -1,0 +1,66 @@
+"""Lote F: cobertura de plantão (#970).
+
+Revision ID: 130_ponto_lote_f
+Revises: 129_merge_he_teto_versao
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "130_ponto_lote_f"
+down_revision = "129_merge_he_teto_versao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_coberturas"):
+        return
+    op.create_table(
+        "ponto_coberturas",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False),
+        sa.Column(
+            "solicitante_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "cobertor_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("data_ref", sa.Date(), nullable=False),
+        sa.Column("motivo", sa.String(1000), nullable=True),
+        sa.Column("estado", sa.String(32), nullable=False, server_default="pendente_cobertor"),
+        sa.Column("origem", sa.String(20), nullable=False, server_default="solicitacao"),
+        sa.Column("resposta_cobertor", sa.String(20), nullable=True),
+        sa.Column("respondido_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "decidido_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("decidido_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("decisao_motivo", sa.String(1000), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_index("ix_ponto_coberturas_tenant_id", "ponto_coberturas", ["tenant_id"])
+    op.create_index("ix_ponto_coberturas_solicitante_id", "ponto_coberturas", ["solicitante_id"])
+    op.create_index("ix_ponto_coberturas_cobertor_id", "ponto_coberturas", ["cobertor_id"])
+    op.create_index("ix_ponto_coberturas_data_ref", "ponto_coberturas", ["data_ref"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_coberturas"):
+        op.drop_table("ponto_coberturas")

--- a/backend/alembic/versions/131_ponto_lote_g.py
+++ b/backend/alembic/versions/131_ponto_lote_g.py
@@ -1,0 +1,104 @@
+"""Lote G: competência mensal e ciência do espelho (#978 / #979).
+
+Revision ID: 131_ponto_lote_g
+Revises: 130_ponto_lote_f
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "131_ponto_lote_g"
+down_revision = "130_ponto_lote_f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("ponto_competencias"):
+        op.create_table(
+            "ponto_competencias",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "tenant_id",
+                sa.Integer(),
+                sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("ano", sa.Integer(), nullable=False),
+            sa.Column("mes", sa.Integer(), nullable=False),
+            sa.Column("fechada", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("fechado_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "fechado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("reaberto_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "reaberto_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("reabrir_motivo", sa.String(1000), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+            sa.UniqueConstraint("tenant_id", "ano", "mes", name="uq_ponto_competencias_tenant_ano_mes"),
+        )
+        op.create_index("ix_ponto_competencias_tenant_id", "ponto_competencias", ["tenant_id"])
+
+    if not insp.has_table("ponto_espelho_ciencias"):
+        op.create_table(
+            "ponto_espelho_ciencias",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "tenant_id",
+                sa.Integer(),
+                sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("ano", sa.Integer(), nullable=False),
+            sa.Column("mes", sa.Integer(), nullable=False),
+            sa.Column(
+                "confirmado_em",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column("ativa", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("invalidada_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("invalidada_motivo", sa.String(500), nullable=True),
+            sa.UniqueConstraint(
+                "tenant_id",
+                "atendente_id",
+                "ano",
+                "mes",
+                name="uq_ponto_espelho_ciencias_atendente_ano_mes",
+            ),
+        )
+        op.create_index("ix_ponto_espelho_ciencias_tenant_id", "ponto_espelho_ciencias", ["tenant_id"])
+        op.create_index(
+            "ix_ponto_espelho_ciencias_atendente_id",
+            "ponto_espelho_ciencias",
+            ["atendente_id"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_espelho_ciencias"):
+        op.drop_table("ponto_espelho_ciencias")
+    if insp.has_table("ponto_competencias"):
+        op.drop_table("ponto_competencias")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -63,6 +63,7 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         usar_local_empresa=bool(getattr(atendente, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(atendente, "local_empresa_raio_metros", None),
         he_teto_minutos=getattr(atendente, "he_teto_minutos", None),
+        he_teto_mensal_minutos=getattr(atendente, "he_teto_mensal_minutos", None),
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
@@ -193,6 +194,7 @@ def criar_atendente(
         usar_local_empresa=bool(getattr(data, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(data, "local_empresa_raio_metros", None),
         he_teto_minutos=getattr(data, "he_teto_minutos", None),
+        he_teto_mensal_minutos=getattr(data, "he_teto_mensal_minutos", None),
     )
     _aplicar_campos_jornada(
         atendente,

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -62,6 +62,7 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         tolerancia_atraso_minutos=int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0),
         usar_local_empresa=bool(getattr(atendente, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(atendente, "local_empresa_raio_metros", None),
+        he_teto_minutos=getattr(atendente, "he_teto_minutos", None),
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
@@ -191,6 +192,7 @@ def criar_atendente(
         tolerancia_atraso_minutos=int(data.tolerancia_atraso_minutos or 0) if modo != "nenhum" else 0,
         usar_local_empresa=bool(getattr(data, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(data, "local_empresa_raio_metros", None),
+        he_teto_minutos=getattr(data, "he_teto_minutos", None),
     )
     _aplicar_campos_jornada(
         atendente,

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -27,6 +27,7 @@ from app.schemas.ponto import (
     PontoFeriadoRead,
     PontoHistoricoRead,
     PontoHojeRead,
+    PontoHoraExtraConceder,
     PontoHoraExtraCreate,
     PontoHoraExtraDecisao,
     PontoHoraExtraMeStatus,
@@ -504,5 +505,23 @@ def decidir_hora_extra(
         aprovar=data.aprovar,
         modo=data.modo,
         ate_horario=data.ate_horario,
+        duracao_minutos=data.duracao_minutos,
         decisao_motivo=data.decisao_motivo,
+    )
+
+
+@router.post("/hora-extra/conceder", response_model=PontoHoraExtraRead, status_code=201)
+def conceder_hora_extra(
+    data: PontoHoraExtraConceder,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return he_svc.conceder_admin(
+        db,
+        admin,
+        atendente_id=data.atendente_id,
+        modo=data.modo,
+        ate_horario=data.ate_horario,
+        duracao_minutos=data.duracao_minutos,
+        motivo=data.motivo,
     )

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -21,6 +21,12 @@ from app.schemas.ponto import (
     PontoBatidaRead,
     PontoBaterRequest,
     PontoCalendarioRead,
+    PontoCoberturaColega,
+    PontoCoberturaConceder,
+    PontoCoberturaCreate,
+    PontoCoberturaDecisao,
+    PontoCoberturaRead,
+    PontoCoberturaResposta,
     PontoDigestRead,
     PontoEstadoRead,
     PontoFeriadoCreate,
@@ -44,6 +50,8 @@ from app.schemas.ponto import (
     PontoSettingsUpdate,
 )
 from app.services import ponto as ponto_svc
+from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_folha as folha_svc
 from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
 from app.services import ponto_relatorio as ponto_relatorio_svc
@@ -184,6 +192,125 @@ def exportar_xlsx(
         content=xlsx,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         headers={"Content-Disposition": 'attachment; filename="ponto_relatorio.xlsx"'},
+    )
+
+
+@router.get("/export/folha.csv")
+def exportar_folha_csv(
+    atendente_id: int | None = Query(None),
+    desde: date = Query(...),
+    ate: date = Query(...),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    """Template contábil/folha RH (#975) — colunas documentadas no cabeçalho CSV."""
+    conteudo = folha_svc.export_folha_csv(
+        db, admin, atendente_id=atendente_id, desde=desde, ate=ate
+    )
+    return Response(
+        content=conteudo.encode("utf-8"),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="ponto_folha.csv"'},
+    )
+
+
+@router.get("/export/folha.xlsx")
+def exportar_folha_xlsx(
+    atendente_id: int | None = Query(None),
+    desde: date = Query(...),
+    ate: date = Query(...),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    xlsx = folha_svc.export_folha_xlsx(
+        db, admin, atendente_id=atendente_id, desde=desde, ate=ate
+    )
+    return Response(
+        content=xlsx,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": 'attachment; filename="ponto_folha.xlsx"'},
+    )
+
+
+@router.post("/coberturas", response_model=PontoCoberturaRead, status_code=201)
+def solicitar_cobertura(
+    data: PontoCoberturaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.solicitar(
+        db,
+        atendente,
+        cobertor_id=data.cobertor_id,
+        data_ref=data.data_ref,
+        motivo=data.motivo,
+    )
+
+
+@router.get("/coberturas/me", response_model=list[PontoCoberturaRead])
+def minhas_coberturas(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.listar_me(db, atendente)
+
+
+@router.get("/coberturas/colegas", response_model=list[PontoCoberturaColega])
+def colegas_cobertura(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.listar_colegas(db, atendente)
+
+
+@router.post("/coberturas/{cobertura_id}/responder", response_model=PontoCoberturaRead)
+def responder_cobertura(
+    cobertura_id: int,
+    data: PontoCoberturaResposta,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return cob_svc.responder_cobertor(db, atendente, cobertura_id, aceitar=data.aceitar)
+
+
+@router.get("/coberturas", response_model=list[PontoCoberturaRead])
+def listar_coberturas_admin(
+    estado: str | None = Query("pendente_admin"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return cob_svc.listar_admin(db, admin, estado=estado)
+
+
+@router.post("/coberturas/conceder", response_model=PontoCoberturaRead, status_code=201)
+def conceder_cobertura(
+    data: PontoCoberturaConceder,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return cob_svc.conceder_admin(
+        db,
+        admin,
+        solicitante_id=data.solicitante_id,
+        cobertor_id=data.cobertor_id,
+        data_ref=data.data_ref,
+        motivo=data.motivo,
+    )
+
+
+@router.post("/coberturas/{cobertura_id}/decidir", response_model=PontoCoberturaRead)
+def decidir_cobertura(
+    cobertura_id: int,
+    data: PontoCoberturaDecisao,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return cob_svc.decidir_admin(
+        db,
+        admin,
+        cobertura_id,
+        aprovar=data.aprovar,
+        decisao_motivo=data.decisao_motivo,
     )
 
 

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -38,6 +38,7 @@ from app.schemas.ponto import (
     PontoLocalCreate,
     PontoLocalRead,
     PontoLocalUpdate,
+    PontoResumoSemanaRead,
     PontoSettingsPublicRead,
     PontoSettingsRead,
     PontoSettingsUpdate,
@@ -297,6 +298,15 @@ def meu_banco_horas(
 ):
     ponto_svc.exigir_acesso_ponto(atendente)
     return ponto_svc.banco_horas(db, atendente, desde=desde, ate=ate)
+
+
+@router.get("/me/resumo-semana", response_model=PontoResumoSemanaRead)
+def meu_resumo_semana(
+    ref: date | None = Query(None, description="Qualquer dia da semana (padrão: hoje)"),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return ponto_svc.resumo_semana(db, atendente, ref=ref)
 
 
 @router.get("/banco-horas", response_model=PontoBancoHorasRead)

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -21,12 +21,16 @@ from app.schemas.ponto import (
     PontoBatidaRead,
     PontoBaterRequest,
     PontoCalendarioRead,
+    PontoCienciaItem,
+    PontoCienciaMe,
     PontoCoberturaColega,
     PontoCoberturaConceder,
     PontoCoberturaCreate,
     PontoCoberturaDecisao,
     PontoCoberturaRead,
     PontoCoberturaResposta,
+    PontoCompetenciaRead,
+    PontoCompetenciaReabrir,
     PontoDigestRead,
     PontoEstadoRead,
     PontoFeriadoCreate,
@@ -48,9 +52,11 @@ from app.schemas.ponto import (
     PontoSettingsPublicRead,
     PontoSettingsRead,
     PontoSettingsUpdate,
+    PontoSetupStatus,
 )
 from app.services import ponto as ponto_svc
 from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_competencia as comp_svc
 from app.services import ponto_folha as folha_svc
 from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
@@ -312,6 +318,85 @@ def decidir_cobertura(
         aprovar=data.aprovar,
         decisao_motivo=data.decisao_motivo,
     )
+
+
+@router.get("/setup-status", response_model=PontoSetupStatus)
+def ponto_setup_status(
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    """Checklist de configuração do módulo ponto (#981)."""
+    return comp_svc.setup_status(db, admin)
+
+
+@router.get("/competencias", response_model=list[PontoCompetenciaRead])
+def listar_competencias(
+    ano: int | None = Query(None),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.listar_competencias(db, admin, ano=ano)
+
+
+@router.get("/competencias/{ano}/{mes}", response_model=PontoCompetenciaRead)
+def obter_competencia(
+    ano: int,
+    mes: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.obter_competencia(db, admin, ano=ano, mes=mes)
+
+
+@router.post("/competencias/{ano}/{mes}/fechar", response_model=PontoCompetenciaRead)
+def fechar_competencia(
+    ano: int,
+    mes: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.fechar_competencia(db, admin, ano=ano, mes=mes)
+
+
+@router.post("/competencias/{ano}/{mes}/reabrir", response_model=PontoCompetenciaRead)
+def reabrir_competencia(
+    ano: int,
+    mes: int,
+    data: PontoCompetenciaReabrir,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.reabrir_competencia(db, admin, ano=ano, mes=mes, motivo=data.motivo)
+
+
+@router.get("/competencias/{ano}/{mes}/ciencias", response_model=list[PontoCienciaItem])
+def listar_ciencias(
+    ano: int,
+    mes: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return comp_svc.listar_ciencias_admin(db, admin, ano=ano, mes=mes)
+
+
+@router.get("/me/ciencia", response_model=PontoCienciaMe)
+def minha_ciencia(
+    ano: int = Query(...),
+    mes: int = Query(..., ge=1, le=12),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return comp_svc.ciencia_me(db, atendente, ano=ano, mes=mes)
+
+
+@router.post("/me/ciencia", response_model=PontoCienciaMe)
+def confirmar_ciencia(
+    ano: int = Query(...),
+    mes: int = Query(..., ge=1, le=12),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return comp_svc.confirmar_ciencia(db, atendente, ano=ano, mes=mes)
 
 
 @router.get("/batidas", response_model=ListaPaginada[PontoBatidaAdminItem])

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import date
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.core.auth import exigir_admin, obter_atendente_atual
@@ -16,6 +17,10 @@ from app.schemas.ponto import (
     PontoAjusteUpdate,
     PontoAlertasMe,
     PontoAnularBody,
+    PontoAusenciaConceder,
+    PontoAusenciaCreate,
+    PontoAusenciaDecisao,
+    PontoAusenciaRead,
     PontoBancoHorasRead,
     PontoBatidaAdminItem,
     PontoBatidaRead,
@@ -44,8 +49,10 @@ from app.schemas.ponto import (
     PontoSettingsUpdate,
 )
 from app.services import ponto as ponto_svc
+from app.services import ponto_ausencia as ausencia_svc
 from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
+from app.services import ponto_justificativa_storage as just_anexo_svc
 from app.services import ponto_relatorio as ponto_relatorio_svc
 from app.services import ponto_settings as ponto_settings_svc
 
@@ -430,6 +437,58 @@ def criar_justificativa(
     )
 
 
+@router.post("/justificativas/upload", response_model=PontoJustificativaRead, status_code=201)
+async def criar_justificativa_com_anexo(
+    data_ref: date = Form(...),
+    tipo: str = Form(...),
+    motivo: str = Form(...),
+    arquivo: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    raw = await arquivo.read()
+    try:
+        nome, mime = just_anexo_svc.validar_anexo_justificativa(
+            arquivo.filename, arquivo.content_type, len(raw)
+        )
+        key = just_anexo_svc.gravar_bytes(raw, mimetype=mime, nome_original=nome)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return just_svc.criar(
+        db,
+        atendente,
+        data_ref=data_ref,
+        tipo=tipo,
+        motivo=motivo,
+        anexo_nome=nome,
+        anexo_content_type=mime,
+        anexo_storage_key=key,
+        anexo_tamanho_bytes=len(raw),
+    )
+
+
+@router.get("/justificativas/{justificativa_id}/anexo")
+def baixar_anexo_justificativa(
+    justificativa_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    row = just_svc.obter_para_anexo(
+        db,
+        justificativa_id=justificativa_id,
+        tenant_id=atendente.tenant_id,
+        solicitante=atendente,
+    )
+    path = just_anexo_svc.caminho_absoluto(row.anexo_storage_key)
+    if path is None:
+        raise HTTPException(status_code=404, detail="Arquivo do anexo não encontrado")
+    return FileResponse(
+        path,
+        media_type=row.anexo_content_type or "application/octet-stream",
+        filename=row.anexo_nome or path.name,
+    )
+
+
 @router.get("/justificativas/me", response_model=list[PontoJustificativaRead])
 def minhas_justificativas(
     db: Session = Depends(get_db),
@@ -462,6 +521,82 @@ def decidir_justificativa(
         decisao_motivo=data.decisao_motivo,
         aplicar_batidas=data.aplicar_batidas,
     )
+
+
+@router.post("/ausencias", response_model=PontoAusenciaRead, status_code=201)
+def solicitar_ausencia(
+    data: PontoAusenciaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return ausencia_svc.solicitar(
+        db,
+        atendente,
+        tipo=data.tipo,
+        desde=data.desde,
+        ate=data.ate,
+        motivo=data.motivo,
+    )
+
+
+@router.get("/ausencias/me", response_model=list[PontoAusenciaRead])
+def minhas_ausencias(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return ausencia_svc.listar_me(db, atendente)
+
+
+@router.get("/ausencias", response_model=list[PontoAusenciaRead])
+def listar_ausencias_admin(
+    estado: str | None = Query("pendente"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ausencia_svc.listar_admin(db, admin, estado=estado)
+
+
+@router.post("/ausencias/conceder", response_model=PontoAusenciaRead, status_code=201)
+def conceder_ausencia(
+    data: PontoAusenciaConceder,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ausencia_svc.conceder_admin(
+        db,
+        admin,
+        atendente_id=data.atendente_id,
+        tipo=data.tipo,
+        desde=data.desde,
+        ate=data.ate,
+        motivo=data.motivo,
+    )
+
+
+@router.post("/ausencias/{ausencia_id}/decidir", response_model=PontoAusenciaRead)
+def decidir_ausencia(
+    ausencia_id: int,
+    data: PontoAusenciaDecisao,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ausencia_svc.decidir(
+        db,
+        admin,
+        ausencia_id,
+        aprovar=data.aprovar,
+        decisao_motivo=data.decisao_motivo,
+    )
+
+
+@router.delete("/ausencias/{ausencia_id}", status_code=204)
+def remover_ausencia(
+    ausencia_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    ausencia_svc.remover_admin(db, admin, ausencia_id)
+    return Response(status_code=204)
 
 
 @router.get("/hora-extra/me/status", response_model=PontoHoraExtraMeStatus)

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -489,7 +489,14 @@ def solicitar_hora_extra(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     ponto_svc.exigir_acesso_ponto(atendente)
-    return he_svc.solicitar(db, atendente, motivo=data.motivo)
+    return he_svc.solicitar(
+        db,
+        atendente,
+        motivo=data.motivo,
+        modo=data.modo,
+        ate_horario=data.ate_horario,
+        duracao_minutos=data.duracao_minutos,
+    )
 
 
 @router.get("/hora-extra", response_model=list[PontoHoraExtraRead])

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -56,6 +56,10 @@ class Settings(BaseSettings):
     # Tamanho máximo (bytes) para cada anexo de ticket.
     TICKET_ANEXOS_MAX_BYTES: int = 25 * 1024 * 1024
 
+    # Anexos de justificativa de ponto (#977) — mesmos limites de tamanho.
+    PONTO_JUSTIFICATIVA_ANEXOS_DIR: str = "data/ponto_justificativa_anexos"
+    PONTO_JUSTIFICATIVA_ANEXOS_MAX_BYTES: int = 25 * 1024 * 1024
+
     # Mídia de sugestões/problemas (#856+): prints no texto + PDF/vídeo em anexo.
     SOLICITACAO_MEDIA_DIR: str = "data/solicitacao_media"
     SOLICITACAO_MEDIA_MAX_BYTES: int = 25 * 1024 * 1024

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
 from app.models.ponto_cobertura import PontoCobertura
+from app.models.ponto_competencia import PontoCompetencia, PontoEspelhoCiencia
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.atendente import Atendente, AtendenteSetor
 from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
+from app.models.ponto_cobertura import PontoCobertura
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
@@ -102,6 +103,7 @@ __all__ = [
     "PontoBatida",
     "PontoJustificativa",
     "PontoHoraExtra",
+    "PontoCobertura",
     "PontoSettings",
     "PontoLocal",
     "PontoFeriado",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.atendente import Atendente, AtendenteSetor
 from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
+from app.models.ponto_ausencia import PontoAusencia
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
@@ -102,6 +103,7 @@ __all__ = [
     "PontoBatida",
     "PontoJustificativa",
     "PontoHoraExtra",
+    "PontoAusencia",
     "PontoSettings",
     "PontoLocal",
     "PontoFeriado",

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -47,6 +47,8 @@ class Atendente(Base):
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
     # Teto máximo de HE por liberação, em minutos (#966); null = sem teto.
     he_teto_minutos = Column(Integer, nullable=True)
+    # NULL = herda setting global (#974)
+    he_teto_mensal_minutos = Column(Integer, nullable=True)
     # Locais de ponto (#984): empresa + extras por atendente.
     usar_local_empresa = Column(Boolean, nullable=False, default=True, server_default="true")
     local_empresa_raio_metros = Column(Integer, nullable=True)

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -45,6 +45,8 @@ class Atendente(Base):
     horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM (ciclo)
     horario_previsto_saida = Column(String(5), nullable=True)
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
+    # Teto máximo de HE por liberação, em minutos (#966); null = sem teto.
+    he_teto_minutos = Column(Integer, nullable=True)
     # Locais de ponto (#984): empresa + extras por atendente.
     usar_local_empresa = Column(Boolean, nullable=False, default=True, server_default="true")
     local_empresa_raio_metros = Column(Integer, nullable=True)

--- a/backend/app/models/ponto_ausencia.py
+++ b/backend/app/models/ponto_ausencia.py
@@ -1,4 +1,4 @@
-"""Justificativas de ponto (#774)."""
+"""Ausências programadas de ponto (#976)."""
 
 from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
@@ -7,24 +7,24 @@ from sqlalchemy.sql import func
 from app.database import Base
 
 
-class PontoJustificativa(Base):
-    __tablename__ = "ponto_justificativas"
+class PontoAusencia(Base):
+    __tablename__ = "ponto_ausencias"
 
     id = Column(Integer, primary_key=True, index=True)
     tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
-    data_ref = Column(Date, nullable=False, index=True)
-    tipo = Column(String(32), nullable=False)  # falta | esquecimento | folga_com_ponto | outro
-    motivo = Column(String(1000), nullable=False)
-    estado = Column(String(20), nullable=False, default="pendente")  # pendente | aprovada | rejeitada
-    decisao_motivo = Column(String(1000), nullable=True)
+    # ferias | folga_programada
+    tipo = Column(String(32), nullable=False)
+    desde = Column(Date, nullable=False, index=True)
+    ate = Column(Date, nullable=False, index=True)
+    motivo = Column(String(1000), nullable=True)
+    # pendente | aprovada | rejeitada
+    estado = Column(String(20), nullable=False, default="pendente", server_default="pendente")
+    # solicitacao | admin
+    origem = Column(String(20), nullable=False, default="solicitacao", server_default="solicitacao")
     decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
     decidido_em = Column(DateTime(timezone=True), nullable=True)
-    # Anexo opcional (#977)
-    anexo_nome = Column(String(255), nullable=True)
-    anexo_content_type = Column(String(128), nullable=True)
-    anexo_storage_key = Column(String(255), nullable=True)
-    anexo_tamanho_bytes = Column(Integer, nullable=True)
+    decisao_motivo = Column(String(1000), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     atendente = relationship("Atendente", foreign_keys=[atendente_id])

--- a/backend/app/models/ponto_cobertura.py
+++ b/backend/app/models/ponto_cobertura.py
@@ -1,0 +1,32 @@
+"""Coberturas / troca de plantão (#970)."""
+
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoCobertura(Base):
+    __tablename__ = "ponto_coberturas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    solicitante_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    cobertor_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    data_ref = Column(Date, nullable=False, index=True)
+    motivo = Column(String(1000), nullable=True)
+    # pendente_cobertor | pendente_admin | aprovada | rejeitada | cancelada
+    estado = Column(String(32), nullable=False, default="pendente_cobertor", server_default="pendente_cobertor")
+    # solicitacao | admin
+    origem = Column(String(20), nullable=False, default="solicitacao", server_default="solicitacao")
+    resposta_cobertor = Column(String(20), nullable=True)  # aceita | recusa
+    respondido_em = Column(DateTime(timezone=True), nullable=True)
+    decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    decidido_em = Column(DateTime(timezone=True), nullable=True)
+    decisao_motivo = Column(String(1000), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    solicitante = relationship("Atendente", foreign_keys=[solicitante_id])
+    cobertor = relationship("Atendente", foreign_keys=[cobertor_id])
+    decidido_por = relationship("Atendente", foreign_keys=[decidido_por_id])

--- a/backend/app/models/ponto_competencia.py
+++ b/backend/app/models/ponto_competencia.py
@@ -1,0 +1,63 @@
+"""Competência mensal e ciência do espelho (#978 / #979)."""
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoCompetencia(Base):
+    __tablename__ = "ponto_competencias"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "ano", "mes", name="uq_ponto_competencias_tenant_ano_mes"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    ano = Column(Integer, nullable=False)
+    mes = Column(Integer, nullable=False)
+    fechada = Column(Boolean, nullable=False, default=False, server_default="false")
+    fechado_em = Column(DateTime(timezone=True), nullable=True)
+    fechado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    reaberto_em = Column(DateTime(timezone=True), nullable=True)
+    reaberto_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    reabrir_motivo = Column(String(1000), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    fechado_por = relationship("Atendente", foreign_keys=[fechado_por_id])
+    reaberto_por = relationship("Atendente", foreign_keys=[reaberto_por_id])
+
+
+class PontoEspelhoCiencia(Base):
+    __tablename__ = "ponto_espelho_ciencias"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "atendente_id",
+            "ano",
+            "mes",
+            name="uq_ponto_espelho_ciencias_atendente_ano_mes",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    ano = Column(Integer, nullable=False)
+    mes = Column(Integer, nullable=False)
+    confirmado_em = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    # Se ajuste pós-ciência invalidar, fica False e confirmado_em permanece histórico no audit
+    ativa = Column(Boolean, nullable=False, default=True, server_default="true")
+    invalidada_em = Column(DateTime(timezone=True), nullable=True)
+    invalidada_motivo = Column(String(500), nullable=True)
+
+    atendente = relationship("Atendente", foreign_keys=[atendente_id])

--- a/backend/app/models/ponto_hora_extra.py
+++ b/backend/app/models/ponto_hora_extra.py
@@ -16,9 +16,11 @@ class PontoHoraExtra(Base):
     # pendente | aprovada | rejeitada | expirada
     estado = Column(String(20), nullable=False, default="pendente", server_default="pendente")
     motivo = Column(String(1000), nullable=True)
-    # resto_do_dia | ate_horario (só quando aprovada)
+    # resto_do_dia | ate_horario | duracao (só quando aprovada)
     modo = Column(String(20), nullable=True)
     ate_em = Column(DateTime(timezone=True), nullable=True)
+    # solicitacao | admin (#966)
+    origem = Column(String(20), nullable=False, default="solicitacao", server_default="solicitacao")
     decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
     decidido_em = Column(DateTime(timezone=True), nullable=True)
     decisao_motivo = Column(String(1000), nullable=True)

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -17,6 +17,8 @@ class PontoSettings(Base):
     # Margem após saída prevista do dia (#961); fecho = min(N horas, saída+margem).
     fecho_margem_pos_saida_minutos = Column(Integer, nullable=False, default=30, server_default="30")
     jornada_diaria_minutos = Column(Integer, nullable=False, default=480, server_default="480")
+    # 0 = desligado (#973)
+    pausa_minima_minutos = Column(Integer, nullable=False, default=0, server_default="0")
     # opcional | recomendada | obrigatoria (#844)
     politica_geolocalizacao = Column(String(20), nullable=False, default="opcional", server_default="opcional")
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -17,6 +17,8 @@ class PontoSettings(Base):
     # Margem após saída prevista do dia (#961); fecho = min(N horas, saída+margem).
     fecho_margem_pos_saida_minutos = Column(Integer, nullable=False, default=30, server_default="30")
     jornada_diaria_minutos = Column(Integer, nullable=False, default=480, server_default="480")
+    # NULL = sem teto mensal global (#974)
+    he_teto_mensal_minutos = Column(Integer, nullable=True)
     # opcional | recomendada | obrigatoria (#844)
     politica_geolocalizacao = Column(String(20), nullable=False, default="opcional", server_default="opcional")
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -24,6 +24,7 @@ class AtendenteBase(BaseModel):
     usar_local_empresa: bool = True
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
     he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
+    he_teto_mensal_minutos: int | None = Field(default=None, ge=30, le=31 * 24 * 60)
 
 
 class AtendenteCreate(AtendenteBase):
@@ -50,6 +51,7 @@ class AtendenteUpdate(BaseModel):
     usar_local_empresa: bool | None = None
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
     he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
+    he_teto_mensal_minutos: int | None = Field(default=None, ge=30, le=31 * 24 * 60)
 
 
 class AtendenteRead(AtendenteBase):

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -23,6 +23,7 @@ class AtendenteBase(BaseModel):
     tolerancia_atraso_minutos: int = Field(default=0, ge=0, le=120)
     usar_local_empresa: bool = True
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
+    he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
 
 
 class AtendenteCreate(AtendenteBase):
@@ -48,6 +49,7 @@ class AtendenteUpdate(BaseModel):
     tolerancia_atraso_minutos: int | None = Field(default=None, ge=0, le=120)
     usar_local_empresa: bool | None = None
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
+    he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
 
 
 class AtendenteRead(AtendenteBase):

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -254,13 +254,29 @@ class PontoAnularBody(BaseModel):
 
 
 class PontoAlertasMe(BaseModel):
-    """Lembretes ao utilizador — sem batida automática (#773 / #769)."""
+    """Lembretes ao usuário — sem batida automática (#773 / #769 / #968)."""
 
     sem_entrada_em_dia_escala: bool = False
     online_sem_ponto: bool = False
     jornada_aberta_longa: bool = False
     horas_jornada_aberta: float | None = None
+    lembrete_entrada_tolerancia: bool = False
+    lembrete_saida_tolerancia: bool = False
     mensagens: list[str] = []
+
+
+class PontoResumoSemanaRead(BaseModel):
+    """Resumo semanal do colaborador (#972)."""
+
+    desde: date
+    ate: date
+    segundos_esperados: int
+    segundos_realizados: int
+    saldo_segundos: int
+    atrasos: int
+    he_minutos: int
+    dias_escala: int
+    dias_feriado: int = 0
 
 
 class PontoJustificativaCreate(BaseModel):

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -309,6 +309,7 @@ class PontoHoraExtraRead(BaseModel):
     motivo: str | None = None
     modo: str | None = None
     ate_em: datetime | None = None
+    origem: str = "solicitacao"
     decidido_por_id: int | None = None
     decidido_em: datetime | None = None
     decisao_motivo: str | None = None
@@ -319,9 +320,18 @@ class PontoHoraExtraRead(BaseModel):
 
 class PontoHoraExtraDecisao(BaseModel):
     aprovar: bool
-    modo: Literal["resto_do_dia", "ate_horario"] | None = None
+    modo: Literal["resto_do_dia", "ate_horario", "duracao"] | None = None
     ate_horario: str | None = Field(default=None, max_length=5, description="HH:MM se modo=ate_horario")
+    duracao_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
     decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoHoraExtraConceder(BaseModel):
+    atendente_id: int = Field(..., ge=1)
+    modo: Literal["resto_do_dia", "ate_horario", "duracao"]
+    ate_horario: str | None = Field(default=None, max_length=5)
+    duracao_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
+    motivo: str | None = Field(default=None, max_length=1000)
 
 
 class PontoHoraExtraMeStatus(BaseModel):
@@ -329,3 +339,5 @@ class PontoHoraExtraMeStatus(BaseModel):
     pode_pegar_whatsapp: bool
     he_ativa: PontoHoraExtraRead | None = None
     pedido_pendente: PontoHoraExtraRead | None = None
+    he_teto_minutos: int | None = None
+    he_restante_minutos: int | None = None

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -404,3 +404,52 @@ class PontoCoberturaRead(BaseModel):
     created_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class PontoSetupItem(BaseModel):
+    codigo: str
+    titulo: str
+    detalhe: str
+    destino: str
+    ok: bool
+    informativo: bool = False
+
+
+class PontoSetupStatus(BaseModel):
+    defaults_fecho_off: bool
+    tolerancia_sugerida_minutos: int = 15
+    pendentes: int
+    itens: list[PontoSetupItem]
+
+
+class PontoCompetenciaRead(BaseModel):
+    id: int
+    ano: int
+    mes: int
+    fechada: bool
+    fechado_em: datetime | None = None
+    fechado_por_id: int | None = None
+    fechado_por_nome: str | None = None
+    reaberto_em: datetime | None = None
+    reaberto_por_id: int | None = None
+    reabrir_motivo: str | None = None
+
+
+class PontoCompetenciaReabrir(BaseModel):
+    motivo: str = Field(..., min_length=3, max_length=1000)
+
+
+class PontoCienciaMe(BaseModel):
+    ano: int
+    mes: int
+    competencia_fechada: bool
+    confirmada: bool
+    confirmado_em: datetime | None = None
+    pode_confirmar: bool
+
+
+class PontoCienciaItem(BaseModel):
+    atendente_id: int
+    atendente_nome: str
+    confirmada: bool
+    confirmado_em: datetime | None = None

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -357,3 +357,50 @@ class PontoHoraExtraMeStatus(BaseModel):
     pedido_pendente: PontoHoraExtraRead | None = None
     he_teto_minutos: int | None = None
     he_restante_minutos: int | None = None
+
+
+class PontoCoberturaColega(BaseModel):
+    id: int
+    nome: str
+
+
+class PontoCoberturaCreate(BaseModel):
+    cobertor_id: int = Field(..., ge=1)
+    data_ref: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoCoberturaConceder(BaseModel):
+    solicitante_id: int = Field(..., ge=1)
+    cobertor_id: int = Field(..., ge=1)
+    data_ref: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoCoberturaResposta(BaseModel):
+    aceitar: bool
+
+
+class PontoCoberturaDecisao(BaseModel):
+    aprovar: bool
+    decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoCoberturaRead(BaseModel):
+    id: int
+    solicitante_id: int
+    solicitante_nome: str | None = None
+    cobertor_id: int
+    cobertor_nome: str | None = None
+    data_ref: date
+    motivo: str | None = None
+    estado: str
+    origem: str = "solicitacao"
+    resposta_cobertor: str | None = None
+    respondido_em: datetime | None = None
+    decidido_por_id: int | None = None
+    decidido_em: datetime | None = None
+    decisao_motivo: str | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -198,6 +198,7 @@ class PontoDigestRead(BaseModel):
     jornadas_abertas: int
     online_sem_ponto: int
     justificativas_pendentes: int
+    he_acima_teto_mensal: int = 0
     itens: list[PontoHojeItem]
 
 
@@ -207,6 +208,7 @@ class PontoSettingsRead(BaseModel):
     fecho_apos_horas: int = 14
     fecho_margem_pos_saida_minutos: int = 30
     jornada_diaria_minutos: int = 480
+    he_teto_mensal_minutos: int | None = None
     politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
 
     model_config = ConfigDict(from_attributes=True)
@@ -218,6 +220,7 @@ class PontoSettingsUpdate(BaseModel):
     fecho_apos_horas: int | None = Field(default=None, ge=4, le=48)
     fecho_margem_pos_saida_minutos: int | None = Field(default=None, ge=0, le=240)
     jornada_diaria_minutos: int | None = Field(default=None, ge=60, le=1440)
+    he_teto_mensal_minutos: int | None = Field(default=None, ge=30, le=31 * 24 * 60)
     politica_geolocalizacao: PoliticaGeolocalizacao | None = None
 
 
@@ -315,6 +318,9 @@ class PontoJustificativaDecisao(BaseModel):
 
 class PontoHoraExtraCreate(BaseModel):
     motivo: str | None = Field(default=None, max_length=1000)
+    modo: Literal["resto_do_dia", "ate_horario", "duracao"] | None = None
+    ate_horario: str | None = Field(default=None, max_length=5)
+    duracao_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
 
 
 class PontoHoraExtraRead(BaseModel):
@@ -355,5 +361,8 @@ class PontoHoraExtraMeStatus(BaseModel):
     pode_pegar_whatsapp: bool
     he_ativa: PontoHoraExtraRead | None = None
     pedido_pendente: PontoHoraExtraRead | None = None
+    ultimo_rejeitado: PontoHoraExtraRead | None = None
     he_teto_minutos: int | None = None
     he_restante_minutos: int | None = None
+    he_teto_mensal_minutos: int | None = None
+    he_consumido_mensal_minutos: int = 0

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -130,6 +130,8 @@ StatusDiaPonto = Literal[
     "parcial",
     "folga",
     "folga_com_ponto",
+    "folga_programada",
+    "ferias",
     "livre",
     "atraso",
     "feriado",
@@ -144,10 +146,13 @@ class PontoCalendarioDia(BaseModel):
     status: StatusDiaPonto
     atrasado: bool = False
     feriado: bool = False
+    ausencia_tipo: str | None = None  # ferias | folga_programada
+    pausa_abaixo_minimo: bool = False
     # #842 — meta de jornada × realizado (cores do calendário)
     segundos_trabalhados: int = 0
     segundos_esperados: int = 0
-    classe_visual: Literal["abaixo", "ok", "he", "feriado", "neutro"] = "neutro"
+    segundos_pausa: int = 0
+    classe_visual: Literal["abaixo", "ok", "he", "feriado", "ausencia", "neutro"] = "neutro"
 
 
 class PontoCalendarioRead(BaseModel):
@@ -207,6 +212,7 @@ class PontoSettingsRead(BaseModel):
     fecho_apos_horas: int = 14
     fecho_margem_pos_saida_minutos: int = 30
     jornada_diaria_minutos: int = 480
+    pausa_minima_minutos: int = 0
     politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
 
     model_config = ConfigDict(from_attributes=True)
@@ -218,6 +224,7 @@ class PontoSettingsUpdate(BaseModel):
     fecho_apos_horas: int | None = Field(default=None, ge=4, le=48)
     fecho_margem_pos_saida_minutos: int | None = Field(default=None, ge=0, le=240)
     jornada_diaria_minutos: int | None = Field(default=None, ge=60, le=1440)
+    pausa_minima_minutos: int | None = Field(default=None, ge=0, le=240)
     politica_geolocalizacao: PoliticaGeolocalizacao | None = None
 
 
@@ -262,6 +269,7 @@ class PontoAlertasMe(BaseModel):
     horas_jornada_aberta: float | None = None
     lembrete_entrada_tolerancia: bool = False
     lembrete_saida_tolerancia: bool = False
+    pausa_abaixo_minimo: bool = False
     mensagens: list[str] = []
 
 
@@ -296,6 +304,48 @@ class PontoJustificativaRead(BaseModel):
     decisao_motivo: str | None = None
     decidido_por_id: int | None = None
     decidido_em: datetime | None = None
+    tem_anexo: bool = False
+    anexo_nome: str | None = None
+    anexo_content_type: str | None = None
+    anexo_tamanho_bytes: int | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PontoAusenciaCreate(BaseModel):
+    tipo: Literal["ferias", "folga_programada"]
+    desde: date
+    ate: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoAusenciaConceder(BaseModel):
+    atendente_id: int = Field(..., ge=1)
+    tipo: Literal["ferias", "folga_programada"]
+    desde: date
+    ate: date
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoAusenciaDecisao(BaseModel):
+    aprovar: bool
+    decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoAusenciaRead(BaseModel):
+    id: int
+    atendente_id: int
+    atendente_nome: str | None = None
+    tipo: str
+    desde: date
+    ate: date
+    motivo: str | None = None
+    estado: str
+    origem: str = "solicitacao"
+    decidido_por_id: int | None = None
+    decidido_em: datetime | None = None
+    decisao_motivo: str | None = None
     created_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/escala.py
+++ b/backend/app/services/escala.py
@@ -310,6 +310,15 @@ def saida_prevista_em(atendente: Atendente, dia: date) -> datetime | None:
     return datetime.combine(dia, time(hour=ps[0], minute=ps[1]), tzinfo=PONTO_TZ)
 
 
+def liberacao_saida_lembrete_em(atendente: Atendente, dia: date) -> datetime | None:
+    """Início do lembrete de saída (fim − tolerância) (#968)."""
+    saida = saida_prevista_em(atendente, dia)
+    if saida is None:
+        return None
+    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+    return saida - timedelta(minutes=tol)
+
+
 def validar_janela_entrada(atendente: Atendente, when: datetime) -> None:
     """Bloqueia entrada antes de inicio−tolerância (#964). Admin/sistema não chamam isto."""
     if not escala_configurada(atendente):

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -641,6 +641,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
 
 def digest_hoje(db: Session, admin: Atendente) -> PontoDigestRead:
     from app.models.ponto_justificativa import PontoJustificativa
+    from app.services import ponto_hora_extra as he_svc
 
     hoje = visao_hoje(db, admin)
     pendentes = (
@@ -667,6 +668,7 @@ def digest_hoje(db: Session, admin: Atendente) -> PontoDigestRead:
         jornadas_abertas=abertas,
         online_sem_ponto=online_sem,
         justificativas_pendentes=pendentes,
+        he_acima_teto_mensal=he_svc.contar_acima_teto_mensal(db, admin.tenant_id),
         itens=destaque[:40],
     )
 

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -722,11 +722,14 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     exigir_acesso_ponto(atendente)
     hoje = datetime.now(PONTO_TZ).date()
     agora = _agora_utc()
+    agora_local = agora.astimezone(PONTO_TZ)
     msgs: list[str] = []
     sem_entrada = False
     online_sem = False
     jornada_longa = False
     horas_aberta: float | None = None
+    lembrete_entrada = False
+    lembrete_saida = False
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
     jornada_ativa = escala_svc.escala_configurada(atendente)
@@ -753,18 +756,29 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
         hb = hb.replace(tzinfo=timezone.utc)
     online = bool(hb and hb >= agora - timedelta(seconds=PRESENCA_TTL_SEC))
 
-    # Modo nenhum: sem avisos de falta/atraso (#959)
+    # Modo nenhum: sem avisos de falta/atraso/lembretes de tolerância (#959 / #968)
     if jornada_ativa:
         if esperado is True and not tem_entrada_hoje and entrada is None:
-            sem_entrada = True
-            msgs.append("Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada.")
+            liberacao = escala_svc.liberacao_entrada_em(atendente, hoje)
+            if liberacao is not None and agora_local >= liberacao:
+                sem_entrada = True
+                lembrete_entrada = True
+                limite = escala_svc.limite_atraso_em(atendente, hoje)
+                if limite is not None and agora_local <= limite:
+                    msgs.append("Janela de entrada — registre o ponto agora.")
+                else:
+                    msgs.append(
+                        "Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada."
+                    )
 
         if _atrasado_entrada(atendente, primeira):
             msgs.append("Entrada registrada após o horário previsto (fora da tolerância).")
 
     if online and entrada is None:
         online_sem = True
-        if "ainda não há entrada" not in " ".join(msgs).lower():
+        if "ainda não há entrada" not in " ".join(msgs).lower() and "Janela de entrada" not in " ".join(
+            msgs
+        ):
             msgs.append("Você está online no painel sem jornada de ponto aberta.")
 
     if entrada is not None:
@@ -775,16 +789,118 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
                 f"Jornada aberta há cerca de {horas_aberta:.0f} h — lembre-se de registrar a saída."
             )
         elif jornada_ativa:
+            inicio_saida = escala_svc.liberacao_saida_lembrete_em(atendente, hoje)
             saida_prev = escala_svc.saida_prevista_em(atendente, hoje)
-            if saida_prev is not None and agora.astimezone(PONTO_TZ) >= saida_prev:
-                msgs.append("Horário de saída previsto já passou — registre a saída.")
+            if inicio_saida is not None and agora_local >= inicio_saida:
+                lembrete_saida = True
+                if saida_prev is not None and agora_local >= saida_prev:
+                    msgs.append("Horário de saída previsto já passou — registre a saída.")
+                else:
+                    msgs.append("Janela de saída — registre o ponto ao encerrar.")
 
     return PontoAlertasMe(
         sem_entrada_em_dia_escala=sem_entrada,
         online_sem_ponto=online_sem,
         jornada_aberta_longa=jornada_longa,
         horas_jornada_aberta=horas_aberta,
+        lembrete_entrada_tolerancia=lembrete_entrada,
+        lembrete_saida_tolerancia=lembrete_saida,
         mensagens=msgs,
+    )
+
+
+def _semana_bounds(ref: date) -> tuple[date, date]:
+    """Segunda a domingo da semana que contém `ref` (pt-BR / ISO weekday)."""
+    desde = ref - timedelta(days=ref.weekday())
+    return desde, desde + timedelta(days=6)
+
+
+def _contar_atrasos_periodo(
+    db: Session,
+    atendente: Atendente,
+    *,
+    desde: date,
+    ate: date,
+) -> int:
+    if not escala_svc.escala_configurada(atendente):
+        return 0
+    n = 0
+    d = desde
+    while d <= ate:
+        if ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d):
+            d += timedelta(days=1)
+            continue
+        if not escala_svc.eh_dia_de_trabalho(atendente, d):
+            d += timedelta(days=1)
+            continue
+        ini, fim = _bounds_periodo(d, d)
+        bats = (
+            _q_ativas(db)
+            .filter(
+                PontoBatida.atendente_id == atendente.id,
+                PontoBatida.registrado_em >= ini,
+                PontoBatida.registrado_em < fim,
+            )
+            .all()
+        )
+        if _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats)):
+            n += 1
+        d += timedelta(days=1)
+    return n
+
+
+def _he_minutos_periodo(db: Session, atendente: Atendente, *, desde: date, ate: date) -> int:
+    from app.models.ponto_hora_extra import PontoHoraExtra
+
+    ini, fim = _bounds_periodo(desde, ate)
+    rows = (
+        db.query(PontoHoraExtra)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente.id,
+            PontoHoraExtra.estado.in_(("aprovada", "expirada")),
+            PontoHoraExtra.ate_em.isnot(None),
+            PontoHoraExtra.decidido_em.isnot(None),
+            PontoHoraExtra.decidido_em >= ini,
+            PontoHoraExtra.decidido_em < fim,
+        )
+        .all()
+    )
+    total = 0
+    for r in rows:
+        dec = r.decidido_em
+        ate_em = r.ate_em
+        if dec is None or ate_em is None:
+            continue
+        if dec.tzinfo is None:
+            dec = dec.replace(tzinfo=timezone.utc)
+        if ate_em.tzinfo is None:
+            ate_em = ate_em.replace(tzinfo=timezone.utc)
+        total += max(0, int((ate_em - dec).total_seconds() // 60))
+    return total
+
+
+def resumo_semana(
+    db: Session,
+    atendente: Atendente,
+    *,
+    ref: date | None = None,
+) -> "PontoResumoSemanaRead":
+    from app.schemas.ponto import PontoResumoSemanaRead
+
+    exigir_acesso_ponto(atendente)
+    dia_ref = ref or datetime.now(PONTO_TZ).date()
+    desde, ate = _semana_bounds(dia_ref)
+    bh = banco_horas(db, atendente, desde=desde, ate=ate)
+    return PontoResumoSemanaRead(
+        desde=desde,
+        ate=ate,
+        segundos_esperados=bh.segundos_esperados,
+        segundos_realizados=bh.segundos_realizados,
+        saldo_segundos=bh.saldo_segundos,
+        atrasos=_contar_atrasos_periodo(db, atendente, desde=desde, ate=ate),
+        he_minutos=_he_minutos_periodo(db, atendente, desde=desde, ate=ate),
+        dias_escala=bh.dias_escala,
+        dias_feriado=bh.dias_feriado,
     )
 
 
@@ -812,6 +928,12 @@ def admin_criar_batida(
     alvo = _atendente_do_tenant(db, admin.tenant_id, atendente_id)
     if tipo not in TIPOS_VALIDOS:
         raise HTTPException(status_code=400, detail="Tipo inválido")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo do ajuste (mínimo 3 caracteres).",
+        )
     batida = PontoBatida(
         tenant_id=admin.tenant_id,
         atendente_id=alvo.id,
@@ -829,7 +951,7 @@ def admin_criar_batida(
         "create_ajuste",
         admin.id,
         payload={
-            "motivo": motivo,
+            "motivo": motivo_limpo,
             "atendente_id": alvo.id,
             "tipo": tipo,
             "registrado_em": _as_utc(registrado_em).isoformat(),
@@ -857,6 +979,12 @@ def admin_atualizar_batida(
     )
     if not batida or batida.anulada:
         raise HTTPException(status_code=404, detail="Batida não encontrada")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo do ajuste (mínimo 3 caracteres).",
+        )
     antes = {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()}
     if tipo is not None:
         if tipo not in TIPOS_VALIDOS:
@@ -871,7 +999,11 @@ def admin_atualizar_batida(
         batida.id,
         "update_ajuste",
         admin.id,
-        payload={"motivo": motivo, "antes": antes, "depois": {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()}},
+        payload={
+            "motivo": motivo_limpo,
+            "antes": antes,
+            "depois": {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()},
+        },
     )
     db.commit()
     db.refresh(batida)
@@ -886,6 +1018,12 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
     )
     if not batida or batida.anulada:
         raise HTTPException(status_code=404, detail="Batida não encontrada")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo da anulação (mínimo 3 caracteres).",
+        )
     batida.anulada = True
     registrar_audit(
         db,
@@ -894,7 +1032,7 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
         "anular",
         admin.id,
         payload={
-            "motivo": motivo,
+            "motivo": motivo_limpo,
             "tipo": batida.tipo,
             "registrado_em": batida.registrado_em.isoformat(),
             "atendente_id": batida.atendente_id,

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -432,7 +432,14 @@ def _status_dia(
     tem_saida: bool,
     feriado: bool = False,
     atrasado: bool = False,
+    ausencia_tipo: str | None = None,
 ) -> str:
+    if ausencia_tipo in ("ferias", "folga_programada"):
+        if tem_entrada and tem_saida:
+            return "ok"
+        if tem_entrada or tem_saida:
+            return "folga_com_ponto"
+        return ausencia_tipo
     if feriado:
         if tem_entrada and tem_saida:
             return "ok"
@@ -462,8 +469,11 @@ def _classe_visual_dia(
     esperado: bool,
     segundos_trabalhados: int,
     segundos_esperados: int,
+    ausencia_tipo: str | None = None,
 ) -> str:
-    """Paleta #842: vermelho abaixo / verde ok / azul HE / laranja feriado."""
+    """Paleta #842: vermelho abaixo / verde ok / azul HE / laranja feriado / violeta ausência."""
+    if ausencia_tipo in ("ferias", "folga_programada"):
+        return "ausencia"
     if feriado:
         return "feriado"
     meta = segundos_esperados if segundos_esperados > 0 else 0
@@ -476,6 +486,32 @@ def _classe_visual_dia(
     if segundos_trabalhados > meta:
         return "he"
     return "ok"
+
+
+def _segundos_pausas_do_dia(batidas: list[PontoBatida]) -> int:
+    """Soma todas as pausas fechadas do dia (fora dos blocos entrada→saída)."""
+    ordenadas = sorted(batidas, key=lambda b: (_as_utc(b.registrado_em), b.id))
+    total = 0
+    pendente: PontoBatida | None = None
+    for b in ordenadas:
+        if b.tipo == "pausa_inicio":
+            pendente = b
+        elif b.tipo == "pausa_fim" and pendente is not None:
+            total += max(0, int((_as_utc(b.registrado_em) - _as_utc(pendente.registrado_em)).total_seconds()))
+            pendente = None
+    return total
+
+
+def _pausa_abaixo_minimo(
+    *,
+    tem_entrada: bool,
+    segundos_pausa: int,
+    pausa_minima_minutos: int,
+) -> bool:
+    """#973 — sinaliza se iniciou jornada e a pausa total ficou abaixo do mínimo."""
+    if pausa_minima_minutos <= 0 or not tem_entrada:
+        return False
+    return segundos_pausa < pausa_minima_minutos * 60
 
 
 def calendario(
@@ -514,9 +550,14 @@ def calendario(
         por_dia.setdefault(d, []).append(b)
 
     usa = escala_svc.escala_configurada(atendente)
+    from app.services import ponto_ausencia as ausencia_svc
+
+    ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
+    pausa_min = int(getattr(settings, "pausa_minima_minutos", None) or 0)
     dias_out: list[PontoCalendarioDia] = []
     for d in dias_mes:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
+        ausencia_tipo = ausencias.get(d)
         esp = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
         bats = por_dia.get(d, [])
         te = any(b.tipo == "entrada" for b in bats)
@@ -524,7 +565,8 @@ def calendario(
         atrasado = _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats))
         intervalos = _intervalos_de_batidas(bats)
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
-        esperado_visual = bool(esp and not feriado)
+        pausas = _segundos_pausas_do_dia(bats)
+        esperado_visual = bool(esp and not feriado and not ausencia_tipo)
         if usa and esperado_visual:
             esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
@@ -548,16 +590,23 @@ def calendario(
                     tem_saida=ts,
                     feriado=feriado,
                     atrasado=atrasado,
+                    ausencia_tipo=ausencia_tipo,
                 ),
                 atrasado=atrasado,
                 feriado=feriado,
+                ausencia_tipo=ausencia_tipo,
+                pausa_abaixo_minimo=_pausa_abaixo_minimo(
+                    tem_entrada=te, segundos_pausa=pausas, pausa_minima_minutos=pausa_min
+                ),
                 segundos_trabalhados=trabalhados,
                 segundos_esperados=esperados,
+                segundos_pausa=pausas,
                 classe_visual=_classe_visual_dia(  # type: ignore[arg-type]
                     feriado=feriado,
                     esperado=esperado_para_cor,
                     segundos_trabalhados=trabalhados,
                     segundos_esperados=esperados,
+                    ausencia_tipo=ausencia_tipo,
                 ),
             )
         )
@@ -574,6 +623,7 @@ def calendario(
 
 
 def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
+    from app.services import ponto_ausencia as ausencia_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     hoje = datetime.now(PONTO_TZ).date()
@@ -593,6 +643,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     itens: list[PontoHojeItem] = []
     for a in atendentes:
         usa = escala_svc.escala_configurada(a)
+        ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, a.id, hoje)
         esperado = escala_svc.eh_dia_de_trabalho(a, hoje) if usa else False
         entrada = _entrada_da_jornada_aberta(db, a.id)
         inicio, fim = _bounds_periodo(hoje, hoje)
@@ -615,6 +666,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
             tem_saida=ts,
             feriado=feriado_hoje,
             atrasado=atrasado,
+            ausencia_tipo=ausencia_tipo,
         )
         hb = a.presenca_heartbeat_em
         if hb is not None and hb.tzinfo is None:
@@ -625,7 +677,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
             PontoHojeItem(
                 atendente_id=a.id,
                 nome=a.nome,
-                esperado=esperado and not feriado_hoje,
+                esperado=bool(esperado and not feriado_hoje and not ausencia_tipo),
                 em_jornada=entrada is not None,
                 em_pausa=em_pausa_aberta(db, a.id),
                 entrada_em=entrada.registrado_em if entrada else None,
@@ -678,17 +730,22 @@ def banco_horas(
     desde: date,
     ate: date,
 ) -> PontoBancoHorasRead:
+    from app.services import ponto_ausencia as ausencia_svc
+
     if ate < desde:
         raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
     usa = escala_svc.escala_configurada(atendente)
+    ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
     dias_escala = 0
     dias_feriado = 0
     esperado = 0
     d = desde
     while d <= ate:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
-        if feriado:
-            dias_feriado += 1
+        if feriado or d in ausencias:
+            if feriado:
+                dias_feriado += 1
+            # ausência/feriado: não soma esperado
         elif usa and escala_svc.eh_dia_de_trabalho(atendente, d):
             dias_escala += 1
             esperado += escala_svc.segundos_esperados_dia(atendente, d)
@@ -717,6 +774,7 @@ JORNADA_ALERTA_HORAS = 12.0
 
 def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     from app.schemas.ponto import PontoAlertasMe
+    from app.services import ponto_ausencia as ausencia_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     exigir_acesso_ponto(atendente)
@@ -730,11 +788,13 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     horas_aberta: float | None = None
     lembrete_entrada = False
     lembrete_saida = False
+    pausa_baixa = False
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
+    ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, atendente.id, hoje)
     jornada_ativa = escala_svc.escala_configurada(atendente)
     esperado = None
-    if jornada_ativa and not feriado:
+    if jornada_ativa and not feriado and not ausencia_tipo:
         esperado = escala_svc.eh_dia_de_trabalho(atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
@@ -750,6 +810,18 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     )
     tem_entrada_hoje = any(b.tipo == "entrada" for b in bats_hoje)
     primeira = _primeira_entrada_do_dia(bats_hoje)
+
+    settings = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
+    pausa_min = int(getattr(settings, "pausa_minima_minutos", None) or 0)
+    if pausa_min > 0 and tem_entrada_hoje:
+        pausas = _segundos_pausas_do_dia(bats_hoje)
+        if _pausa_abaixo_minimo(
+            tem_entrada=True, segundos_pausa=pausas, pausa_minima_minutos=pausa_min
+        ):
+            pausa_baixa = True
+            msgs.append(
+                f"Pausa de hoje abaixo do mínimo configurado ({pausa_min} min)."
+            )
 
     hb = atendente.presenca_heartbeat_em
     if hb is not None and hb.tzinfo is None:
@@ -805,6 +877,7 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
         horas_jornada_aberta=horas_aberta,
         lembrete_entrada_tolerancia=lembrete_entrada,
         lembrete_saida_tolerancia=lembrete_saida,
+        pausa_abaixo_minimo=pausa_baixa,
         mensagens=msgs,
     )
 

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -514,10 +514,20 @@ def calendario(
         por_dia.setdefault(d, []).append(b)
 
     usa = escala_svc.escala_configurada(atendente)
+    from app.services import ponto_cobertura as cob_svc
+
+    papeis = cob_svc.mapa_papeis_periodo(db, atendente.id, desde=desde, ate=ate)
     dias_out: list[PontoCalendarioDia] = []
     for d in dias_mes:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
-        esp = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
+        esp_escala = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
+        papel = papeis.get(d)
+        if papel == "solicitante":
+            esp = False
+        elif papel == "cobertor":
+            esp = True
+        else:
+            esp = esp_escala
         bats = por_dia.get(d, [])
         te = any(b.tipo == "entrada" for b in bats)
         ts = any(b.tipo == "saida" for b in bats)
@@ -525,7 +535,7 @@ def calendario(
         intervalos = _intervalos_de_batidas(bats)
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
         esperado_visual = bool(esp and not feriado)
-        if usa and esperado_visual:
+        if (usa or papel == "cobertor") and esperado_visual:
             esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
             esperados = meta_default
@@ -534,7 +544,7 @@ def calendario(
         else:
             esperados = 0
         # Sem jornada esperada: dia com batidas compara à meta; dia vazio fica neutro
-        esperado_para_cor = esperado_visual if usa else bool(te or ts)
+        esperado_para_cor = esperado_visual if (usa or papel) else bool(te or ts)
         dias_out.append(
             PontoCalendarioDia(
                 data=d,
@@ -542,7 +552,7 @@ def calendario(
                 tem_entrada=te,
                 tem_saida=ts,
                 status=_status_dia(  # type: ignore[arg-type]
-                    usa_escala=usa,
+                    usa_escala=usa or papel == "cobertor",
                     esperado=esp,
                     tem_entrada=te,
                     tem_saida=ts,
@@ -574,6 +584,7 @@ def calendario(
 
 
 def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
+    from app.services import ponto_cobertura as cob_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     hoje = datetime.now(PONTO_TZ).date()
@@ -593,7 +604,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     itens: list[PontoHojeItem] = []
     for a in atendentes:
         usa = escala_svc.escala_configurada(a)
-        esperado = escala_svc.eh_dia_de_trabalho(a, hoje) if usa else False
+        esperado = cob_svc.eh_dia_esperado_efetivo(db, a, hoje) if not feriado_hoje else False
         entrada = _entrada_da_jornada_aberta(db, a.id)
         inicio, fim = _bounds_periodo(hoje, hoje)
         bats = (
@@ -609,7 +620,7 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
         ts = any(b.tipo == "saida" for b in bats)
         atrasado = _atrasado_entrada(a, _primeira_entrada_do_dia(bats))
         st = _status_dia(
-            usa_escala=usa,
+            usa_escala=usa or esperado,
             esperado=esperado,
             tem_entrada=te,
             tem_saida=ts,
@@ -678,9 +689,13 @@ def banco_horas(
     desde: date,
     ate: date,
 ) -> PontoBancoHorasRead:
+    from app.services import ponto_cobertura as cob_svc
+
     if ate < desde:
         raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
     usa = escala_svc.escala_configurada(atendente)
+    settings = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
+    meta_default = int(getattr(settings, "jornada_diaria_minutos", None) or 480) * 60
     dias_escala = 0
     dias_feriado = 0
     esperado = 0
@@ -689,15 +704,15 @@ def banco_horas(
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
         if feriado:
             dias_feriado += 1
-        elif usa and escala_svc.eh_dia_de_trabalho(atendente, d):
+        elif cob_svc.eh_dia_esperado_efetivo(db, atendente, d):
             dias_escala += 1
-            esperado += escala_svc.segundos_esperados_dia(atendente, d)
+            seg = escala_svc.segundos_esperados_dia(atendente, d)
+            esperado += seg if seg > 0 else meta_default
         d += timedelta(days=1)
 
     hist = historico(db, atendente, desde=desde, ate=ate, offset=0, limit=10_000)
     realizado = hist.total_segundos_fechados
-    # Sem escala: não gera débito — saldo = realizado (crédito puro)
-    if not usa:
+    if not usa and dias_escala == 0:
         esperado = 0
     return PontoBancoHorasRead(
         atendente_id=atendente.id,
@@ -732,10 +747,14 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     lembrete_saida = False
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
-    jornada_ativa = escala_svc.escala_configurada(atendente)
+    from app.services import ponto_cobertura as cob_svc
+
+    jornada_ativa = escala_svc.escala_configurada(atendente) or (
+        cob_svc.papel_cobertura_aprovada(db, atendente.id, hoje) is not None
+    )
     esperado = None
-    if jornada_ativa and not feriado:
-        esperado = escala_svc.eh_dia_de_trabalho(atendente, hoje)
+    if not feriado:
+        esperado = cob_svc.eh_dia_esperado_efetivo(db, atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
     inicio, fim = _bounds_periodo(hoje, hoje)

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -944,6 +944,8 @@ def admin_criar_batida(
     motivo: str,
     commit: bool = True,
 ) -> PontoBatida:
+    from app.services import ponto_competencia as comp_svc
+
     alvo = _atendente_do_tenant(db, admin.tenant_id, atendente_id)
     if tipo not in TIPOS_VALIDOS:
         raise HTTPException(status_code=400, detail="Tipo inválido")
@@ -953,11 +955,14 @@ def admin_criar_batida(
             status_code=400,
             detail="Informe o motivo do ajuste (mínimo 3 caracteres).",
         )
+    quando = _as_utc(registrado_em)
+    dia = _data_negocio(quando)
+    pos_fechamento = comp_svc.competencia_fechada_para_data(db, admin.tenant_id, dia)
     batida = PontoBatida(
         tenant_id=admin.tenant_id,
         atendente_id=alvo.id,
         tipo=tipo,
-        registrado_em=_as_utc(registrado_em),
+        registrado_em=quando,
         origem="admin",
         anulada=False,
     )
@@ -973,9 +978,19 @@ def admin_criar_batida(
             "motivo": motivo_limpo,
             "atendente_id": alvo.id,
             "tipo": tipo,
-            "registrado_em": _as_utc(registrado_em).isoformat(),
+            "registrado_em": quando.isoformat(),
+            "pos_fechamento": pos_fechamento,
         },
     )
+    if pos_fechamento:
+        comp_svc.invalidar_ciencias_mes(
+            db,
+            tenant_id=admin.tenant_id,
+            atendente_id=alvo.id,
+            ano=dia.year,
+            mes=dia.month,
+            motivo="Ajuste administrativo após fechamento da competência",
+        )
     if commit:
         db.commit()
         db.refresh(batida)
@@ -991,6 +1006,8 @@ def admin_atualizar_batida(
     registrado_em: datetime | None,
     motivo: str,
 ) -> PontoBatida:
+    from app.services import ponto_competencia as comp_svc
+
     batida = (
         db.query(PontoBatida)
         .filter(PontoBatida.id == batida_id, PontoBatida.tenant_id == admin.tenant_id)
@@ -1012,6 +1029,8 @@ def admin_atualizar_batida(
     if registrado_em is not None:
         batida.registrado_em = _as_utc(registrado_em)
     batida.origem = batida.origem or "admin"
+    dia = _data_negocio(batida.registrado_em)
+    pos_fechamento = comp_svc.competencia_fechada_para_data(db, admin.tenant_id, dia)
     registrar_audit(
         db,
         "ponto_batida",
@@ -1022,14 +1041,27 @@ def admin_atualizar_batida(
             "motivo": motivo_limpo,
             "antes": antes,
             "depois": {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()},
+            "pos_fechamento": pos_fechamento,
+            "atendente_id": batida.atendente_id,
         },
     )
+    if pos_fechamento:
+        comp_svc.invalidar_ciencias_mes(
+            db,
+            tenant_id=admin.tenant_id,
+            atendente_id=batida.atendente_id,
+            ano=dia.year,
+            mes=dia.month,
+            motivo="Ajuste administrativo após fechamento da competência",
+        )
     db.commit()
     db.refresh(batida)
     return batida
 
 
 def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo: str) -> PontoBatida:
+    from app.services import ponto_competencia as comp_svc
+
     batida = (
         db.query(PontoBatida)
         .filter(PontoBatida.id == batida_id, PontoBatida.tenant_id == admin.tenant_id)
@@ -1044,6 +1076,8 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
             detail="Informe o motivo da anulação (mínimo 3 caracteres).",
         )
     batida.anulada = True
+    dia = _data_negocio(batida.registrado_em)
+    pos_fechamento = comp_svc.competencia_fechada_para_data(db, admin.tenant_id, dia)
     registrar_audit(
         db,
         "ponto_batida",
@@ -1055,8 +1089,18 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
             "tipo": batida.tipo,
             "registrado_em": batida.registrado_em.isoformat(),
             "atendente_id": batida.atendente_id,
+            "pos_fechamento": pos_fechamento,
         },
     )
+    if pos_fechamento:
+        comp_svc.invalidar_ciencias_mes(
+            db,
+            tenant_id=admin.tenant_id,
+            atendente_id=batida.atendente_id,
+            ano=dia.year,
+            mes=dia.month,
+            motivo="Anulação após fechamento da competência",
+        )
     db.commit()
     db.refresh(batida)
     return batida

--- a/backend/app/services/ponto_ausencia.py
+++ b/backend/app/services/ponto_ausencia.py
@@ -1,0 +1,288 @@
+"""Ausências programadas: férias / folga (#976)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.ponto_ausencia import PontoAusencia
+from app.schemas.ponto import PontoAusenciaRead
+from app.services import ponto as ponto_svc
+
+TIPOS = frozenset({"ferias", "folga_programada"})
+ESTADOS = frozenset({"pendente", "aprovada", "rejeitada"})
+
+
+def _to_read(row: PontoAusencia) -> PontoAusenciaRead:
+    return PontoAusenciaRead(
+        id=row.id,
+        atendente_id=row.atendente_id,
+        atendente_nome=row.atendente.nome if row.atendente else None,
+        tipo=row.tipo,
+        desde=row.desde,
+        ate=row.ate,
+        motivo=row.motivo,
+        estado=row.estado,
+        origem=row.origem or "solicitacao",
+        decidido_por_id=row.decidido_por_id,
+        decidido_em=row.decidido_em,
+        decisao_motivo=row.decisao_motivo,
+        created_at=row.created_at,
+    )
+
+
+def _validar_periodo(desde: date, ate: date) -> None:
+    if ate < desde:
+        raise HTTPException(status_code=400, detail="A data final deve ser igual ou posterior à inicial.")
+    if (ate - desde).days > 366:
+        raise HTTPException(status_code=400, detail="Período máximo de 366 dias.")
+
+
+def _validar_tipo(tipo: str) -> str:
+    t = (tipo or "").strip().lower()
+    if t not in TIPOS:
+        raise HTTPException(status_code=400, detail="Tipo deve ser ferias ou folga_programada.")
+    return t
+
+
+def tipo_ausencia_aprovada_no_dia(db: Session, atendente_id: int, dia: date) -> str | None:
+    """Retorna tipo (ferias|folga_programada) se houver ausência aprovada cobrindo o dia."""
+    row = (
+        db.query(PontoAusencia)
+        .filter(
+            PontoAusencia.atendente_id == atendente_id,
+            PontoAusencia.estado == "aprovada",
+            PontoAusencia.desde <= dia,
+            PontoAusencia.ate >= dia,
+        )
+        .order_by(PontoAusencia.id.desc())
+        .first()
+    )
+    return row.tipo if row else None
+
+
+def mapa_ausencias_aprovadas(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> dict[date, str]:
+    """Mapa dia → tipo para o período (útil no calendário)."""
+    rows = (
+        db.query(PontoAusencia)
+        .filter(
+            PontoAusencia.atendente_id == atendente_id,
+            PontoAusencia.estado == "aprovada",
+            PontoAusencia.ate >= desde,
+            PontoAusencia.desde <= ate,
+        )
+        .all()
+    )
+    out: dict[date, str] = {}
+    for r in rows:
+        d = max(r.desde, desde)
+        fim = min(r.ate, ate)
+        cur = d
+        while cur <= fim:
+            out[cur] = r.tipo
+            cur = date.fromordinal(cur.toordinal() + 1)
+    return out
+
+
+def solicitar(
+    db: Session,
+    atendente: Atendente,
+    *,
+    tipo: str,
+    desde: date,
+    ate: date,
+    motivo: str | None = None,
+) -> PontoAusenciaRead:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    t = _validar_tipo(tipo)
+    _validar_periodo(desde, ate)
+    row = PontoAusencia(
+        tenant_id=atendente.tenant_id,
+        atendente_id=atendente.id,
+        tipo=t,
+        desde=desde,
+        ate=ate,
+        motivo=(motivo or "").strip()[:1000] or None,
+        estado="pendente",
+        origem="solicitacao",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "create",
+        atendente.id,
+        payload={"tipo": t, "desde": str(desde), "ate": str(ate), "estado": "pendente"},
+    )
+    db.commit()
+    db.refresh(row)
+    row = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.id == row.id)
+        .first()
+    )
+    assert row is not None
+    return _to_read(row)
+
+
+def conceder_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int,
+    tipo: str,
+    desde: date,
+    ate: date,
+    motivo: str | None = None,
+) -> PontoAusenciaRead:
+    t = _validar_tipo(tipo)
+    _validar_periodo(desde, ate)
+    alvo = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.role != "saas_ops",
+        )
+        .first()
+    )
+    if not alvo:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    agora = datetime.now(timezone.utc)
+    row = PontoAusencia(
+        tenant_id=admin.tenant_id,
+        atendente_id=alvo.id,
+        tipo=t,
+        desde=desde,
+        ate=ate,
+        motivo=(motivo or "").strip()[:1000] or "Ausência agendada pelo administrador.",
+        estado="aprovada",
+        origem="admin",
+        decidido_por_id=admin.id,
+        decidido_em=agora,
+        decisao_motivo="Agendamento direto",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "conceder",
+        admin.id,
+        payload={"atendente_id": alvo.id, "tipo": t, "desde": str(desde), "ate": str(ate)},
+    )
+    db.commit()
+    db.refresh(row)
+    row = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.id == row.id)
+        .first()
+    )
+    assert row is not None
+    return _to_read(row)
+
+
+def decidir(
+    db: Session,
+    admin: Atendente,
+    ausencia_id: int,
+    *,
+    aprovar: bool,
+    decisao_motivo: str | None = None,
+) -> PontoAusenciaRead:
+    row = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.id == ausencia_id, PontoAusencia.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Ausência não encontrada")
+    if row.estado != "pendente":
+        raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
+    row.decidido_por_id = admin.id
+    row.decidido_em = datetime.now(timezone.utc)
+    row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
+    if aprovar:
+        row.estado = "aprovada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Aprovado pelo administrador"
+    else:
+        row.estado = "rejeitada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Negado pelo administrador"
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "decidir",
+        admin.id,
+        payload={"estado": row.estado},
+    )
+    db.commit()
+    db.refresh(row)
+    return _to_read(row)
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoAusenciaRead]:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    rows = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.atendente_id == atendente.id)
+        .order_by(PontoAusencia.desde.desc(), PontoAusencia.id.desc())
+        .limit(100)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente",
+) -> list[PontoAusenciaRead]:
+    q = (
+        db.query(PontoAusencia)
+        .options(joinedload(PontoAusencia.atendente))
+        .filter(PontoAusencia.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        if estado not in ESTADOS:
+            raise HTTPException(status_code=400, detail="Estado inválido.")
+        q = q.filter(PontoAusencia.estado == estado)
+    rows = q.order_by(PontoAusencia.created_at.asc()).limit(200).all()
+    return [_to_read(r) for r in rows]
+
+
+def remover_admin(db: Session, admin: Atendente, ausencia_id: int) -> None:
+    """Remove ausência aprovada/agendada (correção)."""
+    row = (
+        db.query(PontoAusencia)
+        .filter(PontoAusencia.id == ausencia_id, PontoAusencia.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Ausência não encontrada")
+    registrar_audit(
+        db,
+        "ponto_ausencia",
+        row.id,
+        "delete",
+        admin.id,
+        payload={"tipo": row.tipo, "desde": str(row.desde), "ate": str(row.ate)},
+    )
+    db.delete(row)
+    db.commit()

--- a/backend/app/services/ponto_cobertura.py
+++ b/backend/app/services/ponto_cobertura.py
@@ -1,0 +1,384 @@
+"""Troca / cobertura de plantão (#970)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.ponto_cobertura import PontoCobertura
+from app.schemas.ponto import PontoCoberturaRead
+from app.services import escala as escala_svc
+from app.services import ponto as ponto_svc
+
+ESTADOS = frozenset(
+    {"pendente_cobertor", "pendente_admin", "aprovada", "rejeitada", "cancelada"}
+)
+
+
+def _to_read(row: PontoCobertura) -> PontoCoberturaRead:
+    return PontoCoberturaRead(
+        id=row.id,
+        solicitante_id=row.solicitante_id,
+        solicitante_nome=row.solicitante.nome if row.solicitante else None,
+        cobertor_id=row.cobertor_id,
+        cobertor_nome=row.cobertor.nome if row.cobertor else None,
+        data_ref=row.data_ref,
+        motivo=row.motivo,
+        estado=row.estado,
+        origem=row.origem or "solicitacao",
+        resposta_cobertor=row.resposta_cobertor,
+        respondido_em=row.respondido_em,
+        decidido_por_id=row.decidido_por_id,
+        decidido_em=row.decidido_em,
+        decisao_motivo=row.decisao_motivo,
+        created_at=row.created_at,
+    )
+
+
+def _carregar(db: Session, cobertura_id: int) -> PontoCobertura:
+    row = (
+        db.query(PontoCobertura)
+        .options(
+            joinedload(PontoCobertura.solicitante),
+            joinedload(PontoCobertura.cobertor),
+        )
+        .filter(PontoCobertura.id == cobertura_id)
+        .first()
+    )
+    assert row is not None
+    return row
+
+
+def papel_cobertura_aprovada(db: Session, atendente_id: int, dia: date) -> str | None:
+    """Retorna 'solicitante' | 'cobertor' se houver cobertura aprovada no dia."""
+    row = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.estado == "aprovada",
+            PontoCobertura.data_ref == dia,
+            or_(
+                PontoCobertura.solicitante_id == atendente_id,
+                PontoCobertura.cobertor_id == atendente_id,
+            ),
+        )
+        .order_by(PontoCobertura.id.desc())
+        .first()
+    )
+    if not row:
+        return None
+    if row.solicitante_id == atendente_id:
+        return "solicitante"
+    return "cobertor"
+
+
+def eh_dia_esperado_efetivo(db: Session, atendente: Atendente, dia: date) -> bool:
+    """Dia esperado após coberturas aprovadas (#970)."""
+    papel = papel_cobertura_aprovada(db, atendente.id, dia)
+    if papel == "solicitante":
+        return False
+    if papel == "cobertor":
+        return True
+    if not escala_svc.escala_configurada(atendente):
+        return False
+    return escala_svc.eh_dia_de_trabalho(atendente, dia)
+
+
+def mapa_papeis_periodo(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> dict[date, str]:
+    rows = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.estado == "aprovada",
+            PontoCobertura.data_ref >= desde,
+            PontoCobertura.data_ref <= ate,
+            or_(
+                PontoCobertura.solicitante_id == atendente_id,
+                PontoCobertura.cobertor_id == atendente_id,
+            ),
+        )
+        .all()
+    )
+    out: dict[date, str] = {}
+    for r in rows:
+        out[r.data_ref] = "solicitante" if r.solicitante_id == atendente_id else "cobertor"
+    return out
+
+
+def _atendente_tenant(db: Session, tenant_id: int, atendente_id: int) -> Atendente:
+    a = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == tenant_id,
+            Atendente.role != "saas_ops",
+            Atendente.ativo.is_(True),
+        )
+        .first()
+    )
+    if not a:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    return a
+
+
+def solicitar(
+    db: Session,
+    solicitante: Atendente,
+    *,
+    cobertor_id: int,
+    data_ref: date,
+    motivo: str | None = None,
+) -> PontoCoberturaRead:
+    ponto_svc.exigir_acesso_ponto(solicitante)
+    if cobertor_id == solicitante.id:
+        raise HTTPException(status_code=400, detail="Escolha outro colaborador para cobrir.")
+    cobertor = _atendente_tenant(db, solicitante.tenant_id, cobertor_id)
+    if data_ref < date.today():
+        raise HTTPException(status_code=400, detail="A data da cobertura deve ser hoje ou futura.")
+    existente = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.tenant_id == solicitante.tenant_id,
+            PontoCobertura.data_ref == data_ref,
+            PontoCobertura.estado.in_(("pendente_cobertor", "pendente_admin", "aprovada")),
+            or_(
+                PontoCobertura.solicitante_id.in_((solicitante.id, cobertor.id)),
+                PontoCobertura.cobertor_id.in_((solicitante.id, cobertor.id)),
+            ),
+        )
+        .first()
+    )
+    if existente:
+        raise HTTPException(
+            status_code=400,
+            detail="Já existe cobertura pendente ou aprovada envolvendo estes colaboradores nesta data.",
+        )
+    row = PontoCobertura(
+        tenant_id=solicitante.tenant_id,
+        solicitante_id=solicitante.id,
+        cobertor_id=cobertor.id,
+        data_ref=data_ref,
+        motivo=(motivo or "").strip()[:1000] or None,
+        estado="pendente_cobertor",
+        origem="solicitacao",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "create",
+        solicitante.id,
+        payload={
+            "cobertor_id": cobertor.id,
+            "data_ref": str(data_ref),
+            "estado": "pendente_cobertor",
+        },
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def responder_cobertor(
+    db: Session,
+    cobertor: Atendente,
+    cobertura_id: int,
+    *,
+    aceitar: bool,
+) -> PontoCoberturaRead:
+    ponto_svc.exigir_acesso_ponto(cobertor)
+    row = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.id == cobertura_id,
+            PontoCobertura.tenant_id == cobertor.tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Cobertura não encontrada")
+    if row.cobertor_id != cobertor.id:
+        raise HTTPException(status_code=403, detail="Só o cobertor pode responder este pedido.")
+    if row.estado != "pendente_cobertor":
+        raise HTTPException(status_code=400, detail="Este pedido já foi respondido.")
+    row.respondido_em = datetime.now(timezone.utc)
+    if aceitar:
+        row.resposta_cobertor = "aceita"
+        row.estado = "pendente_admin"
+    else:
+        row.resposta_cobertor = "recusa"
+        row.estado = "rejeitada"
+        row.decisao_motivo = "Recusado pelo cobertor"
+        row.decidido_em = row.respondido_em
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "responder_cobertor",
+        cobertor.id,
+        payload={"aceitar": aceitar, "estado": row.estado},
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def decidir_admin(
+    db: Session,
+    admin: Atendente,
+    cobertura_id: int,
+    *,
+    aprovar: bool,
+    decisao_motivo: str | None = None,
+) -> PontoCoberturaRead:
+    row = (
+        db.query(PontoCobertura)
+        .filter(
+            PontoCobertura.id == cobertura_id,
+            PontoCobertura.tenant_id == admin.tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Cobertura não encontrada")
+    if row.estado not in ("pendente_admin", "pendente_cobertor"):
+        raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
+    row.decidido_por_id = admin.id
+    row.decidido_em = datetime.now(timezone.utc)
+    row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
+    if aprovar:
+        row.estado = "aprovada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Homologado pelo administrador"
+        if row.resposta_cobertor is None:
+            row.resposta_cobertor = "aceita"
+            row.respondido_em = row.decidido_em
+    else:
+        row.estado = "rejeitada"
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Negado pelo administrador"
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "decidir",
+        admin.id,
+        payload={"estado": row.estado},
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def conceder_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    solicitante_id: int,
+    cobertor_id: int,
+    data_ref: date,
+    motivo: str | None = None,
+) -> PontoCoberturaRead:
+    if solicitante_id == cobertor_id:
+        raise HTTPException(status_code=400, detail="Solicitante e cobertor devem ser diferentes.")
+    sol = _atendente_tenant(db, admin.tenant_id, solicitante_id)
+    cob = _atendente_tenant(db, admin.tenant_id, cobertor_id)
+    agora = datetime.now(timezone.utc)
+    row = PontoCobertura(
+        tenant_id=admin.tenant_id,
+        solicitante_id=sol.id,
+        cobertor_id=cob.id,
+        data_ref=data_ref,
+        motivo=(motivo or "").strip()[:1000] or "Cobertura agendada pelo administrador.",
+        estado="aprovada",
+        origem="admin",
+        resposta_cobertor="aceita",
+        respondido_em=agora,
+        decidido_por_id=admin.id,
+        decidido_em=agora,
+        decisao_motivo="Agendamento direto",
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_cobertura",
+        row.id,
+        "conceder",
+        admin.id,
+        payload={
+            "solicitante_id": sol.id,
+            "cobertor_id": cob.id,
+            "data_ref": str(data_ref),
+        },
+    )
+    db.commit()
+    return _to_read(_carregar(db, row.id))
+
+
+def listar_colegas(db: Session, atendente: Atendente) -> list[dict]:
+    """Colaboradores ativos do tenant (exceto eu) para pedir cobertura."""
+    ponto_svc.exigir_acesso_ponto(atendente)
+    rows = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == atendente.tenant_id,
+            Atendente.id != atendente.id,
+            Atendente.ativo.is_(True),
+            Atendente.role != "saas_ops",
+        )
+        .order_by(Atendente.nome.asc())
+        .limit(200)
+        .all()
+    )
+    return [{"id": a.id, "nome": a.nome} for a in rows]
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoCoberturaRead]:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    rows = (
+        db.query(PontoCobertura)
+        .options(
+            joinedload(PontoCobertura.solicitante),
+            joinedload(PontoCobertura.cobertor),
+        )
+        .filter(
+            or_(
+                PontoCobertura.solicitante_id == atendente.id,
+                PontoCobertura.cobertor_id == atendente.id,
+            )
+        )
+        .order_by(PontoCobertura.data_ref.desc(), PontoCobertura.id.desc())
+        .limit(100)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente_admin",
+) -> list[PontoCoberturaRead]:
+    q = (
+        db.query(PontoCobertura)
+        .options(
+            joinedload(PontoCobertura.solicitante),
+            joinedload(PontoCobertura.cobertor),
+        )
+        .filter(PontoCobertura.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        if estado == "pendente":
+            q = q.filter(PontoCobertura.estado.in_(("pendente_cobertor", "pendente_admin")))
+        else:
+            if estado not in ESTADOS:
+                raise HTTPException(status_code=400, detail="Estado inválido.")
+            q = q.filter(PontoCobertura.estado == estado)
+    rows = q.order_by(PontoCobertura.created_at.asc()).limit(200).all()
+    return [_to_read(r) for r in rows]

--- a/backend/app/services/ponto_competencia.py
+++ b/backend/app/services/ponto_competencia.py
@@ -1,0 +1,427 @@
+"""Setup checklist (#981), competência (#978) e ciência do espelho (#979)."""
+
+from __future__ import annotations
+
+from calendar import monthrange
+from datetime import date, datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.core.auth import ROLES_ATENDENTE
+from app.models.atendente import Atendente
+from app.models.ponto_competencia import PontoCompetencia, PontoEspelhoCiencia
+from app.models.ponto_settings import PontoLocal
+from app.schemas.ponto import (
+    PontoCienciaItem,
+    PontoCienciaMe,
+    PontoCompetenciaRead,
+    PontoSetupItem,
+    PontoSetupStatus,
+)
+from app.services import ponto as ponto_svc
+from app.services import ponto_settings as ponto_settings_svc
+from app.services.escala import escala_configurada
+
+
+def _validar_ano_mes(ano: int, mes: int) -> None:
+    if ano < 2000 or ano > 2100 or mes < 1 or mes > 12:
+        raise HTTPException(status_code=400, detail="Competência inválida (ano/mês).")
+
+
+def competencia_fechada(db: Session, tenant_id: int, *, ano: int, mes: int) -> bool:
+    row = (
+        db.query(PontoCompetencia)
+        .filter(
+            PontoCompetencia.tenant_id == tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+            PontoCompetencia.fechada.is_(True),
+        )
+        .first()
+    )
+    return row is not None
+
+
+def competencia_fechada_para_data(db: Session, tenant_id: int, dia: date) -> bool:
+    return competencia_fechada(db, tenant_id, ano=dia.year, mes=dia.month)
+
+
+def setup_status(db: Session, admin: Atendente) -> PontoSetupStatus:
+    st = ponto_settings_svc.get_or_create_settings(db, admin.tenant_id)
+    ativos = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role.in_(tuple(ROLES_ATENDENTE)),
+        )
+        .all()
+    )
+    sem_jornada = sum(1 for a in ativos if not escala_configurada(a))
+    locais_ativos = (
+        db.query(PontoLocal)
+        .filter(
+            PontoLocal.tenant_id == admin.tenant_id,
+            PontoLocal.ativo.is_(True),
+            PontoLocal.atendente_id.isnot(None),
+        )
+        .count()
+    )
+    itens: list[PontoSetupItem] = []
+    if sem_jornada > 0:
+        itens.append(
+            PontoSetupItem(
+                codigo="jornada_colaboradores",
+                titulo="Configure a jornada dos colaboradores",
+                detalhe=f"{sem_jornada} colaborador(es) ainda sem jornada (modo nenhum).",
+                destino="cadastro_atendentes",
+                ok=False,
+            )
+        )
+    else:
+        itens.append(
+            PontoSetupItem(
+                codigo="jornada_colaboradores",
+                titulo="Jornada dos colaboradores",
+                detalhe="Todos os ativos têm jornada configurada.",
+                destino="cadastro_atendentes",
+                ok=True,
+            )
+        )
+
+    itens.append(
+        PontoSetupItem(
+            codigo="fecho_automatico",
+            titulo="Revise o fecho automático",
+            detalhe=(
+                "Fecho automático ativo."
+                if st.fecho_automatico_ativo
+                else "Fecho por esquecimento está desligado (padrão até o admin ativar)."
+            ),
+            destino="ponto_settings",
+            ok=True,  # informativo; não bloqueia
+            informativo=True,
+        )
+    )
+    itens.append(
+        PontoSetupItem(
+            codigo="feriados",
+            titulo="Feriados",
+            detalhe=(
+                "Feriados nacionais ligados."
+                if st.usar_feriados_nacionais
+                else "Feriados nacionais desligados — confira feriados custom."
+            ),
+            destino="ponto_feriados",
+            ok=True,
+            informativo=True,
+        )
+    )
+    if st.politica_geolocalizacao != "opcional" and locais_ativos == 0:
+        itens.append(
+            PontoSetupItem(
+                codigo="locais_geo",
+                titulo="Locais de geolocalização",
+                detalhe="Política de geo exige locais, mas nenhum local ativo está vinculado a colaboradores.",
+                destino="cadastro_atendentes",
+                ok=False,
+            )
+        )
+    else:
+        itens.append(
+            PontoSetupItem(
+                codigo="locais_geo",
+                titulo="Locais de geolocalização",
+                detalhe=(
+                    f"Política: {st.politica_geolocalizacao}; {locais_ativos} local(is) ativo(s)."
+                ),
+                destino="cadastro_atendentes",
+                ok=True,
+                informativo=st.politica_geolocalizacao == "opcional",
+            )
+        )
+
+    pendentes = sum(1 for i in itens if not i.ok)
+    return PontoSetupStatus(
+        defaults_fecho_off=not st.fecho_automatico_ativo,
+        tolerancia_sugerida_minutos=15,
+        pendentes=pendentes,
+        itens=itens,
+    )
+
+
+def _to_comp_read(row: PontoCompetencia) -> PontoCompetenciaRead:
+    return PontoCompetenciaRead(
+        id=row.id,
+        ano=row.ano,
+        mes=row.mes,
+        fechada=row.fechada,
+        fechado_em=row.fechado_em,
+        fechado_por_id=row.fechado_por_id,
+        fechado_por_nome=row.fechado_por.nome if row.fechado_por else None,
+        reaberto_em=row.reaberto_em,
+        reaberto_por_id=row.reaberto_por_id,
+        reabrir_motivo=row.reabrir_motivo,
+    )
+
+
+def _get_or_create_comp(db: Session, tenant_id: int, ano: int, mes: int) -> PontoCompetencia:
+    row = (
+        db.query(PontoCompetencia)
+        .filter(
+            PontoCompetencia.tenant_id == tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+        )
+        .first()
+    )
+    if row:
+        return row
+    row = PontoCompetencia(tenant_id=tenant_id, ano=ano, mes=mes, fechada=False)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def obter_competencia(db: Session, admin: Atendente, *, ano: int, mes: int) -> PontoCompetenciaRead:
+    _validar_ano_mes(ano, mes)
+    row = (
+        db.query(PontoCompetencia)
+        .options(joinedload(PontoCompetencia.fechado_por))
+        .filter(
+            PontoCompetencia.tenant_id == admin.tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+        )
+        .first()
+    )
+    if not row:
+        return PontoCompetenciaRead(id=0, ano=ano, mes=mes, fechada=False)
+    return _to_comp_read(row)
+
+
+def fechar_competencia(db: Session, admin: Atendente, *, ano: int, mes: int) -> PontoCompetenciaRead:
+    _validar_ano_mes(ano, mes)
+    row = _get_or_create_comp(db, admin.tenant_id, ano, mes)
+    if row.fechada:
+        raise HTTPException(status_code=400, detail="Esta competência já está fechada.")
+    agora = datetime.now(timezone.utc)
+    row.fechada = True
+    row.fechado_em = agora
+    row.fechado_por_id = admin.id
+    row.reaberto_em = None
+    row.reaberto_por_id = None
+    row.reabrir_motivo = None
+    registrar_audit(
+        db,
+        "ponto_competencia",
+        row.id,
+        "fechar",
+        admin.id,
+        payload={"ano": ano, "mes": mes},
+    )
+    db.commit()
+    return obter_competencia(db, admin, ano=ano, mes=mes)
+
+
+def reabrir_competencia(
+    db: Session,
+    admin: Atendente,
+    *,
+    ano: int,
+    mes: int,
+    motivo: str,
+) -> PontoCompetenciaRead:
+    _validar_ano_mes(ano, mes)
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(status_code=400, detail="Informe o motivo da reabertura (mín. 3 caracteres).")
+    row = (
+        db.query(PontoCompetencia)
+        .filter(
+            PontoCompetencia.tenant_id == admin.tenant_id,
+            PontoCompetencia.ano == ano,
+            PontoCompetencia.mes == mes,
+        )
+        .first()
+    )
+    if not row or not row.fechada:
+        raise HTTPException(status_code=400, detail="Competência não está fechada.")
+    row.fechada = False
+    row.reaberto_em = datetime.now(timezone.utc)
+    row.reaberto_por_id = admin.id
+    row.reabrir_motivo = motivo_limpo[:1000]
+    registrar_audit(
+        db,
+        "ponto_competencia",
+        row.id,
+        "reabrir",
+        admin.id,
+        payload={"ano": ano, "mes": mes, "motivo": motivo_limpo},
+    )
+    db.commit()
+    return obter_competencia(db, admin, ano=ano, mes=mes)
+
+
+def listar_competencias(db: Session, admin: Atendente, *, ano: int | None = None) -> list[PontoCompetenciaRead]:
+    q = (
+        db.query(PontoCompetencia)
+        .options(joinedload(PontoCompetencia.fechado_por))
+        .filter(PontoCompetencia.tenant_id == admin.tenant_id)
+    )
+    if ano is not None:
+        q = q.filter(PontoCompetencia.ano == ano)
+    rows = q.order_by(PontoCompetencia.ano.desc(), PontoCompetencia.mes.desc()).limit(36).all()
+    return [_to_comp_read(r) for r in rows]
+
+
+def invalidar_ciencias_mes(
+    db: Session,
+    *,
+    tenant_id: int,
+    atendente_id: int,
+    ano: int,
+    mes: int,
+    motivo: str,
+) -> None:
+    row = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == tenant_id,
+            PontoEspelhoCiencia.atendente_id == atendente_id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+            PontoEspelhoCiencia.ativa.is_(True),
+        )
+        .first()
+    )
+    if not row:
+        return
+    row.ativa = False
+    row.invalidada_em = datetime.now(timezone.utc)
+    row.invalidada_motivo = motivo[:500]
+
+
+def confirmar_ciencia(db: Session, atendente: Atendente, *, ano: int, mes: int) -> PontoCienciaMe:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    _validar_ano_mes(ano, mes)
+    if not competencia_fechada(db, atendente.tenant_id, ano=ano, mes=mes):
+        raise HTTPException(
+            status_code=400,
+            detail="Só é possível confirmar ciência após o admin fechar a competência do mês.",
+        )
+    existente = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == atendente.tenant_id,
+            PontoEspelhoCiencia.atendente_id == atendente.id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+        )
+        .first()
+    )
+    agora = datetime.now(timezone.utc)
+    if existente and existente.ativa:
+        raise HTTPException(status_code=400, detail="Ciência deste mês já confirmada.")
+    if existente:
+        existente.ativa = True
+        existente.confirmado_em = agora
+        existente.invalidada_em = None
+        existente.invalidada_motivo = None
+        row = existente
+    else:
+        row = PontoEspelhoCiencia(
+            tenant_id=atendente.tenant_id,
+            atendente_id=atendente.id,
+            ano=ano,
+            mes=mes,
+            confirmado_em=agora,
+            ativa=True,
+        )
+        db.add(row)
+        db.flush()
+    registrar_audit(
+        db,
+        "ponto_espelho_ciencia",
+        row.id,
+        "confirmar",
+        atendente.id,
+        payload={"ano": ano, "mes": mes, "confirmado_em": agora.isoformat()},
+    )
+    db.commit()
+    return ciencia_me(db, atendente, ano=ano, mes=mes)
+
+
+def ciencia_me(db: Session, atendente: Atendente, *, ano: int, mes: int) -> PontoCienciaMe:
+    ponto_svc.exigir_acesso_ponto(atendente)
+    _validar_ano_mes(ano, mes)
+    fechada = competencia_fechada(db, atendente.tenant_id, ano=ano, mes=mes)
+    row = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == atendente.tenant_id,
+            PontoEspelhoCiencia.atendente_id == atendente.id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+        )
+        .first()
+    )
+    return PontoCienciaMe(
+        ano=ano,
+        mes=mes,
+        competencia_fechada=fechada,
+        confirmada=bool(row and row.ativa),
+        confirmado_em=row.confirmado_em if row and row.ativa else None,
+        pode_confirmar=fechada and not (row and row.ativa),
+    )
+
+
+def listar_ciencias_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    ano: int,
+    mes: int,
+) -> list[PontoCienciaItem]:
+    _validar_ano_mes(ano, mes)
+    ativos = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role.in_(tuple(ROLES_ATENDENTE)),
+        )
+        .order_by(Atendente.nome.asc())
+        .all()
+    )
+    rows = (
+        db.query(PontoEspelhoCiencia)
+        .filter(
+            PontoEspelhoCiencia.tenant_id == admin.tenant_id,
+            PontoEspelhoCiencia.ano == ano,
+            PontoEspelhoCiencia.mes == mes,
+            PontoEspelhoCiencia.ativa.is_(True),
+        )
+        .all()
+    )
+    por_id = {r.atendente_id: r for r in rows}
+    out: list[PontoCienciaItem] = []
+    for a in ativos:
+        c = por_id.get(a.id)
+        out.append(
+            PontoCienciaItem(
+                atendente_id=a.id,
+                atendente_nome=a.nome,
+                confirmada=c is not None,
+                confirmado_em=c.confirmado_em if c else None,
+            )
+        )
+    return out
+
+
+def periodo_competencia(ano: int, mes: int) -> tuple[date, date]:
+    _validar_ano_mes(ano, mes)
+    ultimo = monthrange(ano, mes)[1]
+    return date(ano, mes, 1), date(ano, mes, ultimo)

--- a/backend/app/services/ponto_folha.py
+++ b/backend/app/services/ponto_folha.py
@@ -1,0 +1,204 @@
+"""Export contábil / template folha RH (#975)."""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date, timedelta
+
+from fastapi import HTTPException
+from openpyxl import Workbook
+from sqlalchemy.orm import Session
+
+from app.core.auth import ROLES_ATENDENTE
+from app.models.atendente import Atendente
+from app.models.audit_log import AuditLog
+from app.models.ponto_batida import PontoBatida
+from app.services import escala as escala_svc
+from app.services import ponto as ponto_svc
+from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_settings as ponto_settings_svc
+from app.services.ponto_relatorio import _coletar_ajustes_audit, _rotulo_acao_ajuste
+
+COLUNAS = [
+    "matricula",
+    "nome",
+    "email",
+    "desde",
+    "ate",
+    "dias_escala",
+    "dias_feriado",
+    "previsto_horas",
+    "realizado_horas",
+    "banco_horas",
+    "atrasos",
+    "faltas",
+    "he_minutos",
+    "ajustes",
+]
+
+
+def _segundos_para_horas(seg: int) -> str:
+    return f"{(seg / 3600.0):.2f}".replace(".", ",")
+
+
+def _atendentes_folha(
+    db: Session, admin: Atendente, *, atendente_id: int | None
+) -> list[Atendente]:
+    q = db.query(Atendente).filter(
+        Atendente.tenant_id == admin.tenant_id,
+        Atendente.ativo.is_(True),
+        Atendente.role.in_(tuple(ROLES_ATENDENTE)),
+    )
+    if atendente_id is not None:
+        q = q.filter(Atendente.id == atendente_id)
+    return q.order_by(Atendente.nome.asc()).all()
+
+
+def _ajustes_por_atendente(ajustes: list[AuditLog]) -> dict[int, int]:
+    contagem: dict[int, int] = {}
+    for a in ajustes:
+        payload = a.payload if isinstance(getattr(a, "payload", None), dict) else {}
+        if not isinstance(payload, dict):
+            continue
+        aid = payload.get("atendente_id")
+        if aid is None:
+            continue
+        try:
+            aid_i = int(aid)
+        except (TypeError, ValueError):
+            continue
+        contagem[aid_i] = contagem.get(aid_i, 0) + 1
+    return contagem
+
+
+def _linha_folha(
+    db: Session,
+    atendente: Atendente,
+    *,
+    desde: date,
+    ate: date,
+    ajustes_n: int,
+) -> dict:
+    bh = ponto_svc.banco_horas(db, atendente, desde=desde, ate=ate)
+    faltas = 0
+    atrasos = 0
+    d = desde
+    usa = escala_svc.escala_configurada(atendente)
+    while d <= ate:
+        feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
+        esp = cob_svc.eh_dia_esperado_efetivo(db, atendente, d) if not feriado else False
+        ini, fim = ponto_svc._bounds_periodo(d, d)
+        bats = (
+            ponto_svc._q_ativas(db)
+            .filter(
+                PontoBatida.atendente_id == atendente.id,
+                PontoBatida.registrado_em >= ini,
+                PontoBatida.registrado_em < fim,
+            )
+            .all()
+        )
+        te = any(b.tipo == "entrada" for b in bats)
+        ts = any(b.tipo == "saida" for b in bats)
+        atrasado = ponto_svc._atrasado_entrada(atendente, ponto_svc._primeira_entrada_do_dia(bats))
+        st = ponto_svc._status_dia(
+            usa_escala=usa or esp,
+            esperado=esp,
+            tem_entrada=te,
+            tem_saida=ts,
+            feriado=feriado,
+            atrasado=atrasado,
+        )
+        if st == "falta":
+            faltas += 1
+        if atrasado or st == "atraso":
+            atrasos += 1
+        d += timedelta(days=1)
+
+    he = ponto_svc._he_minutos_periodo(db, atendente, desde=desde, ate=ate)
+    return {
+        "matricula": str(atendente.id),
+        "nome": atendente.nome,
+        "email": atendente.email or "",
+        "desde": desde.isoformat(),
+        "ate": ate.isoformat(),
+        "dias_escala": bh.dias_escala,
+        "dias_feriado": bh.dias_feriado,
+        "previsto_horas": _segundos_para_horas(bh.segundos_esperados),
+        "realizado_horas": _segundos_para_horas(bh.segundos_realizados),
+        "banco_horas": _segundos_para_horas(bh.saldo_segundos),
+        "atrasos": atrasos,
+        "faltas": faltas,
+        "he_minutos": he,
+        "ajustes": ajustes_n,
+    }
+
+
+def coletar_linhas(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date,
+    ate: date,
+) -> list[dict]:
+    if ate < desde:
+        raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
+    ajustes = _coletar_ajustes_audit(db, admin, desde=desde, ate=ate)
+    por_at = _ajustes_por_atendente(ajustes)
+    return [
+        _linha_folha(db, a, desde=desde, ate=ate, ajustes_n=por_at.get(a.id, 0))
+        for a in _atendentes_folha(db, admin, atendente_id=atendente_id)
+    ]
+
+
+def export_folha_csv(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date,
+    ate: date,
+) -> str:
+    linhas = coletar_linhas(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    buf = io.StringIO()
+    buf.write("\ufeff")
+    w = csv.DictWriter(buf, fieldnames=COLUNAS, delimiter=";")
+    w.writeheader()
+    for row in linhas:
+        w.writerow(row)
+    return buf.getvalue()
+
+
+def export_folha_xlsx(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date,
+    ate: date,
+) -> bytes:
+    linhas = coletar_linhas(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Folha"
+    ws.append(COLUNAS)
+    for row in linhas:
+        ws.append([row[c] for c in COLUNAS])
+    ws2 = wb.create_sheet("Ajustes")
+    ws2.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Payload"])
+    for a in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
+        payload = a.payload if isinstance(getattr(a, "payload", None), dict) else {}
+        ws2.append(
+            [
+                a.created_at.isoformat() if a.created_at else "",
+                a.atendente.nome if a.atendente else "",
+                _rotulo_acao_ajuste(a.action),
+                a.entity_id,
+                (payload or {}).get("motivo") or "",
+                str(payload or ""),
+            ]
+        )
+    out = io.BytesIO()
+    wb.save(out)
+    return out.getvalue()

--- a/backend/app/services/ponto_hora_extra.py
+++ b/backend/app/services/ponto_hora_extra.py
@@ -1,8 +1,8 @@
-"""Hora extra e bloqueio de pegar WhatsApp após jornada (#965)."""
+"""Hora extra WhatsApp após jornada (#965) + antecipada/teto (#966)."""
 
 from __future__ import annotations
 
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session, joinedload
@@ -14,7 +14,7 @@ from app.schemas.ponto import PontoHoraExtraRead
 from app.services import escala as escala_svc
 from app.services.escala import PONTO_TZ
 
-MODOS_APROVACAO = frozenset({"resto_do_dia", "ate_horario"})
+MODOS_APROVACAO = frozenset({"resto_do_dia", "ate_horario", "duracao"})
 
 
 def _agora_tz(when: datetime | None = None) -> datetime:
@@ -36,7 +36,6 @@ def fora_da_jornada(atendente: Atendente, when: datetime | None = None) -> bool:
     saida = escala_svc.saida_prevista_em(atendente, dia)
     if saida is not None:
         return agora >= saida
-    # Ciclo sem pe/ps: fora do bloco de trabalho.
     return not escala_svc.em_periodo_trabalho(atendente, agora)
 
 
@@ -57,8 +56,8 @@ def he_ativa(db: Session, atendente: Atendente, when: datetime | None = None) ->
         return None
     ate = row.ate_em
     if ate.tzinfo is None:
-        ate = ate.replace(tzinfo=PONTO_TZ)
-    if agora >= ate.astimezone(PONTO_TZ):
+        ate = ate.replace(tzinfo=timezone.utc)
+    if agora.astimezone(timezone.utc) >= ate.astimezone(timezone.utc):
         row.estado = "expirada"
         db.flush()
         return None
@@ -99,11 +98,83 @@ def _to_read(row: PontoHoraExtra) -> PontoHoraExtraRead:
         motivo=row.motivo,
         modo=row.modo,
         ate_em=row.ate_em,
+        origem=getattr(row, "origem", None) or "solicitacao",
         decidido_por_id=row.decidido_por_id,
         decidido_em=row.decidido_em,
         decisao_motivo=row.decisao_motivo,
         created_at=row.created_at,
     )
+
+
+def _teto_minutos(atendente: Atendente) -> int | None:
+    raw = getattr(atendente, "he_teto_minutos", None)
+    if raw is None:
+        return None
+    v = int(raw)
+    return v if v > 0 else None
+
+
+def _aplicar_teto(atendente: Atendente, agora: datetime, ate: datetime) -> datetime:
+    teto = _teto_minutos(atendente)
+    if teto is None:
+        return ate
+    limite = agora + timedelta(minutes=teto)
+    final = min(ate, limite)
+    if final <= agora:
+        raise HTTPException(
+            status_code=400,
+            detail=f"O teto de hora extra deste colaborador é de {teto} min — ajuste o horário ou o teto.",
+        )
+    return final
+
+
+def _calcular_ate_em(
+    atendente: Atendente,
+    agora: datetime,
+    *,
+    modo: str,
+    ate_horario: str | None,
+    duracao_minutos: int | None,
+) -> datetime:
+    m = (modo or "").strip().lower()
+    if m not in MODOS_APROVACAO:
+        raise HTTPException(
+            status_code=400,
+            detail="Escolha modo resto_do_dia, ate_horario ou duracao.",
+        )
+    if m == "resto_do_dia":
+        ate = _fim_resto_do_dia(agora)
+    elif m == "ate_horario":
+        ate = _parse_ate_horario(agora.date(), ate_horario or "")
+        if ate <= agora:
+            raise HTTPException(
+                status_code=400,
+                detail="O horário limite da hora extra deve ser no futuro.",
+            )
+    else:
+        mins = int(duracao_minutos or 0)
+        if mins < 15 or mins > 24 * 60:
+            raise HTTPException(
+                status_code=400,
+                detail="Informe a duração em minutos (entre 15 e 1440).",
+            )
+        ate = agora + timedelta(minutes=mins)
+    return _aplicar_teto(atendente, agora, ate).astimezone(timezone.utc)
+
+
+def _expirar_aprovadas_anteriores(db: Session, atendente_id: int) -> None:
+    agora_utc = datetime.now(timezone.utc)
+    rows = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == atendente_id, PontoHoraExtra.estado == "aprovada")
+        .all()
+    )
+    for r in rows:
+        r.estado = "expirada"
+        if r.ate_em is None or (
+            (r.ate_em if r.ate_em.tzinfo else r.ate_em.replace(tzinfo=timezone.utc)) > agora_utc
+        ):
+            r.ate_em = agora_utc
 
 
 def garantir_pedido_pendente(
@@ -133,6 +204,7 @@ def garantir_pedido_pendente(
         tenant_id=atendente.tenant_id,
         atendente_id=atendente.id,
         estado="pendente",
+        origem="solicitacao",
         motivo=(motivo or "Pedido de hora extra para atendimento WhatsApp.")[:1000],
     )
     db.add(row)
@@ -143,7 +215,7 @@ def garantir_pedido_pendente(
         row.id,
         "create",
         atendente.id,
-        payload={"estado": "pendente"},
+        payload={"estado": "pendente", "origem": "solicitacao"},
     )
     if commit:
         db.commit()
@@ -166,15 +238,13 @@ def solicitar(
     if he_ativa(db, atendente):
         raise HTTPException(status_code=400, detail="Você já tem hora extra ativa.")
     row = garantir_pedido_pendente(db, atendente, motivo=motivo, commit=True)
-    db.refresh(row)
-    if row.atendente is None:
-        row = (
-            db.query(PontoHoraExtra)
-            .options(joinedload(PontoHoraExtra.atendente))
-            .filter(PontoHoraExtra.id == row.id)
-            .first()
-        )
-        assert row is not None
+    row = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.id == row.id)
+        .first()
+    )
+    assert row is not None
     return _to_read(row)
 
 
@@ -216,11 +286,20 @@ def me_status(db: Session, atendente: Atendente) -> dict:
         .order_by(PontoHoraExtra.id.desc())
         .first()
     )
+    restante = None
+    if ativa and ativa.ate_em is not None:
+        agora = _agora_tz()
+        ate = ativa.ate_em
+        if ate.tzinfo is None:
+            ate = ate.replace(tzinfo=timezone.utc)
+        restante = max(0, int((ate.astimezone(PONTO_TZ) - agora).total_seconds() // 60))
     return {
         "fora_da_jornada": fora,
         "pode_pegar_whatsapp": (not fora) or ativa is not None,
         "he_ativa": _to_read(ativa) if ativa else None,
         "pedido_pendente": _to_read(pendente) if pendente else None,
+        "he_teto_minutos": _teto_minutos(atendente),
+        "he_restante_minutos": restante,
     }
 
 
@@ -250,6 +329,7 @@ def decidir(
     aprovar: bool,
     modo: str | None = None,
     ate_horario: str | None = None,
+    duracao_minutos: int | None = None,
     decisao_motivo: str | None = None,
 ) -> PontoHoraExtraRead:
     row = (
@@ -263,6 +343,8 @@ def decidir(
     if row.estado != "pendente":
         raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
     agora = _agora_tz()
+    alvo = row.atendente
+    assert alvo is not None
     row.decidido_por_id = admin.id
     row.decidido_em = datetime.now(timezone.utc)
     row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
@@ -272,23 +354,13 @@ def decidir(
         row.ate_em = None
     else:
         m = (modo or "").strip().lower()
-        if m not in MODOS_APROVACAO:
-            raise HTTPException(
-                status_code=400,
-                detail="Ao aprovar, escolha modo resto_do_dia ou ate_horario.",
-            )
+        ate = _calcular_ate_em(
+            alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+        )
+        _expirar_aprovadas_anteriores(db, alvo.id)
         row.estado = "aprovada"
         row.modo = m
-        if m == "resto_do_dia":
-            row.ate_em = _fim_resto_do_dia(agora)
-        else:
-            ate = _parse_ate_horario(agora.date(), ate_horario or "")
-            if ate <= agora:
-                raise HTTPException(
-                    status_code=400,
-                    detail="O horário limite da hora extra deve ser no futuro.",
-                )
-            row.ate_em = ate
+        row.ate_em = ate
     registrar_audit(
         db,
         "ponto_hora_extra",
@@ -299,6 +371,101 @@ def decidir(
     )
     db.commit()
     db.refresh(row)
+    _notificar_admins(db, admin.tenant_id)
+    return _to_read(row)
+
+
+def conceder_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int,
+    modo: str,
+    ate_horario: str | None = None,
+    duracao_minutos: int | None = None,
+    motivo: str | None = None,
+) -> PontoHoraExtraRead:
+    """Admin concede HE antecipada (#966) — sem pedido pendente."""
+    alvo = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.role != "saas_ops",
+        )
+        .first()
+    )
+    if not alvo:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    agora = _agora_tz()
+    m = (modo or "").strip().lower()
+    ate = _calcular_ate_em(
+        alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+    )
+    _expirar_aprovadas_anteriores(db, alvo.id)
+
+    pendentes = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == alvo.id, PontoHoraExtra.estado == "pendente")
+        .order_by(PontoHoraExtra.id.asc())
+        .all()
+    )
+    row: PontoHoraExtra
+    if pendentes:
+        row = pendentes[0]
+        for extra in pendentes[1:]:
+            extra.estado = "rejeitada"
+            extra.decidido_por_id = admin.id
+            extra.decidido_em = datetime.now(timezone.utc)
+            extra.decisao_motivo = "Substituído por concessão do administrador"
+        row.estado = "aprovada"
+        row.origem = "admin"
+        row.modo = m
+        row.ate_em = ate
+        row.motivo = (motivo or row.motivo or "Hora extra concedida pelo administrador.")[:1000]
+        row.decidido_por_id = admin.id
+        row.decidido_em = datetime.now(timezone.utc)
+        row.decisao_motivo = "Concessão antecipada"
+        registrar_audit(
+            db,
+            "ponto_hora_extra",
+            row.id,
+            "conceder",
+            admin.id,
+            payload={"atendente_id": alvo.id, "modo": m, "ate_em": str(ate), "via": "pendente"},
+        )
+    else:
+        row = PontoHoraExtra(
+            tenant_id=admin.tenant_id,
+            atendente_id=alvo.id,
+            estado="aprovada",
+            origem="admin",
+            modo=m,
+            ate_em=ate,
+            motivo=(motivo or "Hora extra concedida pelo administrador.")[:1000],
+            decidido_por_id=admin.id,
+            decidido_em=datetime.now(timezone.utc),
+            decisao_motivo="Concessão antecipada",
+        )
+        db.add(row)
+        db.flush()
+        registrar_audit(
+            db,
+            "ponto_hora_extra",
+            row.id,
+            "conceder",
+            admin.id,
+            payload={"atendente_id": alvo.id, "modo": m, "ate_em": str(ate)},
+        )
+
+    db.commit()
+    row = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.id == row.id)
+        .first()
+    )
+    assert row is not None
     _notificar_admins(db, admin.tenant_id)
     return _to_read(row)
 

--- a/backend/app/services/ponto_hora_extra.py
+++ b/backend/app/services/ponto_hora_extra.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date, datetime, time, timedelta, timezone
 
 from fastapi import HTTPException, status
@@ -182,6 +183,7 @@ def garantir_pedido_pendente(
     atendente: Atendente,
     *,
     motivo: str | None = None,
+    modo: str | None = None,
     commit: bool = True,
 ) -> PontoHoraExtra:
     existente = (
@@ -196,9 +198,12 @@ def garantir_pedido_pendente(
     if existente:
         if motivo and not (existente.motivo or "").strip():
             existente.motivo = (motivo or "")[:1000]
+        if modo and not (existente.modo or "").strip():
+            existente.modo = modo
         if commit:
             db.commit()
             db.refresh(existente)
+            _emit_he_sse(db, existente)
         return existente
     row = PontoHoraExtra(
         tenant_id=atendente.tenant_id,
@@ -206,6 +211,7 @@ def garantir_pedido_pendente(
         estado="pendente",
         origem="solicitacao",
         motivo=(motivo or "Pedido de hora extra para atendimento WhatsApp.")[:1000],
+        modo=(modo or None),
     )
     db.add(row)
     db.flush()
@@ -215,13 +221,32 @@ def garantir_pedido_pendente(
         row.id,
         "create",
         atendente.id,
-        payload={"estado": "pendente", "origem": "solicitacao"},
+        payload={"estado": "pendente", "origem": "solicitacao", "modo": modo},
     )
     if commit:
         db.commit()
         db.refresh(row)
         _notificar_admins(db, atendente.tenant_id)
+        _emit_he_sse(db, row)
     return row
+
+
+def _extrair_janela_do_motivo(motivo: str | None) -> tuple[str | None, int | None]:
+    """Recupera [até HH:MM] / [N min] gravados no pedido (#969)."""
+    if not motivo:
+        return None, None
+    ate = None
+    dur = None
+    m_ate = re.search(r"\[até\s+(\d{1,2}:\d{2})\]", motivo, re.IGNORECASE)
+    if m_ate:
+        ate = m_ate.group(1)
+    m_dur = re.search(r"\[(\d+)\s*min\]", motivo, re.IGNORECASE)
+    if m_dur:
+        try:
+            dur = int(m_dur.group(1))
+        except ValueError:
+            dur = None
+    return ate, dur
 
 
 def solicitar(
@@ -229,15 +254,54 @@ def solicitar(
     atendente: Atendente,
     *,
     motivo: str | None = None,
+    modo: str | None = None,
+    ate_horario: str | None = None,
+    duracao_minutos: int | None = None,
 ) -> PontoHoraExtraRead:
-    if not fora_da_jornada(atendente):
-        raise HTTPException(
-            status_code=400,
-            detail="Você ainda está dentro da jornada — não é necessário pedir hora extra.",
-        )
+    """Colaborador pede HE (#969) — com janela desejada opcional."""
     if he_ativa(db, atendente):
         raise HTTPException(status_code=400, detail="Você já tem hora extra ativa.")
-    row = garantir_pedido_pendente(db, atendente, motivo=motivo, commit=True)
+    teto_m = _teto_mensal_minutos(db, atendente)
+    if teto_m is not None and _consumido_mes(db, atendente) >= teto_m:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Teto mensal de hora extra atingido ({teto_m} min). Aguarde o próximo mês.",
+        )
+    m = (modo or "").strip().lower() or None
+    if m:
+        if m not in MODOS_APROVACAO:
+            raise HTTPException(
+                status_code=400,
+                detail="Escolha modo resto_do_dia, ate_horario ou duracao.",
+            )
+        agora = _agora_tz()
+        # Valida janela sem gravar ate_em (só na aprovação)
+        _calcular_ate_em(
+            atendente,
+            agora,
+            modo=m,
+            ate_horario=ate_horario,
+            duracao_minutos=duracao_minutos,
+        )
+        mins = _minutos_previstos_liberacao(
+            atendente,
+            agora,
+            modo=m,
+            ate_horario=ate_horario,
+            duracao_minutos=duracao_minutos,
+        )
+        _exigir_cabimento_mensal(db, atendente, mins)
+        if m == "ate_horario" and ate_horario:
+            hint = f" [até {ate_horario.strip()}]"
+            motivo = ((motivo or "").rstrip() + hint)[:1000]
+        elif m == "duracao" and duracao_minutos:
+            hint = f" [{int(duracao_minutos)} min]"
+            motivo = ((motivo or "").rstrip() + hint)[:1000]
+    row = garantir_pedido_pendente(db, atendente, motivo=motivo, modo=m, commit=True)
+    if m and row.modo != m:
+        row.modo = m
+        db.commit()
+        db.refresh(row)
     row = (
         db.query(PontoHoraExtra)
         .options(joinedload(PontoHoraExtra.atendente))
@@ -248,33 +312,137 @@ def solicitar(
     return _to_read(row)
 
 
-def listar_admin(
-    db: Session,
-    admin: Atendente,
-    *,
-    estado: str | None = "pendente",
-) -> list[PontoHoraExtraRead]:
-    q = (
-        db.query(PontoHoraExtra)
-        .options(joinedload(PontoHoraExtra.atendente))
-        .filter(PontoHoraExtra.tenant_id == admin.tenant_id)
+def _emit_he_sse(db: Session, row: PontoHoraExtra) -> None:
+    try:
+        from app.services.realtime_emit import emit_ponto_he_atualizada
+
+        emit_ponto_he_atualizada(
+            db,
+            tenant_id=row.tenant_id,
+            he_id=row.id,
+            atendente_id=row.atendente_id,
+            estado=row.estado,
+            origem=getattr(row, "origem", None),
+        )
+    except Exception:
+        pass
+
+
+def _teto_mensal_minutos(db: Session, atendente: Atendente) -> int | None:
+    raw = getattr(atendente, "he_teto_mensal_minutos", None)
+    if raw is not None and int(raw) > 0:
+        return int(raw)
+    from app.services import ponto_settings as ponto_settings_svc
+
+    st = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
+    raw_g = getattr(st, "he_teto_mensal_minutos", None)
+    if raw_g is not None and int(raw_g) > 0:
+        return int(raw_g)
+    return None
+
+
+def _he_minutos_liberados_periodo(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> int:
+    # Bounds locais (evita import circular com ponto.py)
+    inicio = datetime.combine(desde, time.min, tzinfo=PONTO_TZ).astimezone(timezone.utc)
+    fim_exclusive = datetime.combine(ate + timedelta(days=1), time.min, tzinfo=PONTO_TZ).astimezone(
+        timezone.utc
     )
-    if estado:
-        q = q.filter(PontoHoraExtra.estado == estado)
-    rows = q.order_by(PontoHoraExtra.created_at.desc(), PontoHoraExtra.id.desc()).limit(100).all()
-    return [_to_read(r) for r in rows]
-
-
-def listar_me(db: Session, atendente: Atendente) -> list[PontoHoraExtraRead]:
     rows = (
         db.query(PontoHoraExtra)
-        .options(joinedload(PontoHoraExtra.atendente))
-        .filter(PontoHoraExtra.atendente_id == atendente.id)
-        .order_by(PontoHoraExtra.id.desc())
-        .limit(30)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente_id,
+            PontoHoraExtra.estado.in_(("aprovada", "expirada")),
+            PontoHoraExtra.ate_em.isnot(None),
+            PontoHoraExtra.decidido_em.isnot(None),
+            PontoHoraExtra.decidido_em >= inicio,
+            PontoHoraExtra.decidido_em < fim_exclusive,
+        )
         .all()
     )
-    return [_to_read(r) for r in rows]
+    total = 0
+    for r in rows:
+        dec = r.decidido_em
+        ate_em = r.ate_em
+        if dec is None or ate_em is None:
+            continue
+        if dec.tzinfo is None:
+            dec = dec.replace(tzinfo=timezone.utc)
+        if ate_em.tzinfo is None:
+            ate_em = ate_em.replace(tzinfo=timezone.utc)
+        total += max(0, int((ate_em - dec).total_seconds() // 60))
+    return total
+
+
+def _consumido_mes(db: Session, atendente: Atendente, when: datetime | None = None) -> int:
+    agora = _agora_tz(when)
+    inicio_mes = date(agora.year, agora.month, 1)
+    if agora.month == 12:
+        fim_mes = date(agora.year + 1, 1, 1) - timedelta(days=1)
+    else:
+        fim_mes = date(agora.year, agora.month + 1, 1) - timedelta(days=1)
+    return _he_minutos_liberados_periodo(db, atendente.id, desde=inicio_mes, ate=fim_mes)
+
+
+def _minutos_previstos_liberacao(
+    atendente: Atendente,
+    agora: datetime,
+    *,
+    modo: str,
+    ate_horario: str | None,
+    duracao_minutos: int | None,
+) -> int:
+    ate = _calcular_ate_em(
+        atendente, agora, modo=modo, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+    )
+    return max(1, int((ate.astimezone(PONTO_TZ) - agora.astimezone(PONTO_TZ)).total_seconds() // 60))
+
+
+def _exigir_cabimento_mensal(
+    db: Session,
+    atendente: Atendente,
+    minutos_novos: int,
+) -> None:
+    teto = _teto_mensal_minutos(db, atendente)
+    if teto is None:
+        return
+    consumido = _consumido_mes(db, atendente)
+    if consumido + minutos_novos > teto:
+        restante = max(0, teto - consumido)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Teto mensal de hora extra atingido ({consumido}/{teto} min). "
+                f"Restam {restante} min neste mês."
+            ),
+        )
+
+
+def contar_acima_teto_mensal(db: Session, tenant_id: int) -> int:
+    from app.services import ponto_settings as ponto_settings_svc
+
+    st = ponto_settings_svc.get_or_create_settings(db, tenant_id)
+    global_teto = getattr(st, "he_teto_mensal_minutos", None)
+    ativos = (
+        db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role != "saas_ops",
+        )
+        .all()
+    )
+    n = 0
+    for a in ativos:
+        teto = _teto_mensal_minutos(db, a)
+        if teto is None and global_teto is None:
+            continue
+        if teto is None:
+            continue
+        if _consumido_mes(db, a) > teto:
+            n += 1
+    return n
 
 
 def me_status(db: Session, atendente: Atendente) -> dict:
@@ -286,6 +454,12 @@ def me_status(db: Session, atendente: Atendente) -> dict:
         .order_by(PontoHoraExtra.id.desc())
         .first()
     )
+    rejeitada = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == atendente.id, PontoHoraExtra.estado == "rejeitada")
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
     restante = None
     if ativa and ativa.ate_em is not None:
         agora = _agora_tz()
@@ -293,13 +467,18 @@ def me_status(db: Session, atendente: Atendente) -> dict:
         if ate.tzinfo is None:
             ate = ate.replace(tzinfo=timezone.utc)
         restante = max(0, int((ate.astimezone(PONTO_TZ) - agora).total_seconds() // 60))
+    teto_m = _teto_mensal_minutos(db, atendente)
+    consumido_m = _consumido_mes(db, atendente)
     return {
         "fora_da_jornada": fora,
         "pode_pegar_whatsapp": (not fora) or ativa is not None,
         "he_ativa": _to_read(ativa) if ativa else None,
         "pedido_pendente": _to_read(pendente) if pendente else None,
+        "ultimo_rejeitado": _to_read(rejeitada) if rejeitada and not pendente and not ativa else None,
         "he_teto_minutos": _teto_minutos(atendente),
         "he_restante_minutos": restante,
+        "he_teto_mensal_minutos": teto_m,
+        "he_consumido_mensal_minutos": consumido_m,
     }
 
 
@@ -350,12 +529,25 @@ def decidir(
     row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
     if not aprovar:
         row.estado = "rejeitada"
-        row.modo = None
         row.ate_em = None
+        if not row.decisao_motivo:
+            row.decisao_motivo = "Negado pelo administrador"
     else:
-        m = (modo or "").strip().lower()
+        m = (modo or row.modo or "").strip().lower()
+        if m not in MODOS_APROVACAO:
+            raise HTTPException(
+                status_code=400,
+                detail="Informe o modo de liberação (resto_do_dia, ate_horario ou duracao).",
+            )
+        hint_ate, hint_dur = _extrair_janela_do_motivo(row.motivo)
+        ate_h = ate_horario or hint_ate
+        dur_m = duracao_minutos if duracao_minutos is not None else hint_dur
+        mins = _minutos_previstos_liberacao(
+            alvo, agora, modo=m, ate_horario=ate_h, duracao_minutos=dur_m
+        )
+        _exigir_cabimento_mensal(db, alvo, mins)
         ate = _calcular_ate_em(
-            alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+            alvo, agora, modo=m, ate_horario=ate_h, duracao_minutos=dur_m
         )
         _expirar_aprovadas_anteriores(db, alvo.id)
         row.estado = "aprovada"
@@ -372,6 +564,7 @@ def decidir(
     db.commit()
     db.refresh(row)
     _notificar_admins(db, admin.tenant_id)
+    _emit_he_sse(db, row)
     return _to_read(row)
 
 
@@ -399,6 +592,10 @@ def conceder_admin(
         raise HTTPException(status_code=404, detail="Atendente não encontrado")
     agora = _agora_tz()
     m = (modo or "").strip().lower()
+    mins = _minutos_previstos_liberacao(
+        alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+    )
+    _exigir_cabimento_mensal(db, alvo, mins)
     ate = _calcular_ate_em(
         alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
     )
@@ -467,7 +664,37 @@ def conceder_admin(
     )
     assert row is not None
     _notificar_admins(db, admin.tenant_id)
+    _emit_he_sse(db, row)
     return _to_read(row)
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente",
+) -> list[PontoHoraExtraRead]:
+    q = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        q = q.filter(PontoHoraExtra.estado == estado)
+    rows = q.order_by(PontoHoraExtra.created_at.desc(), PontoHoraExtra.id.desc()).limit(100).all()
+    return [_to_read(r) for r in rows]
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoHoraExtraRead]:
+    rows = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.atendente_id == atendente.id)
+        .order_by(PontoHoraExtra.id.desc())
+        .limit(30)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
 
 
 def contar_pendentes_admin(db: Session, tenant_id: int) -> int:

--- a/backend/app/services/ponto_justificativa.py
+++ b/backend/app/services/ponto_justificativa.py
@@ -18,6 +18,7 @@ TIPOS = frozenset({"falta", "esquecimento", "folga_com_ponto", "outro"})
 
 def _to_read(j: PontoJustificativa) -> PontoJustificativaRead:
     nome = j.atendente.nome if j.atendente else None
+    tem = bool(getattr(j, "anexo_storage_key", None))
     return PontoJustificativaRead(
         id=j.id,
         atendente_id=j.atendente_id,
@@ -29,6 +30,10 @@ def _to_read(j: PontoJustificativa) -> PontoJustificativaRead:
         decisao_motivo=j.decisao_motivo,
         decidido_por_id=j.decidido_por_id,
         decidido_em=j.decidido_em,
+        tem_anexo=tem,
+        anexo_nome=getattr(j, "anexo_nome", None) if tem else None,
+        anexo_content_type=getattr(j, "anexo_content_type", None) if tem else None,
+        anexo_tamanho_bytes=getattr(j, "anexo_tamanho_bytes", None) if tem else None,
         created_at=j.created_at,
     )
 
@@ -40,6 +45,10 @@ def criar(
     data_ref,
     tipo: str,
     motivo: str,
+    anexo_nome: str | None = None,
+    anexo_content_type: str | None = None,
+    anexo_storage_key: str | None = None,
+    anexo_tamanho_bytes: int | None = None,
 ) -> PontoJustificativaRead:
     ponto_svc.exigir_acesso_ponto(atendente)
     if tipo not in TIPOS:
@@ -51,6 +60,10 @@ def criar(
         tipo=tipo,
         motivo=motivo.strip(),
         estado="pendente",
+        anexo_nome=anexo_nome,
+        anexo_content_type=anexo_content_type,
+        anexo_storage_key=anexo_storage_key,
+        anexo_tamanho_bytes=anexo_tamanho_bytes,
     )
     db.add(row)
     db.flush()
@@ -60,7 +73,12 @@ def criar(
         row.id,
         "create",
         atendente.id,
-        payload={"data_ref": str(data_ref), "tipo": tipo, "motivo": motivo.strip()},
+        payload={
+            "data_ref": str(data_ref),
+            "tipo": tipo,
+            "motivo": motivo.strip(),
+            "tem_anexo": bool(anexo_storage_key),
+        },
     )
     db.commit()
     db.refresh(row)
@@ -102,6 +120,30 @@ def listar_admin(
         q = q.filter(PontoJustificativa.estado == estado)
     rows = q.order_by(PontoJustificativa.created_at.asc()).limit(200).all()
     return [_to_read(r) for r in rows]
+
+
+def obter_para_anexo(
+    db: Session,
+    *,
+    justificativa_id: int,
+    tenant_id: int,
+    solicitante: Atendente,
+) -> PontoJustificativa:
+    row = (
+        db.query(PontoJustificativa)
+        .filter(
+            PontoJustificativa.id == justificativa_id,
+            PontoJustificativa.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Justificativa não encontrada")
+    if solicitante.role != "admin" and row.atendente_id != solicitante.id:
+        raise HTTPException(status_code=403, detail="Sem permissão para este anexo")
+    if not row.anexo_storage_key:
+        raise HTTPException(status_code=404, detail="Esta justificativa não tem anexo")
+    return row
 
 
 def decidir(

--- a/backend/app/services/ponto_justificativa_storage.py
+++ b/backend/app/services/ponto_justificativa_storage.py
@@ -1,0 +1,70 @@
+"""Storage de anexos de justificativa de ponto (#977)."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+
+from app.config import settings
+from app.services.ticket_anexo_storage import validar_upload as _validar_ticket
+
+# Allowlist mais restrita para RH: imagem + PDF
+_ALLOW_EXT = {".pdf", ".png", ".jpg", ".jpeg", ".webp", ".gif", ".heic"}
+_ALLOW_MIME_PREFIX = ("image/",)
+_ALLOW_MIME = {"application/pdf"}
+
+
+def validar_anexo_justificativa(
+    nome_original: str | None, content_type: str | None, tamanho_bytes: int
+) -> tuple[str, str | None]:
+    if tamanho_bytes > settings.PONTO_JUSTIFICATIVA_ANEXOS_MAX_BYTES:
+        raise ValueError("Arquivo excede o tamanho máximo permitido (25 MB).")
+    nome, mime = _validar_ticket(nome_original, content_type, tamanho_bytes)
+    ext = Path(nome).suffix.lower()
+    if ext not in _ALLOW_EXT:
+        raise ValueError("Anexo deve ser imagem ou PDF.")
+    if mime and not (mime in _ALLOW_MIME or mime.startswith(_ALLOW_MIME_PREFIX)):
+        raise ValueError("Anexo deve ser imagem ou PDF.")
+    return nome, mime
+
+
+def diretorio_anexos() -> Path:
+    p = Path(settings.PONTO_JUSTIFICATIVA_ANEXOS_DIR)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def gravar_bytes(data: bytes, *, mimetype: str | None, nome_original: str) -> str:
+    if len(data) == 0:
+        raise ValueError("Arquivo vazio.")
+    if len(data) > settings.PONTO_JUSTIFICATIVA_ANEXOS_MAX_BYTES:
+        raise ValueError("Arquivo excede o tamanho máximo permitido (25 MB).")
+    ext = Path(nome_original).suffix.lower()
+    if ext not in _ALLOW_EXT:
+        ext = ".bin"
+        if mimetype == "application/pdf":
+            ext = ".pdf"
+        elif mimetype and mimetype.startswith("image/"):
+            ext = ".img"
+    name = f"{uuid.uuid4().hex}{ext}"
+    path = diretorio_anexos() / name
+    path.write_bytes(data)
+    return name
+
+
+def caminho_absoluto(storage_key: str | None) -> Path | None:
+    if not storage_key or not str(storage_key).strip():
+        return None
+    base = diretorio_anexos()
+    s = str(storage_key).strip()
+    if re.search(r"[\\/]", s):
+        return None
+    p = (base / s).resolve()
+    try:
+        p.relative_to(base.resolve())
+    except ValueError:
+        return None
+    return p if p.is_file() else None

--- a/backend/app/services/ponto_relatorio.py
+++ b/backend/app/services/ponto_relatorio.py
@@ -1,14 +1,16 @@
-"""Relatório mensal de ponto — PDF e Excel (#844)."""
+"""Relatório mensal de ponto — PDF e Excel (#844 / #971)."""
 
 from __future__ import annotations
 
 import io
 from datetime import date, datetime, timezone
+
 from html import escape
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.models.atendente import Atendente
+from app.models.audit_log import AuditLog
 from app.models.ponto_batida import PontoBatida
 from app.services.comercial_proposta import html_para_pdf
 from app.services.ponto import PONTO_TZ, _as_utc, _bounds_periodo, _intervalos_de_batidas, _q_ativas
@@ -28,6 +30,44 @@ MESES_PT = (
     "Novembro",
     "Dezembro",
 )
+
+
+def _coletar_ajustes_audit(
+    db: Session,
+    admin: Atendente,
+    *,
+    desde: date | None,
+    ate: date | None,
+) -> list[AuditLog]:
+    q = (
+        db.query(AuditLog)
+        .options(joinedload(AuditLog.atendente))
+        .filter(
+            AuditLog.entity_type == "ponto_batida",
+            AuditLog.action.in_(("create_ajuste", "update_ajuste", "anular")),
+        )
+    )
+    # AuditLog é global por instância; filtrar por autores do tenant
+    ids = [
+        row[0]
+        for row in db.query(Atendente.id).filter(Atendente.tenant_id == admin.tenant_id).all()
+    ]
+    if ids:
+        q = q.filter(AuditLog.atendente_id.in_(ids))
+    inicio, fim = _bounds_periodo(desde, ate)
+    if inicio is not None:
+        q = q.filter(AuditLog.created_at >= inicio)
+    if fim is not None:
+        q = q.filter(AuditLog.created_at < fim)
+    return q.order_by(AuditLog.created_at.asc(), AuditLog.id.asc()).limit(2000).all()
+
+
+def _rotulo_acao_ajuste(action: str) -> str:
+    return {
+        "create_ajuste": "Criação",
+        "update_ajuste": "Alteração",
+        "anular": "Anulação",
+    }.get(action, action)
 
 
 def _coletar_intervalos(
@@ -108,12 +148,33 @@ def export_pdf_mensal(
             "</tr>"
         )
 
+    ajustes_html = ""
+    for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
+        payload = log.payload_json or {}
+        motivo = escape(str(payload.get("motivo") or "—"))
+        quando = (
+            _as_utc(log.created_at).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
+            if log.created_at
+            else "—"
+        )
+        autor = escape(log.atendente.nome if log.atendente else "—")
+        ajustes_html += (
+            "<tr>"
+            f"<td>{quando}</td>"
+            f"<td>{autor}</td>"
+            f"<td>{escape(_rotulo_acao_ajuste(log.action))}</td>"
+            f"<td>{log.entity_id}</td>"
+            f"<td>{motivo}</td>"
+            "</tr>"
+        )
+
     html = f"""<!DOCTYPE html>
 <html lang="pt-BR">
 <head><meta charset="utf-8"><title>Relatório de ponto</title>
 <style>
   body {{ font-family: sans-serif; font-size: 11px; color: #111; }}
   h1 {{ font-size: 18px; margin-bottom: 4px; }}
+  h2 {{ font-size: 14px; margin-top: 20px; }}
   .meta {{ color: #555; margin-bottom: 16px; }}
   table {{ width: 100%; border-collapse: collapse; }}
   th, td {{ border: 1px solid #ccc; padding: 4px 6px; text-align: left; }}
@@ -129,9 +190,16 @@ def export_pdf_mensal(
       <th>Atendente</th><th>Data</th><th>Entrada</th><th>Saída</th>
       <th>Pausas (min)</th><th>Trabalhado (min)</th><th>Aberto</th>
     </tr></thead>
-    <tbody>{rows_html or '<tr><td colspan="7">Sem registos no período.</td></tr>'}</tbody>
+    <tbody>{rows_html or '<tr><td colspan="7">Sem registros no período.</td></tr>'}</tbody>
   </table>
   <p class="total">Total trabalhado (fechado): {round(total_min / 60, 2)} h ({round(total_min, 0)} min)</p>
+  <h2>Ajustes administrativos</h2>
+  <table>
+    <thead><tr>
+      <th>Quando</th><th>Autor</th><th>Ação</th><th>Batida</th><th>Motivo</th>
+    </tr></thead>
+    <tbody>{ajustes_html or '<tr><td colspan="5">Sem ajustes no período.</td></tr>'}</tbody>
+  </table>
 </body>
 </html>"""
     return html_para_pdf(html)
@@ -180,6 +248,24 @@ def export_xlsx_mensal(
         )
     ws.append([])
     ws.append(["Total trabalhado (h)", round(total_min / 60, 2)])
+
+    ws_aj = wb.create_sheet("Ajustes")
+    ws_aj.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Payload"])
+    for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
+        payload = log.payload_json or {}
+        ws_aj.append(
+            [
+                _as_utc(log.created_at).astimezone(PONTO_TZ).strftime("%Y-%m-%d %H:%M")
+                if log.created_at
+                else "",
+                log.atendente.nome if log.atendente else "",
+                _rotulo_acao_ajuste(log.action),
+                log.entity_id,
+                payload.get("motivo") or "",
+                str(payload),
+            ]
+        )
+
     buf = io.BytesIO()
     wb.save(buf)
     return buf.getvalue()

--- a/backend/app/services/ponto_relatorio.py
+++ b/backend/app/services/ponto_relatorio.py
@@ -125,6 +125,12 @@ def export_pdf_mensal(
     linhas = _coletar_intervalos(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
     titulo = _titulo_periodo(desde, ate)
     gerado = datetime.now(timezone.utc).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
+    from app.services import ponto_competencia as comp_svc
+
+    selo_comp = ""
+    if desde and desde.year and desde.month:
+        if comp_svc.competencia_fechada(db, admin.tenant_id, ano=desde.year, mes=desde.month):
+            selo_comp = " · Competência FECHADA"
 
     rows_html = ""
     total_min = 0.0
@@ -152,6 +158,7 @@ def export_pdf_mensal(
     for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
         payload = log.payload_json or {}
         motivo = escape(str(payload.get("motivo") or "—"))
+        pos = "sim" if payload.get("pos_fechamento") else "não"
         quando = (
             _as_utc(log.created_at).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
             if log.created_at
@@ -165,6 +172,7 @@ def export_pdf_mensal(
             f"<td>{escape(_rotulo_acao_ajuste(log.action))}</td>"
             f"<td>{log.entity_id}</td>"
             f"<td>{motivo}</td>"
+            f"<td>{pos}</td>"
             "</tr>"
         )
 
@@ -184,7 +192,7 @@ def export_pdf_mensal(
 </head>
 <body>
   <h1>Relatório de ponto — {escape(titulo)}</h1>
-  <p class="meta">Gerado em {gerado} · DeskRudder</p>
+  <p class="meta">Gerado em {gerado} · DeskRudder{selo_comp}</p>
   <table>
     <thead><tr>
       <th>Atendente</th><th>Data</th><th>Entrada</th><th>Saída</th>
@@ -196,9 +204,9 @@ def export_pdf_mensal(
   <h2>Ajustes administrativos</h2>
   <table>
     <thead><tr>
-      <th>Quando</th><th>Autor</th><th>Ação</th><th>Batida</th><th>Motivo</th>
+      <th>Quando</th><th>Autor</th><th>Ação</th><th>Batida</th><th>Motivo</th><th>Pós-fechamento</th>
     </tr></thead>
-    <tbody>{ajustes_html or '<tr><td colspan="5">Sem ajustes no período.</td></tr>'}</tbody>
+    <tbody>{ajustes_html or '<tr><td colspan="6">Sem ajustes no período.</td></tr>'}</tbody>
   </table>
 </body>
 </html>"""
@@ -224,9 +232,14 @@ def export_xlsx_mensal(
         ) from exc
 
     linhas = _coletar_intervalos(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    from app.services import ponto_competencia as comp_svc
+
     wb = Workbook()
     ws = wb.active
     ws.title = "Ponto"
+    if desde and comp_svc.competencia_fechada(db, admin.tenant_id, ano=desde.year, mes=desde.month):
+        ws.append([f"Competência FECHADA — {_titulo_periodo(desde, ate)}"])
+        ws.append([])
     ws.append(
         ["Atendente", "Data", "Entrada", "Saída", "Pausas (min)", "Trabalhado (min)", "Aberto"]
     )
@@ -250,7 +263,7 @@ def export_xlsx_mensal(
     ws.append(["Total trabalhado (h)", round(total_min / 60, 2)])
 
     ws_aj = wb.create_sheet("Ajustes")
-    ws_aj.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Payload"])
+    ws_aj.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Pós-fechamento", "Payload"])
     for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
         payload = log.payload_json or {}
         ws_aj.append(
@@ -262,6 +275,7 @@ def export_xlsx_mensal(
                 _rotulo_acao_ajuste(log.action),
                 log.entity_id,
                 payload.get("motivo") or "",
+                "sim" if payload.get("pos_fechamento") else "não",
                 str(payload),
             ]
         )

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -69,6 +69,13 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="jornada_diaria_minutos deve estar entre 60 e 1440.",
             )
+    if "he_teto_mensal_minutos" in payload:
+        m = payload["he_teto_mensal_minutos"]
+        if m is not None and (m < 30 or m > 31 * 24 * 60):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="he_teto_mensal_minutos deve estar entre 30 e 44640, ou vazio.",
+            )
     if "politica_geolocalizacao" in payload:
         p = (payload["politica_geolocalizacao"] or "").strip().lower()
         if p not in POLITICAS_VALIDAS:

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -69,6 +69,13 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="jornada_diaria_minutos deve estar entre 60 e 1440.",
             )
+    if "pausa_minima_minutos" in payload:
+        m = payload["pausa_minima_minutos"]
+        if m is None or m < 0 or m > 240:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="pausa_minima_minutos deve estar entre 0 e 240.",
+            )
     if "politica_geolocalizacao" in payload:
         p = (payload["politica_geolocalizacao"] or "").strip().lower()
         if p not in POLITICAS_VALIDAS:

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -574,3 +574,35 @@ def emit_chat_interno_mensagem_atualizada(
     _publish_to_atendentes(recipients, "chat.interno.mensagem.atualizada", payload)
     if acao in {"editada", "apagada"}:
         _emit_notificacao_after_counter_change(db)
+
+
+def emit_ponto_he_atualizada(
+    db: Session,
+    *,
+    tenant_id: int,
+    he_id: int,
+    atendente_id: int,
+    estado: str,
+    origem: str | None = None,
+) -> None:
+    """Pedido/decisão/concessão de hora extra (#982) — admins + colaborador."""
+    ids = {
+        a.id
+        for a in db.query(Atendente)
+        .filter(
+            Atendente.tenant_id == tenant_id,
+            Atendente.role == "admin",
+            Atendente.ativo.is_(True),
+        )
+        .all()
+    }
+    ids.add(atendente_id)
+    payload = {
+        "he_id": he_id,
+        "atendente_id": atendente_id,
+        "estado": estado,
+        "origem": origem,
+    }
+    _publish_to_atendentes(ids, "ponto.he_atualizada", payload)
+    # Contagem do sino (HE pendentes) para admins
+    emit_notificacao_contagem(db, ids)

--- a/backend/tests/test_ponto_he_antecipada_966.py
+++ b/backend/tests/test_ponto_he_antecipada_966.py
@@ -1,6 +1,6 @@
 """HE antecipada + teto (#966)."""
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from app.services.escala import PONTO_TZ
 
@@ -22,13 +22,16 @@ def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
     )
 
 
-def test_conceder_he_antecipada_durante_jornada(client, seed_base, auth_headers):
+def test_conceder_he_antecipada_durante_jornada(client, seed_base, auth_headers, monkeypatch):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
     a1 = seed_base["a1"]
-    # fim no futuro → ainda dentro da jornada
-    fim = (datetime.now(PONTO_TZ) + timedelta(hours=3)).strftime("%H:%M")
-    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    agora = datetime(2026, 6, 17, 14, 0, tzinfo=PONTO_TZ)
+    monkeypatch.setattr(
+        "app.services.ponto._agora_utc",
+        lambda: agora.astimezone(timezone.utc),
+    )
+    assert _patch_jornada_semanal(client, admin, a1.id, fim="18:00").status_code == 200
     r = client.post(
         "/v1/ponto/hora-extra/conceder",
         headers=admin,

--- a/backend/tests/test_ponto_he_antecipada_966.py
+++ b/backend/tests/test_ponto_he_antecipada_966.py
@@ -1,0 +1,122 @@
+"""HE antecipada + teto (#966)."""
+
+from datetime import date, datetime, timedelta
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def test_conceder_he_antecipada_durante_jornada(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    # fim no futuro → ainda dentro da jornada
+    fim = (datetime.now(PONTO_TZ) + timedelta(hours=3)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    r = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 90, "motivo": "Pico"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["estado"] == "aprovada"
+    assert body["origem"] == "admin"
+    assert body["modo"] == "duracao"
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    assert st.json()["he_ativa"] is not None
+    assert st.json()["he_restante_minutos"] is not None
+    assert st.json()["he_restante_minutos"] <= 90
+
+
+def test_teto_limita_concessao(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_minutos": 60},
+    ).status_code == 200
+    # Pedido resto do dia seria até 23:59 — teto de 60 min corta
+    r = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "resto_do_dia"},
+    )
+    assert r.status_code == 201, r.text
+    ate = datetime.fromisoformat(r.json()["ate_em"].replace("Z", "+00:00"))
+    agora = datetime.now(PONTO_TZ)
+    delta_min = (ate.astimezone(PONTO_TZ) - agora).total_seconds() / 60
+    assert delta_min <= 61
+
+
+def test_teto_bloqueia_duracao_maior(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_minutos": 30},
+    ).status_code == 200
+    # 30 min teto + modo duracao 30 = ok
+    r_ok = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+    )
+    assert r_ok.status_code == 201, r_ok.text
+    # Nova concessão 120 com teto 30: ainda deve criar mas cortada a 30
+    r2 = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 120},
+    )
+    assert r2.status_code == 201, r2.text
+    ate = datetime.fromisoformat(r2.json()["ate_em"].replace("Z", "+00:00"))
+    agora = datetime.now(PONTO_TZ)
+    assert (ate.astimezone(PONTO_TZ) - agora).total_seconds() / 60 <= 31
+
+
+def test_he_ativa_libera_apos_jornada(client, seed_base, auth_headers, db_session):
+    from app.models.whatsapp_chat import WhatsappChat
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    # Concede antes
+    assert client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 120},
+    ).status_code == 201
+    # Força fim da jornada no passado
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=1)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    chat = WhatsappChat(
+        wa_id="5511999999660",
+        protocolo="WPP-TEST-966",
+        estado="aguardando_atendente",
+        setor_id=seed_base["setor1"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+    db_session.refresh(chat)
+    r = client.post(f"/v1/whatsapp/chats/{chat.id}/assumir", headers=user)
+    assert r.status_code == 200, r.text

--- a/backend/tests/test_ponto_he_sse_982.py
+++ b/backend/tests/test_ponto_he_sse_982.py
@@ -1,0 +1,36 @@
+"""SSE ponto.he_atualizada (#982) — destinatários admin + colaborador."""
+
+from unittest.mock import MagicMock, patch
+
+from app.models.atendente import Atendente
+from app.services.realtime_emit import emit_ponto_he_atualizada
+
+
+def test_emit_ponto_he_atualizada_admins_e_colaborador():
+    db = MagicMock()
+    admin = Atendente(id=1, tenant_id=10, role="admin", ativo=True, nome="Admin", email="a@x")
+    outro = Atendente(id=2, tenant_id=10, role="atendente", ativo=True, nome="X", email="x@x")
+    db.query.return_value.filter.return_value.all.return_value = [admin]
+
+    with (
+        patch("app.services.realtime_emit._publish_to_atendentes") as pub,
+        patch("app.services.realtime_emit.emit_notificacao_contagem") as cont,
+    ):
+        emit_ponto_he_atualizada(
+            db,
+            tenant_id=10,
+            he_id=99,
+            atendente_id=7,
+            estado="pendente",
+            origem="solicitacao",
+        )
+        pub.assert_called_once()
+        ids, event, payload = pub.call_args[0]
+        assert event == "ponto.he_atualizada"
+        assert 1 in ids
+        assert 7 in ids
+        assert 2 not in ids
+        assert payload["he_id"] == 99
+        assert payload["estado"] == "pendente"
+        cont.assert_called_once()
+        _ = outro

--- a/backend/tests/test_ponto_lote_c_968_971_972.py
+++ b/backend/tests/test_ponto_lote_c_968_971_972.py
@@ -28,8 +28,13 @@ def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, 
     a1 = seed_base["a1"]
     agora = datetime.now(PONTO_TZ)
     # Coloca início da jornada 10 min no futuro e tol=30 → já estamos em inicio−tol
-    inicio = (agora + timedelta(minutes=10)).strftime("%H:%M")
-    fim = (agora + timedelta(hours=8)).strftime("%H:%M")
+    inicio_dt = agora + timedelta(minutes=10)
+    fim_dt = inicio_dt + timedelta(hours=8)
+    # Jornada semanal não pode cruzar meia-noite
+    if fim_dt.date() != inicio_dt.date():
+        fim_dt = inicio_dt.replace(hour=23, minute=59, second=0, microsecond=0)
+    inicio = inicio_dt.strftime("%H:%M")
+    fim = fim_dt.strftime("%H:%M")
     assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
     r = client.get("/v1/ponto/me/alertas", headers=user)
     assert r.status_code == 200, r.text
@@ -46,8 +51,12 @@ def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session
     a1 = seed_base["a1"]
     agora = datetime.now(PONTO_TZ)
     # fim daqui a 10 min, tol 30 → já na janela de saída
-    inicio = (agora - timedelta(hours=8)).strftime("%H:%M")
-    fim = (agora + timedelta(minutes=10)).strftime("%H:%M")
+    fim_dt = agora + timedelta(minutes=10)
+    inicio_dt = fim_dt - timedelta(hours=8)
+    if inicio_dt.date() != fim_dt.date():
+        inicio_dt = fim_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    inicio = inicio_dt.strftime("%H:%M")
+    fim = fim_dt.strftime("%H:%M")
     assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
     db_session.add(
         PontoBatida(

--- a/backend/tests/test_ponto_lote_c_968_971_972.py
+++ b/backend/tests/test_ponto_lote_c_968_971_972.py
@@ -1,0 +1,121 @@
+"""Lote C ponto: lembretes tolerância (#968), resumo semanal (#972), ajustes (#971)."""
+
+from datetime import date, datetime, timedelta, timezone
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_hoje(client, headers, atendente_id: int, *, inicio="08:00", fim="18:00", tol=30):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": inicio, "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": tol,
+        },
+    )
+
+
+def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, monkeypatch):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    agora = datetime.now(PONTO_TZ)
+    # Coloca início da jornada 10 min no futuro e tol=30 → já estamos em inicio−tol
+    inicio = (agora + timedelta(minutes=10)).strftime("%H:%M")
+    fim = (agora + timedelta(hours=8)).strftime("%H:%M")
+    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    r = client.get("/v1/ponto/me/alertas", headers=user)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lembrete_entrada_tolerancia"] is True
+    assert any("Janela de entrada" in m for m in body["mensagens"])
+
+
+def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session):
+    from app.models.ponto_batida import PontoBatida
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    agora = datetime.now(PONTO_TZ)
+    # fim daqui a 10 min, tol 30 → já na janela de saída
+    inicio = (agora - timedelta(hours=8)).strftime("%H:%M")
+    fim = (agora + timedelta(minutes=10)).strftime("%H:%M")
+    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    db_session.add(
+        PontoBatida(
+            tenant_id=a1.tenant_id,
+            atendente_id=a1.id,
+            tipo="entrada",
+            registrado_em=datetime.now(timezone.utc) - timedelta(hours=7),
+            origem="app",
+        )
+    )
+    db_session.commit()
+    r = client.get("/v1/ponto/me/alertas", headers=user)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lembrete_saida_tolerancia"] is True
+    assert any("saída" in m.lower() for m in body["mensagens"])
+
+
+def test_modo_nenhum_sem_lembrete_tolerancia(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"modo_jornada": "nenhum", "usa_escala": False},
+    ).status_code == 200
+    r = client.get("/v1/ponto/me/alertas", headers=user)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["lembrete_entrada_tolerancia"] is False
+    assert body["lembrete_saida_tolerancia"] is False
+
+
+def test_resumo_semana_proprio(client, seed_base, auth_headers):
+    user = auth_headers["a1"]
+    r = client.get("/v1/ponto/me/resumo-semana", headers=user)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "desde" in body and "ate" in body
+    assert "atrasos" in body
+    assert "he_minutos" in body
+    assert "saldo_segundos" in body
+    assert body["segundos_esperados"] >= 0
+
+
+def test_ajuste_motivo_obrigatorio_strip(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    r = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": datetime.now(timezone.utc).isoformat(),
+            "motivo": "  ",
+        },
+    )
+    assert r.status_code == 422
+    r_ok = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": datetime.now(timezone.utc).isoformat(),
+            "motivo": "Correção de esquecimento",
+        },
+    )
+    assert r_ok.status_code == 201, r_ok.text

--- a/backend/tests/test_ponto_lote_c_968_971_972.py
+++ b/backend/tests/test_ponto_lote_c_968_971_972.py
@@ -5,9 +5,47 @@ from datetime import date, datetime, timedelta, timezone
 from app.services.escala import PONTO_TZ
 
 
-def _patch_jornada_hoje(client, headers, atendente_id: int, *, inicio="08:00", fim="18:00", tol=30):
+def _freeze_ponto_agora(monkeypatch, when: datetime) -> None:
+    """Evita flakiness quando o pytest roda perto da meia-noite (jornada semanal)."""
+    when_utc = when.astimezone(timezone.utc)
+    monkeypatch.setattr("app.services.ponto._agora_utc", lambda: when_utc)
+    import app.services.escala as escala_mod
+    import app.services.ponto as ponto_mod
+
+    real_dt = ponto_mod.datetime
+
+    class DatetimeComAgoraFixo(real_dt):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is not None:
+                return when.astimezone(tz)
+            return when.replace(tzinfo=None)
+
+    monkeypatch.setattr(ponto_mod, "datetime", DatetimeComAgoraFixo)
+    monkeypatch.setattr(escala_mod, "datetime", DatetimeComAgoraFixo)
+
+    real_date = ponto_mod.date
+
+    class DateComHojeFixo(real_date):
+        @classmethod
+        def today(cls):
+            return when.date()
+
+    monkeypatch.setattr(ponto_mod, "date", DateComHojeFixo)
+
+
+def _patch_jornada_hoje(
+    client,
+    headers,
+    atendente_id: int,
+    *,
+    ref: date | None = None,
+    inicio="08:00",
+    fim="18:00",
+    tol=30,
+):
     keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
-    hoje_key = keys[date.today().weekday()]
+    hoje_key = keys[(ref or date.today()).weekday()]
     hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
     hs[hoje_key] = {"ativo": True, "inicio": inicio, "fim": fim}
     return client.patch(
@@ -26,16 +64,16 @@ def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, 
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
     a1 = seed_base["a1"]
-    agora = datetime.now(PONTO_TZ)
+    agora = datetime(2026, 6, 17, 10, 0, tzinfo=PONTO_TZ)
+    _freeze_ponto_agora(monkeypatch, agora)
     # Coloca início da jornada 10 min no futuro e tol=30 → já estamos em inicio−tol
     inicio_dt = agora + timedelta(minutes=10)
     fim_dt = inicio_dt + timedelta(hours=8)
-    # Jornada semanal não pode cruzar meia-noite
-    if fim_dt.date() != inicio_dt.date():
-        fim_dt = inicio_dt.replace(hour=23, minute=59, second=0, microsecond=0)
     inicio = inicio_dt.strftime("%H:%M")
     fim = fim_dt.strftime("%H:%M")
-    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    assert _patch_jornada_hoje(
+        client, admin, a1.id, ref=agora.date(), inicio=inicio, fim=fim, tol=30
+    ).status_code == 200
     r = client.get("/v1/ponto/me/alertas", headers=user)
     assert r.status_code == 200, r.text
     body = r.json()
@@ -43,27 +81,28 @@ def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, 
     assert any("Janela de entrada" in m for m in body["mensagens"])
 
 
-def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session):
+def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session, monkeypatch):
     from app.models.ponto_batida import PontoBatida
 
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
     a1 = seed_base["a1"]
-    agora = datetime.now(PONTO_TZ)
+    agora = datetime(2026, 6, 17, 16, 50, tzinfo=PONTO_TZ)
+    _freeze_ponto_agora(monkeypatch, agora)
     # fim daqui a 10 min, tol 30 → já na janela de saída
     fim_dt = agora + timedelta(minutes=10)
     inicio_dt = fim_dt - timedelta(hours=8)
-    if inicio_dt.date() != fim_dt.date():
-        inicio_dt = fim_dt.replace(hour=0, minute=0, second=0, microsecond=0)
     inicio = inicio_dt.strftime("%H:%M")
     fim = fim_dt.strftime("%H:%M")
-    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    assert _patch_jornada_hoje(
+        client, admin, a1.id, ref=agora.date(), inicio=inicio, fim=fim, tol=30
+    ).status_code == 200
     db_session.add(
         PontoBatida(
             tenant_id=a1.tenant_id,
             atendente_id=a1.id,
             tipo="entrada",
-            registrado_em=datetime.now(timezone.utc) - timedelta(hours=7),
+            registrado_em=agora.astimezone(timezone.utc) - timedelta(hours=7),
             origem="app",
         )
     )

--- a/backend/tests/test_ponto_lote_d_969_974.py
+++ b/backend/tests/test_ponto_lote_d_969_974.py
@@ -1,8 +1,6 @@
 """Lote D: solicitação HE (#969) + teto mensal (#974)."""
 
-from datetime import date, datetime, timedelta
-
-from app.services.escala import PONTO_TZ
+from datetime import date
 
 
 def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
@@ -177,8 +175,7 @@ def test_me_status_campos_mensais(client, seed_base, auth_headers):
         headers=admin,
         json={"he_teto_mensal_minutos": 120},
     ).status_code == 200
-    fim = (datetime.now(PONTO_TZ) + timedelta(hours=2)).strftime("%H:%M")
-    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    assert _patch_jornada_semanal(client, admin, a1.id, fim="18:00").status_code == 200
     st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
     assert st.status_code == 200
     body = st.json()

--- a/backend/tests/test_ponto_lote_d_969_974.py
+++ b/backend/tests/test_ponto_lote_d_969_974.py
@@ -1,0 +1,186 @@
+"""Lote D: solicitação HE (#969) + teto mensal (#974)."""
+
+from datetime import date, datetime, timedelta
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def test_colaborador_solicita_he_com_janela(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    r = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Pico", "modo": "duracao", "duracao_minutos": 45},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["estado"] == "pendente"
+    assert body["modo"] == "duracao"
+    assert "45 min" in (body.get("motivo") or "")
+    pend = client.get("/v1/ponto/hora-extra?estado=pendente", headers=admin)
+    assert pend.status_code == 200
+    assert any(x["id"] == body["id"] for x in pend.json())
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    assert st.json()["pedido_pendente"]["id"] == body["id"]
+    # Admin aprova usando janela do pedido
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{body['id']}/decidir",
+        headers=admin,
+        json={"aprovar": True},
+    )
+    assert dec.status_code == 200, dec.text
+    assert dec.json()["estado"] == "aprovada"
+    assert dec.json()["modo"] == "duracao"
+    st2 = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st2.json()["he_ativa"] is not None
+    _ = a1  # seed usado via auth
+
+
+def test_he_rejeitada_feedback(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    sol = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Preciso", "modo": "resto_do_dia"},
+    )
+    assert sol.status_code == 201, sol.text
+    he_id = sol.json()["id"]
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{he_id}/decidir",
+        headers=admin,
+        json={"aprovar": False, "decisao_motivo": "Sem necessidade hoje"},
+    )
+    assert dec.status_code == 200
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    rej = st.json()["ultimo_rejeitado"]
+    assert rej is not None
+    assert "Sem necessidade" in (rej.get("decisao_motivo") or "")
+
+
+def test_teto_mensal_bloqueia_concessao(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 60},
+    ).status_code == 200
+    r1 = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 60},
+    )
+    assert r1.status_code == 201, r1.text
+    r2 = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+    )
+    assert r2.status_code == 400, r2.text
+    assert "mensal" in r2.json()["detail"].lower()
+
+
+def test_teto_mensal_global_settings_e_digest(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    st = client.patch(
+        "/v1/ponto/settings",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 45},
+    )
+    assert st.status_code == 200, st.text
+    assert st.json()["he_teto_mensal_minutos"] == 45
+    assert client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 45},
+    ).status_code == 201
+    # Segunda concessão estoura
+    assert (
+        client.post(
+            "/v1/ponto/hora-extra/conceder",
+            headers=admin,
+            json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+        ).status_code
+        == 400
+    )
+    dig = client.get("/v1/ponto/digest", headers=admin)
+    assert dig.status_code == 200
+    assert "he_acima_teto_mensal" in dig.json()
+    # Consumido == teto ainda não conta como "acima" (> teto)
+    assert dig.json()["he_acima_teto_mensal"] >= 0
+
+
+def test_solicitar_bloqueado_quando_teto_mensal_cheio(client, seed_base, auth_headers, db_session):
+    from app.models.ponto_hora_extra import PontoHoraExtra
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 30},
+    ).status_code == 200
+    assert client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+    ).status_code == 201
+    # Expira a HE ativa para isolar o bloqueio de teto mensal
+    row = (
+        db_session.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == a1.id, PontoHoraExtra.estado == "aprovada")
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    assert row is not None
+    row.estado = "expirada"
+    db_session.commit()
+    r = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Mais", "modo": "duracao", "duracao_minutos": 30},
+    )
+    assert r.status_code == 400
+    assert "mensal" in r.json()["detail"].lower()
+
+
+def test_me_status_campos_mensais(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_mensal_minutos": 120},
+    ).status_code == 200
+    fim = (datetime.now(PONTO_TZ) + timedelta(hours=2)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    body = st.json()
+    assert body["he_teto_mensal_minutos"] == 120
+    assert body["he_consumido_mensal_minutos"] >= 0

--- a/backend/tests/test_ponto_lote_e_976_977_973.py
+++ b/backend/tests/test_ponto_lote_e_976_977_973.py
@@ -1,0 +1,147 @@
+"""Lote E: ausências (#976), pausa mínima (#973), anexo justificativa (#977)."""
+
+from datetime import date, datetime, timedelta, timezone
+from io import BytesIO
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="18:00"):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def test_ausencia_admin_agenda_sem_falta(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _patch_jornada_semanal(client, admin, a1.id).status_code == 200
+    hoje = date.today()
+    r = client.post(
+        "/v1/ponto/ausencias/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "ferias",
+            "desde": hoje.isoformat(),
+            "ate": hoje.isoformat(),
+            "motivo": "Recesso",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["estado"] == "aprovada"
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={hoje.year}&mes={hoje.month}",
+        headers=user,
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == hoje.isoformat())
+    assert dia["status"] == "ferias"
+    assert dia["esperado"] is False
+    assert dia["classe_visual"] == "ausencia"
+
+
+def test_colaborador_solicita_folga_admin_aprova(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    amanha = date.today() + timedelta(days=1)
+    sol = client.post(
+        "/v1/ponto/ausencias",
+        headers=user,
+        json={
+            "tipo": "folga_programada",
+            "desde": amanha.isoformat(),
+            "ate": amanha.isoformat(),
+            "motivo": "Compromisso",
+        },
+    )
+    assert sol.status_code == 201, sol.text
+    assert sol.json()["estado"] == "pendente"
+    pend = client.get("/v1/ponto/ausencias?estado=pendente", headers=admin)
+    assert any(x["id"] == sol.json()["id"] for x in pend.json())
+    dec = client.post(
+        f"/v1/ponto/ausencias/{sol.json()['id']}/decidir",
+        headers=admin,
+        json={"aprovar": True},
+    )
+    assert dec.status_code == 200
+    assert dec.json()["estado"] == "aprovada"
+
+
+def test_pausa_minima_flag_calendario(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        "/v1/ponto/settings",
+        headers=admin,
+        json={"pausa_minima_minutos": 60},
+    ).status_code == 200
+    agora = datetime.now(PONTO_TZ)
+    t0 = agora.replace(hour=8, minute=0, second=0, microsecond=0)
+    if t0.tzinfo is None:
+        t0 = t0.replace(tzinfo=PONTO_TZ)
+    if t0 > agora:
+        t0 = agora - timedelta(hours=5)
+    seq = [
+        ("entrada", t0),
+        ("pausa_inicio", t0 + timedelta(hours=2)),
+        ("pausa_fim", t0 + timedelta(hours=2, minutes=10)),
+        ("saida", t0 + timedelta(hours=4)),
+    ]
+    for tipo, when in seq:
+        r = client.post(
+            "/v1/ponto/batidas",
+            headers=admin,
+            json={
+                "atendente_id": a1.id,
+                "tipo": tipo,
+                "registrado_em": when.astimezone(timezone.utc).isoformat(),
+                "motivo": "teste pausa mínima",
+            },
+        )
+        assert r.status_code == 201, f"{tipo}: {r.text}"
+    hoje = date.today()
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={hoje.year}&mes={hoje.month}",
+        headers=user,
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == hoje.isoformat())
+    assert dia["pausa_abaixo_minimo"] is True
+    assert dia["segundos_pausa"] < 60 * 60
+
+
+def test_justificativa_com_anexo_pdf(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    pdf = b"%PDF-1.4 fake test content"
+    r = client.post(
+        "/v1/ponto/justificativas/upload",
+        headers=user,
+        data={
+            "data_ref": date.today().isoformat(),
+            "tipo": "falta",
+            "motivo": "Atestado médico",
+        },
+        files={"arquivo": ("atestado.pdf", BytesIO(pdf), "application/pdf")},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["tem_anexo"] is True
+    assert body["anexo_nome"]
+    dl = client.get(f"/v1/ponto/justificativas/{body['id']}/anexo", headers=admin)
+    assert dl.status_code == 200
+    assert dl.content == pdf

--- a/backend/tests/test_ponto_lote_f_975_970.py
+++ b/backend/tests/test_ponto_lote_f_975_970.py
@@ -1,0 +1,152 @@
+"""Lote F ponto: export folha RH (#975) e cobertura de plantão (#970)."""
+
+from datetime import date, timedelta
+
+
+def _patch_jornada_hoje(client, headers, atendente_id: int, *, ativo=True):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    # Semanal exige pelo menos um dia ativo
+    outro = keys[(date.today().weekday() + 1) % 7]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": ativo, "inicio": "08:00", "fim": "18:00"}
+    if not ativo:
+        hs[outro] = {"ativo": True, "inicio": "08:00", "fim": "18:00"}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 15,
+        },
+    )
+
+
+def test_export_folha_csv_colunas(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    desde = date.today().replace(day=1).isoformat()
+    ate = date.today().isoformat()
+    r = client.get(
+        "/v1/ponto/export/folha.csv",
+        headers=admin,
+        params={"desde": desde, "ate": ate},
+    )
+    assert r.status_code == 200, r.text
+    assert "text/csv" in r.headers.get("content-type", "")
+    text = r.content.decode("utf-8-sig")
+    header = text.splitlines()[0]
+    for col in (
+        "matricula",
+        "nome",
+        "previsto_horas",
+        "realizado_horas",
+        "atrasos",
+        "faltas",
+        "he_minutos",
+        "banco_horas",
+        "ajustes",
+    ):
+        assert col in header
+
+
+def test_export_folha_xlsx(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    desde = date.today().replace(day=1).isoformat()
+    ate = date.today().isoformat()
+    r = client.get(
+        "/v1/ponto/export/folha.xlsx",
+        headers=admin,
+        params={"desde": desde, "ate": ate},
+    )
+    assert r.status_code == 200, r.text
+    assert r.content[:2] == b"PK"  # zip/xlsx
+
+
+def test_cobertura_fluxo_solicitar_aceitar_homologar(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1h = auth_headers["a1"]
+    a2h = auth_headers["a2"]
+    a1 = seed_base["a1"]
+    a2 = seed_base["a2"]
+    assert _patch_jornada_hoje(client, admin, a1.id, ativo=True).status_code == 200
+    assert _patch_jornada_hoje(client, admin, a2.id, ativo=False).status_code == 200
+
+    data_ref = date.today().isoformat()
+    sol = client.post(
+        "/v1/ponto/coberturas",
+        headers=a1h,
+        json={"cobertor_id": a2.id, "data_ref": data_ref, "motivo": "Consulta médica"},
+    )
+    assert sol.status_code == 201, sol.text
+    cob_id = sol.json()["id"]
+    assert sol.json()["estado"] == "pendente_cobertor"
+
+    resp = client.post(
+        f"/v1/ponto/coberturas/{cob_id}/responder",
+        headers=a2h,
+        json={"aceitar": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["estado"] == "pendente_admin"
+
+    dec = client.post(
+        f"/v1/ponto/coberturas/{cob_id}/decidir",
+        headers=admin,
+        json={"aprovar": True},
+    )
+    assert dec.status_code == 200, dec.text
+    assert dec.json()["estado"] == "aprovada"
+
+    hoje = date.today()
+    cal1 = client.get(
+        "/v1/ponto/me/calendario",
+        headers=a1h,
+        params={"ano": hoje.year, "mes": hoje.month},
+    )
+    assert cal1.status_code == 200, cal1.text
+    dia1 = next(d for d in cal1.json()["dias"] if d["data"] == data_ref)
+    assert dia1["esperado"] is False
+    assert dia1["status"] != "falta"
+
+    cal2 = client.get(
+        "/v1/ponto/me/calendario",
+        headers=a2h,
+        params={"ano": hoje.year, "mes": hoje.month},
+    )
+    assert cal2.status_code == 200, cal2.text
+    dia2 = next(d for d in cal2.json()["dias"] if d["data"] == data_ref)
+    assert dia2["esperado"] is True
+
+
+def test_cobertura_admin_conceder(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    a2 = seed_base["a2"]
+    data_ref = (date.today() + timedelta(days=1)).isoformat()
+    r = client.post(
+        "/v1/ponto/coberturas/conceder",
+        headers=admin,
+        json={
+            "solicitante_id": a1.id,
+            "cobertor_id": a2.id,
+            "data_ref": data_ref,
+            "motivo": "Plantão urgente",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["estado"] == "aprovada"
+    assert r.json()["origem"] == "admin"
+
+
+def test_cobertura_colegas_e_me(client, seed_base, auth_headers):
+    a1h = auth_headers["a1"]
+    cols = client.get("/v1/ponto/coberturas/colegas", headers=a1h)
+    assert cols.status_code == 200, cols.text
+    ids = {c["id"] for c in cols.json()}
+    assert seed_base["a1"].id not in ids
+    assert seed_base["a2"].id in ids
+
+    me = client.get("/v1/ponto/coberturas/me", headers=a1h)
+    assert me.status_code == 200

--- a/backend/tests/test_ponto_lote_g_981_978_979.py
+++ b/backend/tests/test_ponto_lote_g_981_978_979.py
@@ -1,0 +1,78 @@
+"""Lote G ponto: setup (#981), competência (#978), ciência (#979)."""
+
+from datetime import date, datetime, timezone
+
+
+def test_setup_status_admin(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    r = client.get("/v1/ponto/setup-status", headers=admin)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "itens" in body
+    assert body["defaults_fecho_off"] is True
+    assert body["tolerancia_sugerida_minutos"] == 15
+    assert any(i["codigo"] == "jornada_colaboradores" for i in body["itens"])
+
+
+def test_competencia_fechar_reabrir_e_ajuste_pos(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    hoje = date.today()
+    ano, mes = hoje.year, hoje.month
+
+    fech = client.post(f"/v1/ponto/competencias/{ano}/{mes}/fechar", headers=admin)
+    assert fech.status_code == 200, fech.text
+    assert fech.json()["fechada"] is True
+
+    getc = client.get(f"/v1/ponto/competencias/{ano}/{mes}", headers=admin)
+    assert getc.json()["fechada"] is True
+
+    ajuste = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": datetime.now(timezone.utc).isoformat(),
+            "motivo": "Correção pós-fechamento",
+        },
+    )
+    assert ajuste.status_code == 201, ajuste.text
+
+    reab = client.post(
+        f"/v1/ponto/competencias/{ano}/{mes}/reabrir",
+        headers=admin,
+        json={"motivo": "Erro no fechamento"},
+    )
+    assert reab.status_code == 200, reab.text
+    assert reab.json()["fechada"] is False
+
+
+def test_ciencia_somente_apos_fechamento(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    hoje = date.today()
+    # Usa mês passado para não conflitar com teste anterior no mesmo worker
+    if hoje.month == 1:
+        ano, mes = hoje.year - 1, 12
+    else:
+        ano, mes = hoje.year, hoje.month - 1
+
+    bloqueado = client.post(f"/v1/ponto/me/ciencia?ano={ano}&mes={mes}", headers=user)
+    assert bloqueado.status_code == 400
+
+    assert client.post(f"/v1/ponto/competencias/{ano}/{mes}/fechar", headers=admin).status_code == 200
+
+    ok = client.post(f"/v1/ponto/me/ciencia?ano={ano}&mes={mes}", headers=user)
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["confirmada"] is True
+
+    lista = client.get(f"/v1/ponto/competencias/{ano}/{mes}/ciencias", headers=admin)
+    assert lista.status_code == 200
+    a1 = seed_base["a1"]
+    item = next(i for i in lista.json() if i["atendente_id"] == a1.id)
+    assert item["confirmada"] is True
+
+    me = client.get(f"/v1/ponto/me/ciencia?ano={ano}&mes={mes}", headers=user)
+    assert me.json()["confirmada"] is True
+    assert me.json()["pode_confirmar"] is False

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -27,6 +27,7 @@ Evento inicial ao conectar:
 | `notificacao.contagem` | RT-F3 — contadores navbar | `NotificacaoResumo` (compatível com `/notificacoes/resumo`) |
 | `chat.interno.mensagem` | Nova mensagem no chat interno | `{ conversa_id, tipo, setor_id?, remetente_id, corpo_preview }` |
 | `chat.interno.mensagem.atualizada` | Mensagem editada, apagada ou reação alterada | `{ conversa_id, mensagem_id, acao }` — `acao`: `editada` \| `apagada` \| `reacao` |
+| `ponto.he_atualizada` | Pedido/decisão/concessão de hora extra (#982) | `{ he_id, atendente_id, estado, origem }` |
 
 Destinatários filtrados por RBAC (setor homônimo + admin).
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -838,6 +838,50 @@ export const ponto = {
     }
     return res.blob()
   },
+  exportFolha: async (
+    ext: 'csv' | 'xlsx',
+    params: { atendente_id?: number; desde: string; ate: string },
+  ) => {
+    const token = getAuthToken()
+    const headers: Record<string, string> = {}
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const path = ext === 'csv' ? '/ponto/export/folha.csv' : '/ponto/export/folha.xlsx'
+    const url = `${apiOrigin()}${API_VERSION_PREFIX}${withParams(path, params)}`
+    const res = await fetch(url, { headers })
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin()
+      throw new ApiError('Sessão expirada ou inválida.', 401, {})
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}))
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody)
+    }
+    return res.blob()
+  },
+  solicitarCobertura: (data: Ponto.CoberturaCreate) =>
+    api<Ponto.Cobertura>('/ponto/coberturas', { method: 'POST', body: JSON.stringify(data) }),
+  minhasCoberturas: () => api<Ponto.Cobertura[]>('/ponto/coberturas/me'),
+  colegasCobertura: () => api<Ponto.CoberturaColega[]>('/ponto/coberturas/colegas'),
+  responderCobertura: (id: number, data: Ponto.CoberturaResposta) =>
+    api<Ponto.Cobertura>(`/ponto/coberturas/${id}/responder`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  coberturasAdmin: (estado?: string) =>
+    api<Ponto.Cobertura[]>(withParams('/ponto/coberturas', { estado })),
+  concederCobertura: (data: Ponto.CoberturaConceder) =>
+    api<Ponto.Cobertura>('/ponto/coberturas/conceder', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  decidirCobertura: (id: number, data: Ponto.CoberturaDecisao) =>
+    api<Ponto.Cobertura>(`/ponto/coberturas/${id}/decidir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   meSettings: () => api<Ponto.SettingsPublic>('/ponto/me/settings'),
   locais: (params?: { atendente_id?: number; so_orfos?: boolean }) =>
     api<Ponto.Local[]>(withParams('/ponto/locais', params)),
@@ -5022,6 +5066,45 @@ export namespace Ponto {
     estado: 'aprovada' | 'rejeitada'
     decisao_motivo: string
     aplicar_batidas?: { tipo: Tipo; registrado_em: string; motivo: string }[]
+  }
+  export interface CoberturaCreate {
+    cobertor_id: number
+    data_ref: string
+    motivo?: string | null
+  }
+  export interface CoberturaColega {
+    id: number
+    nome: string
+  }
+  export interface CoberturaConceder {
+    solicitante_id: number
+    cobertor_id: number
+    data_ref: string
+    motivo?: string | null
+  }
+  export interface CoberturaResposta {
+    aceitar: boolean
+  }
+  export interface CoberturaDecisao {
+    aprovar: boolean
+    decisao_motivo?: string | null
+  }
+  export interface Cobertura {
+    id: number
+    solicitante_id: number
+    solicitante_nome?: string | null
+    cobertor_id: number
+    cobertor_nome?: string | null
+    data_ref: string
+    motivo?: string | null
+    estado: string
+    origem?: string
+    resposta_cobertor?: string | null
+    respondido_em?: string | null
+    decidido_por_id?: number | null
+    decidido_em?: string | null
+    decisao_motivo?: string | null
+    created_at?: string | null
   }
   export interface HoraExtra {
     id: number

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2516,6 +2516,7 @@ export namespace Atendentes {
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
     he_teto_minutos?: number | null;
+    he_teto_mensal_minutos?: number | null;
     /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
     saas_setor_ids?: number[];
     saas_setor_nomes?: string[];
@@ -2539,6 +2540,7 @@ export namespace Atendentes {
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
     he_teto_minutos?: number | null;
+    he_teto_mensal_minutos?: number | null;
   }
   export interface Update {
     email?: string;
@@ -2559,6 +2561,7 @@ export namespace Atendentes {
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
     he_teto_minutos?: number | null;
+    he_teto_mensal_minutos?: number | null;
   }
   export interface AvaliacaoResumo {
     media: number | null;
@@ -4908,6 +4911,7 @@ export namespace Ponto {
     jornadas_abertas: number
     online_sem_ponto: number
     justificativas_pendentes: number
+    he_acima_teto_mensal?: number
     itens: HojeItem[]
   }
   export interface Settings {
@@ -4916,6 +4920,7 @@ export namespace Ponto {
     fecho_apos_horas: number
     fecho_margem_pos_saida_minutos: number
     jornada_diaria_minutos: number
+    he_teto_mensal_minutos?: number | null
     politica_geolocalizacao: PoliticaGeolocalizacao
   }
   export interface SettingsPublic {
@@ -4928,6 +4933,7 @@ export namespace Ponto {
     fecho_apos_horas?: number
     fecho_margem_pos_saida_minutos?: number
     jornada_diaria_minutos?: number
+    he_teto_mensal_minutos?: number | null
     politica_geolocalizacao?: PoliticaGeolocalizacao
   }
   export interface Local {
@@ -5039,6 +5045,9 @@ export namespace Ponto {
   }
   export interface HoraExtraCreate {
     motivo?: string | null
+    modo?: 'resto_do_dia' | 'ate_horario' | 'duracao' | null
+    ate_horario?: string | null
+    duracao_minutos?: number | null
   }
   export interface HoraExtraDecisao {
     aprovar: boolean
@@ -5059,8 +5068,11 @@ export namespace Ponto {
     pode_pegar_whatsapp: boolean
     he_ativa?: HoraExtra | null
     pedido_pendente?: HoraExtra | null
+    ultimo_rejeitado?: HoraExtra | null
     he_teto_minutos?: number | null
     he_restante_minutos?: number | null
+    he_teto_mensal_minutos?: number | null
+    he_consumido_mensal_minutos?: number
   }
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -882,6 +882,22 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  setupStatus: () => api<Ponto.SetupStatus>('/ponto/setup-status'),
+  competencia: (ano: number, mes: number) =>
+    api<Ponto.Competencia>(`/ponto/competencias/${ano}/${mes}`),
+  fecharCompetencia: (ano: number, mes: number) =>
+    api<Ponto.Competencia>(`/ponto/competencias/${ano}/${mes}/fechar`, { method: 'POST' }),
+  reabrirCompetencia: (ano: number, mes: number, data: { motivo: string }) =>
+    api<Ponto.Competencia>(`/ponto/competencias/${ano}/${mes}/reabrir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  cienciasAdmin: (ano: number, mes: number) =>
+    api<Ponto.CienciaItem[]>(`/ponto/competencias/${ano}/${mes}/ciencias`),
+  minhaCiencia: (ano: number, mes: number) =>
+    api<Ponto.CienciaMe>(withParams('/ponto/me/ciencia', { ano, mes })),
+  confirmarCiencia: (ano: number, mes: number) =>
+    api<Ponto.CienciaMe>(withParams('/ponto/me/ciencia', { ano, mes }), { method: 'POST' }),
   meSettings: () => api<Ponto.SettingsPublic>('/ponto/me/settings'),
   locais: (params?: { atendente_id?: number; so_orfos?: boolean }) =>
     api<Ponto.Local[]>(withParams('/ponto/locais', params)),
@@ -5105,6 +5121,46 @@ export namespace Ponto {
     decidido_em?: string | null
     decisao_motivo?: string | null
     created_at?: string | null
+  }
+  export interface SetupItem {
+    codigo: string
+    titulo: string
+    detalhe: string
+    destino: string
+    ok: boolean
+    informativo?: boolean
+  }
+  export interface SetupStatus {
+    defaults_fecho_off: boolean
+    tolerancia_sugerida_minutos: number
+    pendentes: number
+    itens: SetupItem[]
+  }
+  export interface Competencia {
+    id: number
+    ano: number
+    mes: number
+    fechada: boolean
+    fechado_em?: string | null
+    fechado_por_id?: number | null
+    fechado_por_nome?: string | null
+    reaberto_em?: string | null
+    reaberto_por_id?: number | null
+    reabrir_motivo?: string | null
+  }
+  export interface CienciaMe {
+    ano: number
+    mes: number
+    competencia_fechada: boolean
+    confirmada: boolean
+    confirmado_em?: string | null
+    pode_confirmar: boolean
+  }
+  export interface CienciaItem {
+    atendente_id: number
+    atendente_nome: string
+    confirmada: boolean
+    confirmado_em?: string | null
   }
   export interface HoraExtra {
     id: number

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -717,6 +717,8 @@ export const ponto = {
     api<Ponto.Calendario>(withParams('/ponto/me/calendario', { ano, mes })),
   meuBancoHoras: (desde: string, ate: string) =>
     api<Ponto.BancoHoras>(withParams('/ponto/me/banco-horas', { desde, ate })),
+  meuResumoSemana: (ref?: string) =>
+    api<Ponto.ResumoSemana>(withParams('/ponto/me/resumo-semana', ref ? { ref } : {})),
   bancoHorasAdmin: (atendenteId: number, desde: string, ate: string) =>
     api<Ponto.BancoHoras>(
       withParams('/ponto/banco-horas', { atendente_id: atendenteId, desde, ate }),
@@ -4972,7 +4974,20 @@ export namespace Ponto {
     online_sem_ponto: boolean
     jornada_aberta_longa: boolean
     horas_jornada_aberta: number | null
+    lembrete_entrada_tolerancia?: boolean
+    lembrete_saida_tolerancia?: boolean
     mensagens: string[]
+  }
+  export interface ResumoSemana {
+    desde: string
+    ate: string
+    segundos_esperados: number
+    segundos_realizados: number
+    saldo_segundos: number
+    atrasos: number
+    he_minutos: number
+    dias_escala: number
+    dias_feriado?: number
   }
   export interface AjusteCreate {
     atendente_id: number

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -774,6 +774,11 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  concederHoraExtra: (data: Ponto.HoraExtraConceder) =>
+    api<Ponto.HoraExtra>('/ponto/hora-extra/conceder', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   exportCsv: async (params?: { atendente_id?: number; desde?: string; ate?: string }) => {
     const token = getAuthToken()
     const headers: Record<string, string> = {}
@@ -2508,6 +2513,7 @@ export namespace Atendentes {
     tolerancia_atraso_minutos?: number;
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
+    he_teto_minutos?: number | null;
     /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
     saas_setor_ids?: number[];
     saas_setor_nomes?: string[];
@@ -2530,6 +2536,7 @@ export namespace Atendentes {
     tolerancia_atraso_minutos?: number;
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
+    he_teto_minutos?: number | null;
   }
   export interface Update {
     email?: string;
@@ -2549,6 +2556,7 @@ export namespace Atendentes {
     tolerancia_atraso_minutos?: number;
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
+    he_teto_minutos?: number | null;
   }
   export interface AvaliacaoResumo {
     media: number | null;
@@ -5008,6 +5016,7 @@ export namespace Ponto {
     motivo?: string | null
     modo?: string | null
     ate_em?: string | null
+    origem?: string
     decidido_por_id?: number | null
     decidido_em?: string | null
     decisao_motivo?: string | null
@@ -5018,15 +5027,25 @@ export namespace Ponto {
   }
   export interface HoraExtraDecisao {
     aprovar: boolean
-    modo?: 'resto_do_dia' | 'ate_horario' | null
+    modo?: 'resto_do_dia' | 'ate_horario' | 'duracao' | null
     ate_horario?: string | null
+    duracao_minutos?: number | null
     decisao_motivo?: string | null
+  }
+  export interface HoraExtraConceder {
+    atendente_id: number
+    modo: 'resto_do_dia' | 'ate_horario' | 'duracao'
+    ate_horario?: string | null
+    duracao_minutos?: number | null
+    motivo?: string | null
   }
   export interface HoraExtraMeStatus {
     fora_da_jornada: boolean
     pode_pegar_whatsapp: boolean
     he_ativa?: HoraExtra | null
     pedido_pendente?: HoraExtra | null
+    he_teto_minutos?: number | null
+    he_restante_minutos?: number | null
   }
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -754,6 +754,14 @@ export const ponto = {
     }),
   criarJustificativa: (data: Ponto.JustificativaCreate) =>
     api<Ponto.Justificativa>('/ponto/justificativas', { method: 'POST', body: JSON.stringify(data) }),
+  criarJustificativaComAnexo: (data: Ponto.JustificativaCreate, arquivo: File) => {
+    const fd = new FormData()
+    fd.append('data_ref', data.data_ref)
+    fd.append('tipo', data.tipo)
+    fd.append('motivo', data.motivo)
+    fd.append('arquivo', arquivo)
+    return api<Ponto.Justificativa>('/ponto/justificativas/upload', { method: 'POST', body: fd })
+  },
   minhasJustificativas: () => api<Ponto.Justificativa[]>('/ponto/justificativas/me'),
   justificativasAdmin: (estado?: string) =>
     api<Ponto.Justificativa[]>(withParams('/ponto/justificativas', { estado })),
@@ -762,6 +770,43 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  justificativaAnexoUrl: (id: number) =>
+    `${apiOrigin()}${API_VERSION_PREFIX}/ponto/justificativas/${id}/anexo`,
+  baixarJustificativaAnexo: async (id: number, nome?: string | null) => {
+    const token = getAuthToken()
+    const headers: Record<string, string> = {}
+    if (token) headers.Authorization = `Bearer ${token}`
+    if (isMultiTenantMode()) {
+      const tid = resolveTenantIdFromHostname()
+      if (tid) headers['X-Dx-Tenant-Id'] = String(tid)
+    }
+    const res = await fetch(
+      `${apiOrigin()}${API_VERSION_PREFIX}/ponto/justificativas/${id}/anexo`,
+      { headers },
+    )
+    if (!res.ok) throw new ApiError('Falha ao baixar anexo', res.status, await res.text())
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = nome || `justificativa-${id}`
+    a.click()
+    URL.revokeObjectURL(url)
+  },
+  solicitarAusencia: (data: Ponto.AusenciaCreate) =>
+    api<Ponto.Ausencia>('/ponto/ausencias', { method: 'POST', body: JSON.stringify(data) }),
+  minhasAusencias: () => api<Ponto.Ausencia[]>('/ponto/ausencias/me'),
+  ausenciasAdmin: (estado?: string) =>
+    api<Ponto.Ausencia[]>(withParams('/ponto/ausencias', { estado })),
+  concederAusencia: (data: Ponto.AusenciaConceder) =>
+    api<Ponto.Ausencia>('/ponto/ausencias/conceder', { method: 'POST', body: JSON.stringify(data) }),
+  decidirAusencia: (id: number, data: Ponto.AusenciaDecisao) =>
+    api<Ponto.Ausencia>(`/ponto/ausencias/${id}/decidir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  removerAusencia: (id: number) =>
+    api<void>(`/ponto/ausencias/${id}`, { method: 'DELETE' }),
   horaExtraMeStatus: () => api<Ponto.HoraExtraMeStatus>('/ponto/hora-extra/me/status'),
   minhasHoraExtra: () => api<Ponto.HoraExtra[]>('/ponto/hora-extra/me'),
   solicitarHoraExtra: (data?: Ponto.HoraExtraCreate) =>
@@ -4783,6 +4828,8 @@ export namespace Ponto {
     | 'parcial'
     | 'folga'
     | 'folga_com_ponto'
+    | 'folga_programada'
+    | 'ferias'
     | 'livre'
     | 'atraso'
     | 'feriado'
@@ -4859,11 +4906,14 @@ export namespace Ponto {
     status: StatusDia
     atrasado?: boolean
     feriado?: boolean
+    ausencia_tipo?: string | null
+    pausa_abaixo_minimo?: boolean
     segundos_trabalhados?: number
     segundos_esperados?: number
+    segundos_pausa?: number
     classe_visual?: ClasseVisualDia
   }
-  export type ClasseVisualDia = 'abaixo' | 'ok' | 'he' | 'feriado' | 'neutro'
+  export type ClasseVisualDia = 'abaixo' | 'ok' | 'he' | 'feriado' | 'ausencia' | 'neutro'
   export interface Calendario {
     atendente_id: number
     ano: number
@@ -4916,6 +4966,7 @@ export namespace Ponto {
     fecho_apos_horas: number
     fecho_margem_pos_saida_minutos: number
     jornada_diaria_minutos: number
+    pausa_minima_minutos?: number
     politica_geolocalizacao: PoliticaGeolocalizacao
   }
   export interface SettingsPublic {
@@ -4928,6 +4979,7 @@ export namespace Ponto {
     fecho_apos_horas?: number
     fecho_margem_pos_saida_minutos?: number
     jornada_diaria_minutos?: number
+    pausa_minima_minutos?: number
     politica_geolocalizacao?: PoliticaGeolocalizacao
   }
   export interface Local {
@@ -5016,12 +5068,48 @@ export namespace Ponto {
     decisao_motivo?: string | null
     decidido_por_id?: number | null
     decidido_em?: string | null
+    tem_anexo?: boolean
+    anexo_nome?: string | null
+    anexo_content_type?: string | null
+    anexo_tamanho_bytes?: number | null
     created_at?: string | null
   }
   export interface JustificativaDecisao {
     estado: 'aprovada' | 'rejeitada'
     decisao_motivo: string
     aplicar_batidas?: { tipo: Tipo; registrado_em: string; motivo: string }[]
+  }
+  export interface AusenciaCreate {
+    tipo: 'ferias' | 'folga_programada'
+    desde: string
+    ate: string
+    motivo?: string | null
+  }
+  export interface AusenciaConceder {
+    atendente_id: number
+    tipo: 'ferias' | 'folga_programada'
+    desde: string
+    ate: string
+    motivo?: string | null
+  }
+  export interface AusenciaDecisao {
+    aprovar: boolean
+    decisao_motivo?: string | null
+  }
+  export interface Ausencia {
+    id: number
+    atendente_id: number
+    atendente_nome?: string | null
+    tipo: string
+    desde: string
+    ate: string
+    motivo?: string | null
+    estado: string
+    origem?: string
+    decidido_por_id?: number | null
+    decidido_em?: string | null
+    decisao_motivo?: string | null
+    created_at?: string | null
   }
   export interface HoraExtra {
     id: number

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -77,7 +77,7 @@ function LayoutInner() {
     return () => window.removeEventListener(TICKET_ATIVO_EVENT, sync)
   }, [location.pathname])
 
-  /** Conversa aberta no hub — ocultar chrome da app no telemóvel (#753). */
+  /** Conversa aberta no hub — ocultar chrome da app só no celular (#753 / #S202608-0007). */
   const [chatDetalheAberto, setChatDetalheAberto] = useState(
     () => isChatHub && lerChatAtivoSession() != null,
   )
@@ -124,9 +124,10 @@ function LayoutInner() {
       />
 
       <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden md:col-start-2 md:row-start-1">
+        {/* Com conversa aberta, esconde a barra só no celular (#996 / #S202608-0007). */}
         <header
           className={`z-30 flex h-16 min-h-[64px] w-full min-w-0 shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6 ${
-            ocultarHeaderMobile ? 'hidden' : ''
+            ocultarHeaderMobile ? 'max-md:hidden' : ''
           }`}
         >
           <button

--- a/frontend/src/components/PontoAjudaModal.tsx
+++ b/frontend/src/components/PontoAjudaModal.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { Button } from './ui/Button'
+import { PONTO_AJUDA_SECOES, PONTO_AJUDA_TITULO } from '../lib/pontoAjuda'
+
+type Props = {
+  open: boolean
+  onClose: () => void
+}
+
+export function PontoAjudaModal({ open, onClose }: Props) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[700] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ponto-ajuda-modal-title"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/50 backdrop-blur-[1px]"
+        onClick={onClose}
+        aria-label="Fechar ajuda"
+      />
+      <div className="relative max-h-[min(85vh,720px)] w-full max-w-lg overflow-y-auto rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-600 dark:bg-slate-900 md:max-w-2xl">
+        <h2 id="ponto-ajuda-modal-title" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          {PONTO_AJUDA_TITULO}
+        </h2>
+        <div className="mt-4 space-y-5">
+          {PONTO_AJUDA_SECOES.map((sec) => (
+            <section key={sec.titulo}>
+              <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">{sec.titulo}</h3>
+              <ul className="mt-2 list-disc space-y-1.5 pl-5 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                {sec.paragrafos.map((p) => (
+                  <li key={p.slice(0, 40)}>{p}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <div className="mt-6 flex justify-end">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Fechar
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/components/PontoAlertasBanner.tsx
+++ b/frontend/src/components/PontoAlertasBanner.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { ponto } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 
-/** Banner de lembretes de ponto (#773 / #769) — sem batida automática. */
+/** Banner de lembretes de ponto (#773 / #769 / #968) — sem batida automática. */
 export function PontoAlertasBanner() {
   const { user } = useAuth()
   const [mensagens, setMensagens] = useState<string[]>([])
@@ -12,16 +12,30 @@ export function PontoAlertasBanner() {
   useEffect(() => {
     if (!user || user.must_change_password || user.role === 'saas_ops') return
     let cancelled = false
-    void ponto
-      .alertas()
-      .then((a) => {
-        if (!cancelled) setMensagens(a.mensagens ?? [])
-      })
-      .catch(() => {
-        /* silencioso — não bloquear o painel */
-      })
+
+    const carregar = () => {
+      void ponto
+        .alertas()
+        .then((a) => {
+          if (cancelled) return
+          setMensagens(a.mensagens ?? [])
+          if ((a.mensagens ?? []).length === 0) setDismissed(false)
+        })
+        .catch(() => {
+          /* silencioso — não bloquear o painel */
+        })
+    }
+
+    carregar()
+    const id = window.setInterval(carregar, 60_000)
+    const onVis = () => {
+      if (document.visibilityState === 'visible') carregar()
+    }
+    document.addEventListener('visibilitychange', onVis)
     return () => {
       cancelled = true
+      window.clearInterval(id)
+      document.removeEventListener('visibilitychange', onVis)
     }
   }, [user])
 

--- a/frontend/src/components/PontoCalendarioMes.tsx
+++ b/frontend/src/components/PontoCalendarioMes.tsx
@@ -30,6 +30,8 @@ function classeCss(classe: Ponto.ClasseVisualDia | undefined): string {
       return 'bg-sky-100/90 text-sky-900 ring-sky-200/80 hover:bg-sky-200/90 dark:bg-sky-950/45 dark:text-sky-100 dark:ring-sky-900 dark:hover:bg-sky-950/70'
     case 'feriado':
       return 'bg-orange-100/90 text-orange-900 ring-orange-200/80 hover:bg-orange-200/90 dark:bg-orange-950/45 dark:text-orange-100 dark:ring-orange-900 dark:hover:bg-orange-950/70'
+    case 'ausencia':
+      return 'bg-violet-100/90 text-violet-900 ring-violet-200/80 hover:bg-violet-200/90 dark:bg-violet-950/45 dark:text-violet-100 dark:ring-violet-900 dark:hover:bg-violet-950/70'
     default:
       return 'bg-slate-50 text-slate-600 ring-slate-200/80 hover:bg-slate-100 dark:bg-slate-800/40 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800/70'
   }
@@ -45,6 +47,8 @@ function rotuloClasse(classe: Ponto.ClasseVisualDia | undefined): string {
       return 'Hora extra'
     case 'feriado':
       return 'Feriado'
+    case 'ausencia':
+      return 'Férias / folga'
     default:
       return 'Sem jornada'
   }
@@ -179,6 +183,7 @@ export function PontoCalendarioMes({
             ['ok', 'Dentro da meta'],
             ['he', 'Hora extra'],
             ['feriado', 'Feriado'],
+            ['ausencia', 'Férias / folga'],
             ['neutro', 'Sem jornada'],
           ] as const
         ).map(([k, label]) => (
@@ -213,6 +218,12 @@ export function PontoCalendarioMes({
             Entrada: {detalhe.tem_entrada ? 'sim' : 'não'} · Saída: {detalhe.tem_saida ? 'sim' : 'não'}
             {detalhe.atrasado ? ' · Atraso' : ''}
             {detalhe.feriado ? ' · Feriado' : ''}
+            {detalhe.ausencia_tipo === 'ferias'
+              ? ' · Férias'
+              : detalhe.ausencia_tipo === 'folga_programada'
+                ? ' · Folga programada'
+                : ''}
+            {detalhe.pausa_abaixo_minimo ? ' · Pausa abaixo do mínimo' : ''}
           </p>
           <p className="mt-2 text-xs text-cyan-700 dark:text-cyan-300">
             O histórico ao lado filtra este dia automaticamente.

--- a/frontend/src/lib/pontoAjuda.ts
+++ b/frontend/src/lib/pontoAjuda.ts
@@ -1,0 +1,55 @@
+/** Textos de ajuda do módulo ponto (#980) — pt-BR para o usuário final. */
+
+export const PONTO_AJUDA_TITULO = 'Como funciona o ponto'
+
+export type PontoAjudaSecao = {
+  titulo: string
+  paragrafos: string[]
+}
+
+export const PONTO_AJUDA_SECOES: PontoAjudaSecao[] = [
+  {
+    titulo: 'Modos de jornada',
+    paragrafos: [
+      'Nenhum: o sistema não espera dias de trabalho; o calendário fica neutro e faltas automáticas não se aplicam.',
+      'Semanal: cada dia da semana tem horário de início e fim (como uma grade). Só nesses dias há jornada esperada.',
+      'Ciclo: padrão X dias de trabalho × Y de folga, a partir de uma data de referência definida no cadastro.',
+    ],
+  },
+  {
+    titulo: 'Tolerância e atraso',
+    paragrafos: [
+      'A tolerância vale nos dois lados: você pode entrar a partir de (início − tolerância) e o atraso só conta depois de (início + tolerância).',
+      'Se o admin não configurou jornada, essas regras de atraso/falta não entram em jogo.',
+    ],
+  },
+  {
+    titulo: 'Falta, parcial e folga',
+    paragrafos: [
+      'Falta: dia esperado sem entrada registrada.',
+      'Parcial: houve entrada, mas a saída ainda não fechou a jornada do dia.',
+      'Folga: dia fora da escala; se mesmo assim houver batidas, aparece como folga com ponto.',
+    ],
+  },
+  {
+    titulo: 'Fecho por esquecimento',
+    paragrafos: [
+      'Por padrão o fecho automático fica desligado até o admin ativar nas configurações do ponto.',
+      'Quando ativo, o sistema pode fechar uma jornada aberta após N horas ou após a saída prevista + margem — o que ocorrer primeiro.',
+    ],
+  },
+  {
+    titulo: 'Hora extra e WhatsApp',
+    paragrafos: [
+      'Depois do fim da jornada, pegar chat WhatsApp novo pode exigir liberação de hora extra pelo admin.',
+      'O admin pode liberar o resto do dia, até um horário ou por uma duração em minutos; há teto opcional por colaborador.',
+    ],
+  },
+  {
+    titulo: 'Cobertura e competência',
+    paragrafos: [
+      'Cobertura de plantão: você pede a um colega, ele aceita e o admin homologa (ou o admin agenda direto). No dia, quem pediu não gera falta e quem cobre passa a ter jornada esperada.',
+      'Quando o admin fecha o mês (competência), ajustes posteriores ficam marcados como pós-fechamento. Você pode confirmar ciência no espelho mensal depois do fechamento.',
+    ],
+  },
+]

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -60,6 +60,7 @@ export function AtendenteForm() {
   const [usarLocalEmpresa, setUsarLocalEmpresa] = useState(true)
   const [localEmpresaRaio, setLocalEmpresaRaio] = useState('')
   const [heTetoMinutos, setHeTetoMinutos] = useState('')
+  const [heTetoMensalMinutos, setHeTetoMensalMinutos] = useState('')
 
   useEffect(() => {
     coletarTodasPaginas<Setores.Setor>((o, l) =>
@@ -108,6 +109,7 @@ export function AtendenteForm() {
           a.local_empresa_raio_metros != null ? String(a.local_empresa_raio_metros) : '',
         )
         setHeTetoMinutos(a.he_teto_minutos != null ? String(a.he_teto_minutos) : '')
+        setHeTetoMensalMinutos(a.he_teto_mensal_minutos != null ? String(a.he_teto_mensal_minutos) : '')
         if (a.escala_horas_trabalho === 12 && a.escala_horas_folga === 36) setPresetEscala('12x36')
         else if (a.escala_horas_trabalho === 6 && a.escala_horas_folga === 18) setPresetEscala('6x18')
         else if (a.escala_horas_trabalho === 24 && a.escala_horas_folga === 48) setPresetEscala('24x48')
@@ -202,10 +204,16 @@ export function AtendenteForm() {
     }
   }
 
-  function payloadHeTeto(): { he_teto_minutos: number | null } {
+  function payloadHeTeto(): {
+    he_teto_minutos: number | null
+    he_teto_mensal_minutos: number | null
+  } {
     const raw = heTetoMinutos.trim()
-    if (!raw) return { he_teto_minutos: null }
-    return { he_teto_minutos: Math.min(1440, Math.max(15, Number(raw) || 15)) }
+    const rawM = heTetoMensalMinutos.trim()
+    return {
+      he_teto_minutos: raw ? Math.min(1440, Math.max(15, Number(raw) || 15)) : null,
+      he_teto_mensal_minutos: rawM ? Math.min(44640, Math.max(30, Number(rawM) || 30)) : null,
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -469,6 +477,19 @@ export function AtendenteForm() {
               <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                 Vazio = sem teto. Cada concessão (resto do dia, até horário ou duração) é limitada a esse
                 máximo a partir do momento da liberação.
+              </p>
+              <Input
+                className="mt-3"
+                label="Teto mensal (minutos)"
+                type="number"
+                min={30}
+                max={44640}
+                value={heTetoMensalMinutos}
+                onChange={(e) => setHeTetoMensalMinutos(e.target.value)}
+                placeholder="Usar global / sem limite"
+              />
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Sobrescreve o teto global de Ponto da equipe. Vazio = usa o global (se houver).
               </p>
             </FormSection>
             {isEdit && !Number.isNaN(atendenteId) ? (

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -59,6 +59,7 @@ export function AtendenteForm() {
   const [toleranciaAtraso, setToleranciaAtraso] = useState('0')
   const [usarLocalEmpresa, setUsarLocalEmpresa] = useState(true)
   const [localEmpresaRaio, setLocalEmpresaRaio] = useState('')
+  const [heTetoMinutos, setHeTetoMinutos] = useState('')
 
   useEffect(() => {
     coletarTodasPaginas<Setores.Setor>((o, l) =>
@@ -106,6 +107,7 @@ export function AtendenteForm() {
         setLocalEmpresaRaio(
           a.local_empresa_raio_metros != null ? String(a.local_empresa_raio_metros) : '',
         )
+        setHeTetoMinutos(a.he_teto_minutos != null ? String(a.he_teto_minutos) : '')
         if (a.escala_horas_trabalho === 12 && a.escala_horas_folga === 36) setPresetEscala('12x36')
         else if (a.escala_horas_trabalho === 6 && a.escala_horas_folga === 18) setPresetEscala('6x18')
         else if (a.escala_horas_trabalho === 24 && a.escala_horas_folga === 48) setPresetEscala('24x48')
@@ -200,6 +202,12 @@ export function AtendenteForm() {
     }
   }
 
+  function payloadHeTeto(): { he_teto_minutos: number | null } {
+    const raw = heTetoMinutos.trim()
+    if (!raw) return { he_teto_minutos: null }
+    return { he_teto_minutos: Math.min(1440, Math.max(15, Number(raw) || 15)) }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (modoJornada === 'semanal') {
@@ -213,6 +221,7 @@ export function AtendenteForm() {
     try {
       const escala = payloadJornada()
       const locais = payloadLocais()
+      const heTeto = payloadHeTeto()
       if (isEdit && !Number.isNaN(atendenteId)) {
         await atendentes.update(atendenteId, {
           email,
@@ -222,6 +231,7 @@ export function AtendenteForm() {
           setor_ids: setorIds,
           ...escala,
           ...locais,
+          ...heTeto,
           ...(senha ? { senha } : {}),
         })
         toast.showSuccess('Atendente atualizado.')
@@ -237,6 +247,7 @@ export function AtendenteForm() {
           ativo,
           ...escala,
           ...locais,
+          ...heTeto,
         })
         toast.showSuccess('Atendente cadastrado.')
         navigate(`/atendentes/${created.id}/editar`, { replace: true })
@@ -444,6 +455,21 @@ export function AtendenteForm() {
                   </p>
                 </div>
               )}
+            </FormSection>
+            <FormSection title="Hora extra (WhatsApp)">
+              <Input
+                label="Teto por liberação (minutos)"
+                type="number"
+                min={15}
+                max={1440}
+                value={heTetoMinutos}
+                onChange={(e) => setHeTetoMinutos(e.target.value)}
+                placeholder="Sem limite"
+              />
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Vazio = sem teto. Cada concessão (resto do dia, até horário ou duração) é limitada a esse
+                máximo a partir do momento da liberação.
+              </p>
             </FormSection>
             {isEdit && !Number.isNaN(atendenteId) ? (
               <FormSection title="Locais de trabalho">

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -10,6 +10,7 @@ import { Input } from '../components/ui/Input'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
+import { useAuth } from '../contexts/AuthContext'
 import { isCapacitorNative } from '../lib/capacitorNative'
 import { geolocationSupported, getCurrentPosition, type GeoError } from '../lib/geolocation'
 import {
@@ -46,6 +47,7 @@ type AcaoPrincipal = {
 
 export function MeuPonto() {
   const toast = useToast()
+  const { user } = useAuth()
   const [estado, setEstado] = useState<Ponto.EstadoMe | null>(null)
   const [historico, setHistorico] = useState<Ponto.Historico | null>(null)
   const [desde, setDesde] = useState(inicioMesIso)
@@ -57,6 +59,12 @@ export function MeuPonto() {
   const [justTipo, setJustTipo] = useState<Ponto.JustificativaCreate['tipo']>('esquecimento')
   const [justMotivo, setJustMotivo] = useState('')
   const [enviandoJust, setEnviandoJust] = useState(false)
+  const [coberturas, setCoberturas] = useState<Ponto.Cobertura[]>([])
+  const [colegasCob, setColegasCob] = useState<Ponto.CoberturaColega[]>([])
+  const [cobCobertor, setCobCobertor] = useState('')
+  const [cobData, setCobData] = useState(hojeIso)
+  const [cobMotivo, setCobMotivo] = useState('')
+  const [enviandoCob, setEnviandoCob] = useState(false)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
   const [refSemana, setRefSemana] = useState(hojeIso)
   const [resumoSemana, setResumoSemana] = useState<Ponto.ResumoSemana | null>(null)
@@ -88,18 +96,22 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs] = await Promise.all([
+        const [me, hist, js, bh, gs, cobs, cols] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
           ponto.meuBancoHoras(desde, ate),
           ponto.meSettings(),
+          ponto.minhasCoberturas(),
+          ponto.colegasCobertura(),
         ])
         setEstado(me)
         setHistorico(hist)
         setJustifs(js)
         setBanco(bh)
         setGeoSettings(gs)
+        setCoberturas(cobs)
+        setColegasCob(cols)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -284,6 +296,38 @@ export function MeuPonto() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a justificativa.'))
     } finally {
       setEnviandoJust(false)
+    }
+  }
+
+  async function solicitarCobertura() {
+    if (!cobCobertor) {
+      toast.showWarning('Selecione quem vai cobrir o plantão.')
+      return
+    }
+    setEnviandoCob(true)
+    try {
+      await ponto.solicitarCobertura({
+        cobertor_id: Number(cobCobertor),
+        data_ref: cobData,
+        motivo: cobMotivo.trim() || null,
+      })
+      toast.showSuccess('Pedido de cobertura enviado. Aguarde o cobertor e o admin.')
+      setCobMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível solicitar a cobertura.'))
+    } finally {
+      setEnviandoCob(false)
+    }
+  }
+
+  async function responderCob(id: number, aceitar: boolean) {
+    try {
+      await ponto.responderCobertura(id, { aceitar })
+      toast.showSuccess(aceitar ? 'Cobertura aceita — aguarda homologação do admin.' : 'Pedido recusado.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível responder.'))
     }
   }
 
@@ -733,6 +777,68 @@ export function MeuPonto() {
                   ) : null}
                 </li>
               ))
+            )}
+          </ul>
+        </Card>
+      </div>
+
+      <div className="mt-4">
+        <Card
+          title="Cobertura de plantão"
+          description="Peça para um colega cobrir seu dia; ele aceita e o admin homologa."
+        >
+          <div className="flex flex-wrap items-end gap-3">
+            <Select
+              label="Quem cobre"
+              value={cobCobertor}
+              onChange={(v) => setCobCobertor(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...colegasCob.map((c) => ({ value: String(c.id), label: c.nome })),
+              ]}
+            />
+            <Input label="Data" type="date" value={cobData} onChange={(e) => setCobData(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={cobMotivo}
+              onChange={(e) => setCobMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={enviandoCob} onClick={() => void solicitarCobertura()}>
+              Solicitar
+            </Button>
+          </div>
+          <ul className="mt-4 space-y-2 text-sm">
+            {coberturas.length === 0 ? (
+              <li className="text-slate-500">Nenhuma cobertura neste histórico.</li>
+            ) : (
+              coberturas.map((c) => {
+                const souCobertor = user?.id === c.cobertor_id
+                const pendenteMim = souCobertor && c.estado === 'pendente_cobertor'
+                return (
+                  <li
+                    key={c.id}
+                    className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                  >
+                    <div>
+                      <p className="font-medium">
+                        {c.solicitante_nome} → {c.cobertor_nome} · {c.data_ref}
+                      </p>
+                      <p className="capitalize text-slate-500">{c.estado.replace(/_/g, ' ')}</p>
+                      {c.motivo ? <p className="text-slate-600 dark:text-slate-300">{c.motivo}</p> : null}
+                    </div>
+                    {pendenteMim ? (
+                      <div className="flex gap-2">
+                        <Button type="button" variant="secondary" onClick={() => void responderCob(c.id, true)}>
+                          Aceitar
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void responderCob(c.id, false)}>
+                          Recusar
+                        </Button>
+                      </div>
+                    ) : null}
+                  </li>
+                )
+              })
             )}
           </ul>
         </Card>

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ponto, type Ponto } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { PontoAjudaModal } from '../components/PontoAjudaModal'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
 import { PontoBatidaMapaModal } from '../components/PontoBatidaMapaModal'
 import { PontoMetricCard } from '../components/PontoMetricCard'
@@ -65,6 +66,13 @@ export function MeuPonto() {
   const [cobData, setCobData] = useState(hojeIso)
   const [cobMotivo, setCobMotivo] = useState('')
   const [enviandoCob, setEnviandoCob] = useState(false)
+  const [ajudaAberta, setAjudaAberta] = useState(false)
+  const [ciencia, setCiencia] = useState<Ponto.CienciaMe | null>(null)
+  const cienciaRef = useMemo(() => {
+    const d = new Date()
+    const prev = new Date(d.getFullYear(), d.getMonth() - 1, 1)
+    return { ano: prev.getFullYear(), mes: prev.getMonth() + 1 }
+  }, [])
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
   const [refSemana, setRefSemana] = useState(hojeIso)
   const [resumoSemana, setResumoSemana] = useState<Ponto.ResumoSemana | null>(null)
@@ -96,7 +104,7 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs, cobs, cols] = await Promise.all([
+        const [me, hist, js, bh, gs, cobs, cols, cin] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
@@ -104,6 +112,7 @@ export function MeuPonto() {
           ponto.meSettings(),
           ponto.minhasCoberturas(),
           ponto.colegasCobertura(),
+          ponto.minhaCiencia(cienciaRef.ano, cienciaRef.mes),
         ])
         setEstado(me)
         setHistorico(hist)
@@ -112,6 +121,7 @@ export function MeuPonto() {
         setGeoSettings(gs)
         setCoberturas(cobs)
         setColegasCob(cols)
+        setCiencia(cin)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -123,7 +133,7 @@ export function MeuPonto() {
         setLoading(false)
       }
     },
-    [ate, desde, toast],
+    [ate, cienciaRef.ano, cienciaRef.mes, desde, toast],
   )
 
   const carregarCalendario = useCallback(
@@ -375,7 +385,54 @@ export function MeuPonto() {
       <PageHeader
         title="Meu ponto"
         subtitle="Registre a jornada com um toque. Pausas e histórico ficam à mão — presença online do painel é independente."
+        actions={
+          <Button type="button" variant="secondary" onClick={() => setAjudaAberta(true)}>
+            Como funciona o ponto
+          </Button>
+        }
       />
+
+      {ciencia ? (
+        <Card className="mb-4" title={`Ciência do espelho — ${String(cienciaRef.mes).padStart(2, '0')}/${cienciaRef.ano}`}>
+          {ciencia.confirmada ? (
+            <p className="text-sm text-emerald-700 dark:text-emerald-300">
+              Você confirmou ciência
+              {ciencia.confirmado_em
+                ? ` em ${new Date(ciencia.confirmado_em).toLocaleString('pt-BR')}`
+                : ''}
+              .
+            </p>
+          ) : ciencia.pode_confirmar ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                O mês foi fechado pelo admin. Confirme que leu e concorda com o espelho.
+              </p>
+              <Button
+                type="button"
+                onClick={() => {
+                  void (async () => {
+                    try {
+                      await ponto.confirmarCiencia(cienciaRef.ano, cienciaRef.mes)
+                      toast.showSuccess('Ciência confirmada.')
+                      await carregar(true)
+                    } catch (err) {
+                      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível confirmar.'))
+                    }
+                  })()
+                }}
+              >
+                Li e concordo
+              </Button>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500">
+              {ciencia.competencia_fechada
+                ? 'Ciência indisponível.'
+                : 'Aguarde o fechamento da competência para confirmar.'}
+            </p>
+          )}
+        </Card>
+      ) : null}
 
       {/* Hero — inspirado no dx-ponto: relógio + CTA principal */}
       <Card className="overflow-hidden border-cyan-200/60 bg-gradient-to-br from-slate-50 via-white to-cyan-50/40 dark:border-cyan-900/40 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">
@@ -844,6 +901,7 @@ export function MeuPonto() {
         </Card>
       </div>
 
+      <PontoAjudaModal open={ajudaAberta} onClose={() => setAjudaAberta(false)} />
       <PontoBatidaMapaModal
         open={mapaAberto != null}
         onClose={() => setMapaAberto(null)}

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -58,6 +58,8 @@ export function MeuPonto() {
   const [justMotivo, setJustMotivo] = useState('')
   const [enviandoJust, setEnviandoJust] = useState(false)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
+  const [refSemana, setRefSemana] = useState(hojeIso)
+  const [resumoSemana, setResumoSemana] = useState<Ponto.ResumoSemana | null>(null)
   const agora = new Date()
   const [calAno, setCalAno] = useState(agora.getFullYear())
   const [calMes, setCalMes] = useState(agora.getMonth() + 1)
@@ -129,9 +131,27 @@ export function MeuPonto() {
     [calAno, calMes, toast],
   )
 
+  const carregarResumoSemana = useCallback(
+    async (silencioso = false) => {
+      try {
+        const rs = await ponto.meuResumoSemana(refSemana)
+        setResumoSemana(rs)
+      } catch (err) {
+        if (!silencioso) {
+          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar o resumo da semana.'))
+        }
+      }
+    },
+    [refSemana, toast],
+  )
+
   useEffect(() => {
     void carregar()
   }, [carregar])
+
+  useEffect(() => {
+    void carregarResumoSemana(true)
+  }, [carregarResumoSemana])
 
   useEffect(() => {
     void carregarCalendario()
@@ -229,7 +249,7 @@ export function MeuPonto() {
         }
         toast.showSuccess(msgs[tipo])
       }
-      await Promise.all([carregar(true), carregarCalendario(true)])
+      await Promise.all([carregar(true), carregarCalendario(true), carregarResumoSemana(true)])
     } catch (err) {
       if (isLikelyOfflineError(err)) {
         enqueuePontoBatida({ tipo, ...geo })
@@ -485,6 +505,76 @@ export function MeuPonto() {
           tone={banco && banco.saldo_segundos < 0 ? 'warn' : 'good'}
         />
       </div>
+
+      <Card className="mt-4" title="Resumo da semana">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            {resumoSemana
+              ? `${resumoSemana.desde} → ${resumoSemana.ate}`
+              : 'Carregando…'}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                const d = new Date(`${refSemana}T12:00:00`)
+                d.setDate(d.getDate() - 7)
+                setRefSemana(d.toISOString().slice(0, 10))
+              }}
+            >
+              Semana anterior
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                const d = new Date(`${refSemana}T12:00:00`)
+                d.setDate(d.getDate() + 7)
+                const iso = d.toISOString().slice(0, 10)
+                setRefSemana(iso > hojeIso() ? hojeIso() : iso)
+              }}
+            >
+              Próxima semana
+            </Button>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <PontoMetricCard
+            label="Previsto × feito"
+            value={
+              resumoSemana
+                ? `${formatarDuracao(resumoSemana.segundos_realizados)} / ${formatarDuracao(resumoSemana.segundos_esperados)}`
+                : '—'
+            }
+            tone="info"
+          />
+          <PontoMetricCard
+            label="Atrasos"
+            value={String(resumoSemana?.atrasos ?? 0)}
+            tone={resumoSemana && resumoSemana.atrasos > 0 ? 'warn' : 'neutral'}
+          />
+          <PontoMetricCard
+            label="Hora extra"
+            value={
+              resumoSemana
+                ? `${resumoSemana.he_minutos} min`
+                : '—'
+            }
+            hint="Liberações aprovadas na semana"
+            tone="neutral"
+          />
+          <PontoMetricCard
+            label="Saldo (banco)"
+            value={
+              resumoSemana
+                ? `${resumoSemana.saldo_segundos >= 0 ? '+' : '−'}${formatarDuracao(Math.abs(resumoSemana.saldo_segundos))}`
+                : '—'
+            }
+            tone={resumoSemana && resumoSemana.saldo_segundos < 0 ? 'warn' : 'good'}
+          />
+        </div>
+      </Card>
 
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
         <Card title="Calendário do mês">

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -79,6 +79,13 @@ export function MeuPonto() {
     lon: number
     label: string
   } | null>(null)
+  const [justAnexo, setJustAnexo] = useState<File | null>(null)
+  const [ausencias, setAusencias] = useState<Ponto.Ausencia[]>([])
+  const [ausTipo, setAusTipo] = useState<'ferias' | 'folga_programada'>('folga_programada')
+  const [ausDesde, setAusDesde] = useState(hojeIso)
+  const [ausAte, setAusAte] = useState(hojeIso)
+  const [ausMotivo, setAusMotivo] = useState('')
+  const [enviandoAus, setEnviandoAus] = useState(false)
 
   const politicaGeo = geoSettings?.politica_geolocalizacao ?? 'opcional'
   const geoObrigatoria = politicaGeo === 'obrigatoria' && !!geoSettings?.tem_locais_ativos
@@ -88,18 +95,20 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs] = await Promise.all([
+        const [me, hist, js, bh, gs, aus] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
           ponto.meuBancoHoras(desde, ate),
           ponto.meSettings(),
+          ponto.minhasAusencias(),
         ])
         setEstado(me)
         setHistorico(hist)
         setJustifs(js)
         setBanco(bh)
         setGeoSettings(gs)
+        setAusencias(aus)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -272,18 +281,48 @@ export function MeuPonto() {
     }
     setEnviandoJust(true)
     try {
-      await ponto.criarJustificativa({
+      const payload = {
         data_ref: justData,
         tipo: justTipo,
         motivo: justMotivo.trim(),
-      })
+      }
+      if (justAnexo) {
+        await ponto.criarJustificativaComAnexo(payload, justAnexo)
+      } else {
+        await ponto.criarJustificativa(payload)
+      }
       toast.showSuccess('Justificativa enviada para aprovação.')
       setJustMotivo('')
+      setJustAnexo(null)
       await carregar(true)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a justificativa.'))
     } finally {
       setEnviandoJust(false)
+    }
+  }
+
+  async function solicitarAusencia() {
+    if (ausAte < ausDesde) {
+      toast.showWarning('A data final deve ser igual ou posterior à inicial.')
+      return
+    }
+    setEnviandoAus(true)
+    try {
+      await ponto.solicitarAusencia({
+        tipo: ausTipo,
+        desde: ausDesde,
+        ate: ausAte,
+        motivo: ausMotivo.trim() || null,
+      })
+      toast.showSuccess('Pedido de ausência enviado.')
+      setAusMotivo('')
+      await carregar(true)
+      await carregarCalendario(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível solicitar a ausência.'))
+    } finally {
+      setEnviandoAus(false)
     }
   }
 
@@ -711,6 +750,17 @@ export function MeuPonto() {
                 onChange={(e) => setJustMotivo(e.target.value)}
                 placeholder="Descreva o ocorrido"
               />
+              <div className="min-w-[12rem]">
+                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  Anexo (opcional)
+                </label>
+                <input
+                  type="file"
+                  accept="image/*,.pdf,application/pdf"
+                  className="block w-full text-sm text-slate-600 file:mr-2 file:rounded-md file:border-0 file:bg-slate-100 file:px-2 file:py-1 dark:text-slate-300 dark:file:bg-slate-800"
+                  onChange={(e) => setJustAnexo(e.target.files?.[0] ?? null)}
+                />
+              </div>
               <Button type="button" disabled={enviandoJust} onClick={() => void enviarJustificativa()}>
                 Enviar
               </Button>
@@ -728,8 +778,80 @@ export function MeuPonto() {
                   <span className="font-medium">{j.data_ref}</span> · {j.tipo} ·{' '}
                   <span className="capitalize">{j.estado}</span>
                   <p className="text-slate-600 dark:text-slate-300">{j.motivo}</p>
+                  {j.tem_anexo ? (
+                    <button
+                      type="button"
+                      className="mt-1 text-xs text-cyan-700 underline dark:text-cyan-300"
+                      onClick={() =>
+                        void ponto
+                          .baixarJustificativaAnexo(j.id, j.anexo_nome)
+                          .catch((err) =>
+                            toast.showError(
+                              mensagemFalhaParaToast(err, 'Não foi possível baixar o anexo.'),
+                            ),
+                          )
+                      }
+                    >
+                      Baixar anexo{j.anexo_nome ? ` (${j.anexo_nome})` : ''}
+                    </button>
+                  ) : null}
                   {j.decisao_motivo ? (
                     <p className="text-xs text-slate-500">Decisão: {j.decisao_motivo}</p>
+                  ) : null}
+                </li>
+              ))
+            )}
+          </ul>
+        </Card>
+      </div>
+
+      <div className="mt-4">
+        <Card
+          title="Férias / folga programada"
+          description="Solicite um período; o admin aprova. Dias aprovados não geram falta automática."
+        >
+          <div className="flex flex-wrap items-end gap-3">
+            <Select
+              label="Tipo"
+              value={ausTipo}
+              onChange={(v) => setAusTipo(String(v) as 'ferias' | 'folga_programada')}
+              options={[
+                { value: 'folga_programada', label: 'Folga programada' },
+                { value: 'ferias', label: 'Férias' },
+              ]}
+            />
+            <Input
+              label="De"
+              type="date"
+              value={ausDesde}
+              onChange={(e) => setAusDesde(e.target.value)}
+            />
+            <Input label="Até" type="date" value={ausAte} onChange={(e) => setAusAte(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={ausMotivo}
+              onChange={(e) => setAusMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={enviandoAus} onClick={() => void solicitarAusencia()}>
+              Solicitar
+            </Button>
+          </div>
+          <ul className="mt-4 space-y-2 text-sm">
+            {ausencias.length === 0 ? (
+              <li className="text-slate-500">Nenhum pedido de ausência.</li>
+            ) : (
+              ausencias.map((a) => (
+                <li
+                  key={a.id}
+                  className="rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <span className="font-medium">
+                    {a.tipo === 'ferias' ? 'Férias' : 'Folga programada'}
+                  </span>{' '}
+                  · {a.desde} → {a.ate} · <span className="capitalize">{a.estado}</span>
+                  {a.motivo ? <p className="text-slate-600 dark:text-slate-300">{a.motivo}</p> : null}
+                  {a.decisao_motivo ? (
+                    <p className="text-xs text-slate-500">Decisão: {a.decisao_motivo}</p>
                   ) : null}
                 </li>
               ))

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -10,6 +10,7 @@ import { Input } from '../components/ui/Input'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
+import { useEventStream } from '../contexts/EventStreamContext'
 import { isCapacitorNative } from '../lib/capacitorNative'
 import { geolocationSupported, getCurrentPosition, type GeoError } from '../lib/geolocation'
 import {
@@ -46,6 +47,7 @@ type AcaoPrincipal = {
 
 export function MeuPonto() {
   const toast = useToast()
+  const { subscribe } = useEventStream()
   const [estado, setEstado] = useState<Ponto.EstadoMe | null>(null)
   const [historico, setHistorico] = useState<Ponto.Historico | null>(null)
   const [desde, setDesde] = useState(inicioMesIso)
@@ -79,6 +81,13 @@ export function MeuPonto() {
     lon: number
     label: string
   } | null>(null)
+  const [heStatus, setHeStatus] = useState<Ponto.HoraExtraMeStatus | null>(null)
+  const [heHist, setHeHist] = useState<Ponto.HoraExtra[]>([])
+  const [heMotivo, setHeMotivo] = useState('')
+  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
+  const [heAteHorario, setHeAteHorario] = useState('20:00')
+  const [heDuracaoMin, setHeDuracaoMin] = useState('60')
+  const [enviandoHe, setEnviandoHe] = useState(false)
 
   const politicaGeo = geoSettings?.politica_geolocalizacao ?? 'opcional'
   const geoObrigatoria = politicaGeo === 'obrigatoria' && !!geoSettings?.tem_locais_ativos
@@ -88,18 +97,22 @@ export function MeuPonto() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh, gs] = await Promise.all([
+        const [me, hist, js, bh, gs, heSt, heList] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
           ponto.meuBancoHoras(desde, ate),
           ponto.meSettings(),
+          ponto.horaExtraMeStatus(),
+          ponto.minhasHoraExtra(),
         ])
         setEstado(me)
         setHistorico(hist)
         setJustifs(js)
         setBanco(bh)
         setGeoSettings(gs)
+        setHeStatus(heSt)
+        setHeHist(heList)
         if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
           setIncluirLocalizacao(true)
         }
@@ -148,6 +161,13 @@ export function MeuPonto() {
   useEffect(() => {
     void carregar()
   }, [carregar])
+
+  useEffect(() => {
+    const unsub = subscribe('ponto.he_atualizada', () => {
+      void carregar(true)
+    })
+    return unsub
+  }, [subscribe, carregar])
 
   useEffect(() => {
     void carregarResumoSemana(true)
@@ -284,6 +304,33 @@ export function MeuPonto() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a justificativa.'))
     } finally {
       setEnviandoJust(false)
+    }
+  }
+
+  async function solicitarHe() {
+    if (heStatus?.pedido_pendente) {
+      toast.showWarning('Já existe um pedido de hora extra aguardando decisão.')
+      return
+    }
+    if (heStatus?.he_ativa) {
+      toast.showWarning('Você já tem hora extra ativa.')
+      return
+    }
+    setEnviandoHe(true)
+    try {
+      await ponto.solicitarHoraExtra({
+        motivo: heMotivo.trim() || null,
+        modo: heModo,
+        ate_horario: heModo === 'ate_horario' ? heAteHorario : null,
+        duracao_minutos: heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
+      })
+      toast.showSuccess('Pedido de hora extra enviado.')
+      setHeMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível solicitar hora extra.'))
+    } finally {
+      setEnviandoHe(false)
     }
   }
 
@@ -574,6 +621,97 @@ export function MeuPonto() {
             tone={resumoSemana && resumoSemana.saldo_segundos < 0 ? 'warn' : 'good'}
           />
         </div>
+      </Card>
+
+      <Card className="mt-4" title="Hora extra (WhatsApp)">
+        {heStatus?.he_ativa ? (
+          <p className="mb-3 text-sm text-emerald-800 dark:text-emerald-200">
+            Hora extra ativa
+            {heStatus.he_restante_minutos != null
+              ? ` — restam cerca de ${heStatus.he_restante_minutos} min`
+              : ''}
+            {heStatus.he_ativa.ate_em
+              ? ` (até ${formatarHora(heStatus.he_ativa.ate_em)})`
+              : ''}
+            .
+          </p>
+        ) : null}
+        {heStatus?.pedido_pendente ? (
+          <p className="mb-3 text-sm text-amber-800 dark:text-amber-200">
+            Pedido pendente de aprovação
+            {heStatus.pedido_pendente.modo ? ` (${heStatus.pedido_pendente.modo.replace(/_/g, ' ')})` : ''}
+            .
+          </p>
+        ) : null}
+        {heStatus?.ultimo_rejeitado ? (
+          <p className="mb-3 text-sm text-rose-800 dark:text-rose-200">
+            Último pedido negado
+            {heStatus.ultimo_rejeitado.decisao_motivo
+              ? `: ${heStatus.ultimo_rejeitado.decisao_motivo}`
+              : '.'}
+          </p>
+        ) : null}
+        {heStatus?.he_teto_mensal_minutos != null ? (
+          <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
+            Consumo no mês: {heStatus.he_consumido_mensal_minutos ?? 0} / {heStatus.he_teto_mensal_minutos}{' '}
+            min
+          </p>
+        ) : null}
+        {!heStatus?.he_ativa && !heStatus?.pedido_pendente ? (
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Janela desejada"
+              value={heModo}
+              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario' | 'duracao')}
+              options={[
+                { value: 'resto_do_dia', label: 'Resto do dia' },
+                { value: 'ate_horario', label: 'Até horário' },
+                { value: 'duracao', label: 'Duração (minutos)' },
+              ]}
+            />
+            {heModo === 'ate_horario' ? (
+              <Input
+                label="Até (HH:MM)"
+                type="time"
+                value={heAteHorario}
+                onChange={(e) => setHeAteHorario(e.target.value)}
+              />
+            ) : null}
+            {heModo === 'duracao' ? (
+              <Input
+                label="Minutos"
+                type="number"
+                min={15}
+                max={1440}
+                value={heDuracaoMin}
+                onChange={(e) => setHeDuracaoMin(e.target.value)}
+              />
+            ) : null}
+            <Input
+              label="Motivo"
+              value={heMotivo}
+              onChange={(e) => setHeMotivo(e.target.value)}
+              placeholder="Ex.: pico no WhatsApp"
+            />
+            <Button type="button" disabled={enviandoHe} onClick={() => void solicitarHe()}>
+              Solicitar HE
+            </Button>
+          </div>
+        ) : null}
+        {heHist.length > 0 ? (
+          <ul className="space-y-2 border-t border-slate-200 pt-3 dark:border-slate-700">
+            {heHist.slice(0, 8).map((h) => (
+              <li key={h.id} className="text-sm text-slate-600 dark:text-slate-300">
+                <span className="font-medium text-slate-800 dark:text-slate-100">{h.estado}</span>
+                {h.modo ? ` · ${h.modo.replace(/_/g, ' ')}` : ''}
+                {h.motivo ? ` — ${h.motivo}` : ''}
+                {h.decisao_motivo && h.estado === 'rejeitada' ? ` (${h.decisao_motivo})` : ''}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-slate-500">Nenhum pedido recente.</p>
+        )}
       </Card>
 
       <div className="mt-4 grid gap-4 lg:grid-cols-2">

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -35,6 +35,10 @@ function rotuloStatus(s: Ponto.HojeItem['status']): string {
       return 'Atraso'
     case 'feriado':
       return 'Feriado'
+    case 'ferias':
+      return 'Férias'
+    case 'folga_programada':
+      return 'Folga programada'
     case 'ok':
       return 'Ok'
     default:
@@ -71,6 +75,13 @@ export function PontoEquipe() {
   const [carregandoAjustes, setCarregandoAjustes] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
+  const [ausPendentes, setAusPendentes] = useState<Ponto.Ausencia[]>([])
+  const [ausTipo, setAusTipo] = useState<'ferias' | 'folga_programada'>('folga_programada')
+  const [ausAtendente, setAusAtendente] = useState('')
+  const [ausDesde, setAusDesde] = useState(hojeIso)
+  const [ausAte, setAusAte] = useState(hojeIso)
+  const [ausMotivo, setAusMotivo] = useState('')
+  const [concedendoAus, setConcedendoAus] = useState(false)
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
   const [heDuracaoMin, setHeDuracaoMin] = useState('60')
@@ -96,7 +107,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, aus] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -109,6 +120,7 @@ export function PontoEquipe() {
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
           ponto.horaExtraAdmin('pendente'),
+          ponto.ausenciasAdmin('pendente'),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -118,6 +130,7 @@ export function PontoEquipe() {
         setSettings(st)
         setFeriados(fer)
         setHesPendentes(hes)
+        setAusPendentes(aus)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -317,6 +330,47 @@ export function PontoEquipe() {
     }
   }
 
+  async function decidirAus(id: number, aprovar: boolean) {
+    try {
+      await ponto.decidirAusencia(id, {
+        aprovar,
+        decisao_motivo: aprovar ? null : 'Negado pelo administrador',
+      })
+      toast.showSuccess(aprovar ? 'Ausência aprovada.' : 'Ausência negada.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a ausência.'))
+    }
+  }
+
+  async function concederAus() {
+    if (!ausAtendente) {
+      toast.showWarning('Selecione o atendente.')
+      return
+    }
+    if (ausAte < ausDesde) {
+      toast.showWarning('A data final deve ser igual ou posterior à inicial.')
+      return
+    }
+    setConcedendoAus(true)
+    try {
+      await ponto.concederAusencia({
+        atendente_id: Number(ausAtendente),
+        tipo: ausTipo,
+        desde: ausDesde,
+        ate: ausAte,
+        motivo: ausMotivo.trim() || null,
+      })
+      toast.showSuccess('Ausência agendada.')
+      setAusMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar a ausência.'))
+    } finally {
+      setConcedendoAus(false)
+    }
+  }
+
   async function decidirHe(id: number, aprovar: boolean) {
     setDecidindoHeId(id)
     try {
@@ -371,6 +425,7 @@ export function PontoEquipe() {
         fecho_apos_horas: settings.fecho_apos_horas,
         fecho_margem_pos_saida_minutos: settings.fecho_margem_pos_saida_minutos ?? 30,
         jornada_diaria_minutos: settings.jornada_diaria_minutos,
+        pausa_minima_minutos: settings.pausa_minima_minutos ?? 0,
         politica_geolocalizacao: settings.politica_geolocalizacao,
       })
       setSettings(st)
@@ -534,6 +589,23 @@ export function PontoEquipe() {
                       {j.atendente_nome ?? j.atendente_id} · {j.data_ref} · {j.tipo}
                     </p>
                     <p className="text-slate-600 dark:text-slate-300">{j.motivo}</p>
+                    {j.tem_anexo ? (
+                      <button
+                        type="button"
+                        className="mt-1 text-xs text-cyan-700 underline dark:text-cyan-300"
+                        onClick={() =>
+                          void ponto
+                            .baixarJustificativaAnexo(j.id, j.anexo_nome)
+                            .catch((err) =>
+                              toast.showError(
+                                mensagemFalhaParaToast(err, 'Não foi possível baixar o anexo.'),
+                              ),
+                            )
+                        }
+                      >
+                        Baixar anexo{j.anexo_nome ? ` (${j.anexo_nome})` : ''}
+                      </button>
+                    ) : null}
                   </div>
                   <div className="flex gap-2">
                     <Button type="button" variant="secondary" onClick={() => void decidirJust(j.id, 'aprovada')}>
@@ -541,6 +613,71 @@ export function PontoEquipe() {
                     </Button>
                     <Button type="button" variant="ghost" onClick={() => void decidirJust(j.id, 'rejeitada')}>
                       Rejeitar
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
+        <Card title="Férias / folga programada">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Agende direto ou aprove pedidos dos colaboradores. Dias aprovados não geram falta automática.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Colaborador"
+              value={ausAtendente}
+              onChange={(v) => setAusAtendente(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Select
+              label="Tipo"
+              value={ausTipo}
+              onChange={(v) => setAusTipo(String(v) as 'ferias' | 'folga_programada')}
+              options={[
+                { value: 'folga_programada', label: 'Folga programada' },
+                { value: 'ferias', label: 'Férias' },
+              ]}
+            />
+            <Input label="De" type="date" value={ausDesde} onChange={(e) => setAusDesde(e.target.value)} />
+            <Input label="Até" type="date" value={ausAte} onChange={(e) => setAusAte(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={ausMotivo}
+              onChange={(e) => setAusMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={concedendoAus} onClick={() => void concederAus()}>
+              Agendar
+            </Button>
+          </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Pedidos pendentes</p>
+          {ausPendentes.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
+          ) : (
+            <ul className="space-y-3">
+              {ausPendentes.map((a) => (
+                <li
+                  key={a.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">{a.atendente_nome ?? a.atendente_id}</p>
+                    <p className="text-slate-600 dark:text-slate-300">
+                      {a.tipo === 'ferias' ? 'Férias' : 'Folga programada'} · {a.desde} → {a.ate}
+                    </p>
+                    {a.motivo ? <p className="text-slate-500">{a.motivo}</p> : null}
+                  </div>
+                  <div className="flex gap-2">
+                    <Button type="button" variant="secondary" onClick={() => void decidirAus(a.id, true)}>
+                      Aprovar
+                    </Button>
+                    <Button type="button" variant="ghost" onClick={() => void decidirAus(a.id, false)}>
+                      Negar
                     </Button>
                   </div>
                 </li>
@@ -943,6 +1080,23 @@ export function PontoEquipe() {
                   })
                 }
               />
+              <Input
+                label="Pausa mínima (minutos)"
+                type="number"
+                min={0}
+                max={240}
+                value={String(settings.pausa_minima_minutos ?? 0)}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    pausa_minima_minutos: Math.max(0, Number(e.target.value) || 0),
+                  })
+                }
+              />
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                0 = desligado. Se a soma das pausas do dia ficar abaixo do mínimo (com jornada iniciada), o
+                calendário e os alertas sinalizam — sem bloquear batidas.
+              </p>
               <Select
                 label="Política de geolocalização"
                 value={settings.politica_geolocalizacao ?? 'opcional'}

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -70,6 +70,12 @@ export function PontoEquipe() {
   const [ajusteAuditAte, setAjusteAuditAte] = useState(hojeIso)
   const [carregandoAjustes, setCarregandoAjustes] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
+  const [cobPendentes, setCobPendentes] = useState<Ponto.Cobertura[]>([])
+  const [cobSolicitante, setCobSolicitante] = useState('')
+  const [cobCobertor, setCobCobertor] = useState('')
+  const [cobData, setCobData] = useState(hojeIso)
+  const [cobMotivo, setCobMotivo] = useState('')
+  const [concedendoCob, setConcedendoCob] = useState(false)
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
@@ -96,7 +102,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, cobs] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -109,6 +115,7 @@ export function PontoEquipe() {
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
           ponto.horaExtraAdmin('pendente'),
+          ponto.coberturasAdmin('pendente'),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -118,6 +125,7 @@ export function PontoEquipe() {
         setSettings(st)
         setFeriados(fer)
         setHesPendentes(hes)
+        setCobPendentes(cobs)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -243,6 +251,24 @@ export function PontoEquipe() {
     }
   }
 
+  async function exportarFolha(ext: 'csv' | 'xlsx') {
+    try {
+      const blob = await ponto.exportFolha(ext, {
+        atendente_id: atendenteId ? Number(atendenteId) : undefined,
+        desde,
+        ate,
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = ext === 'csv' ? 'ponto_folha.csv' : 'ponto_folha.xlsx'
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível exportar a folha RH.'))
+    }
+  }
+
   async function salvarAjuste() {
     if (!ajusteAtendente) {
       toast.showWarning('Selecione o atendente.')
@@ -314,6 +340,46 @@ export function PontoEquipe() {
       await carregar(true)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir.'))
+    }
+  }
+
+  async function decidirCob(id: number, aprovar: boolean) {
+    try {
+      await ponto.decidirCobertura(id, {
+        aprovar,
+        decisao_motivo: aprovar ? null : 'Negado pelo administrador',
+      })
+      toast.showSuccess(aprovar ? 'Cobertura homologada.' : 'Cobertura negada.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a cobertura.'))
+    }
+  }
+
+  async function concederCob() {
+    if (!cobSolicitante || !cobCobertor) {
+      toast.showWarning('Selecione solicitante e cobertor.')
+      return
+    }
+    if (cobSolicitante === cobCobertor) {
+      toast.showWarning('Solicitante e cobertor devem ser diferentes.')
+      return
+    }
+    setConcedendoCob(true)
+    try {
+      await ponto.concederCobertura({
+        solicitante_id: Number(cobSolicitante),
+        cobertor_id: Number(cobCobertor),
+        data_ref: cobData,
+        motivo: cobMotivo.trim() || null,
+      })
+      toast.showSuccess('Cobertura agendada.')
+      setCobMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar a cobertura.'))
+    } finally {
+      setConcedendoCob(false)
     }
   }
 
@@ -549,6 +615,71 @@ export function PontoEquipe() {
           )}
         </Card>
 
+        <Card title="Cobertura de plantão">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Agende direto ou homologue pedidos (A pede, B aceita, admin confirma). No dia, A não gera falta e B
+            passa a ter jornada esperada.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Solicitante (folga)"
+              value={cobSolicitante}
+              onChange={(v) => setCobSolicitante(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Select
+              label="Cobertor"
+              value={cobCobertor}
+              onChange={(v) => setCobCobertor(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Input label="Data" type="date" value={cobData} onChange={(e) => setCobData(e.target.value)} />
+            <Input
+              label="Motivo (opcional)"
+              value={cobMotivo}
+              onChange={(e) => setCobMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={concedendoCob} onClick={() => void concederCob()}>
+              Agendar
+            </Button>
+          </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Pedidos pendentes</p>
+          {cobPendentes.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
+          ) : (
+            <ul className="space-y-3">
+              {cobPendentes.map((c) => (
+                <li
+                  key={c.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">
+                      {c.solicitante_nome} → {c.cobertor_nome} · {c.data_ref}
+                    </p>
+                    <p className="text-slate-500">{c.estado.replace(/_/g, ' ')}</p>
+                    {c.motivo ? <p className="text-slate-600 dark:text-slate-300">{c.motivo}</p> : null}
+                  </div>
+                  <div className="flex gap-2">
+                    <Button type="button" variant="secondary" onClick={() => void decidirCob(c.id, true)}>
+                      Homologar
+                    </Button>
+                    <Button type="button" variant="ghost" onClick={() => void decidirCob(c.id, false)}>
+                      Negar
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
         <Card title="Hora extra (WhatsApp após jornada)">
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
             Conceda HE com antecedência ou libere pedidos após o fim da jornada. Modos: resto do dia, até um horário ou
@@ -775,6 +906,12 @@ export function PontoEquipe() {
             </Button>
             <Button type="button" variant="secondary" onClick={() => void exportarRelatorio('xlsx')}>
               Excel mensal
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarFolha('csv')}>
+              Folha RH (CSV)
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarFolha('xlsx')}>
+              Folha RH (Excel)
             </Button>
           </div>
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -66,8 +66,12 @@ export function PontoEquipe() {
   const [salvandoAjuste, setSalvandoAjuste] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
-  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario'>('resto_do_dia')
+  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
+  const [heDuracaoMin, setHeDuracaoMin] = useState('60')
+  const [heConcederAtendente, setHeConcederAtendente] = useState('')
+  const [heConcederMotivo, setHeConcederMotivo] = useState('')
+  const [concedendoHe, setConcedendoHe] = useState(false)
   const [decidindoHeId, setDecidindoHeId] = useState<number | null>(null)
   const [digest, setDigest] = useState<Ponto.Digest | null>(null)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
@@ -261,6 +265,8 @@ export function PontoEquipe() {
         aprovar,
         modo: aprovar ? heModo : null,
         ate_horario: aprovar && heModo === 'ate_horario' ? heAteHorario : null,
+        duracao_minutos:
+          aprovar && heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
         decisao_motivo: aprovar ? null : 'Negado pelo administrador',
       })
       toast.showSuccess(aprovar ? 'Hora extra liberada.' : 'Pedido de hora extra negado.')
@@ -269,6 +275,30 @@ export function PontoEquipe() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a hora extra.'))
     } finally {
       setDecidindoHeId(null)
+    }
+  }
+
+  async function concederHe() {
+    if (!heConcederAtendente) {
+      toast.showWarning('Selecione o atendente.')
+      return
+    }
+    setConcedendoHe(true)
+    try {
+      await ponto.concederHoraExtra({
+        atendente_id: Number(heConcederAtendente),
+        modo: heModo,
+        ate_horario: heModo === 'ate_horario' ? heAteHorario : null,
+        duracao_minutos: heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
+        motivo: heConcederMotivo.trim() || null,
+      })
+      toast.showSuccess('Hora extra concedida.')
+      setHeConcederMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível conceder a hora extra.'))
+    } finally {
+      setConcedendoHe(false)
     }
   }
 
@@ -462,17 +492,27 @@ export function PontoEquipe() {
 
         <Card title="Hora extra (WhatsApp após jornada)">
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
-            Pedidos para pegar novos chats depois do fim da jornada. Ao liberar, escolha o restante do dia ou até um
-            horário.
+            Conceda HE com antecedência ou libere pedidos após o fim da jornada. Modos: resto do dia, até um horário ou
+            duração em minutos (respeita o teto do colaborador, se houver).
           </p>
           <div className="mb-4 flex flex-wrap items-end gap-3">
             <Select
-              label="Ao aprovar"
+              label="Conceder a"
+              value={heConcederAtendente}
+              onChange={(v) => setHeConcederAtendente(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Select
+              label="Modo"
               value={heModo}
-              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario')}
+              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario' | 'duracao')}
               options={[
                 { value: 'resto_do_dia', label: 'Resto do dia' },
                 { value: 'ate_horario', label: 'Até horário' },
+                { value: 'duracao', label: 'Duração (minutos)' },
               ]}
             />
             {heModo === 'ate_horario' ? (
@@ -483,7 +523,26 @@ export function PontoEquipe() {
                 onChange={(e) => setHeAteHorario(e.target.value)}
               />
             ) : null}
+            {heModo === 'duracao' ? (
+              <Input
+                label="Minutos"
+                type="number"
+                min={15}
+                max={1440}
+                value={heDuracaoMin}
+                onChange={(e) => setHeDuracaoMin(e.target.value)}
+              />
+            ) : null}
+            <Input
+              label="Motivo (opcional)"
+              value={heConcederMotivo}
+              onChange={(e) => setHeConcederMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={concedendoHe} onClick={() => void concederHe()}>
+              Conceder HE
+            </Button>
           </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Pedidos pendentes</p>
           {hesPendentes.length === 0 ? (
             <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
           ) : (

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -12,6 +12,7 @@ import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
+import { useEventStream } from '../contexts/EventStreamContext'
 import {
   formatarDuracao,
   formatarHora,
@@ -42,6 +43,14 @@ function rotuloStatus(s: Ponto.HojeItem['status']): string {
   }
 }
 
+function extrairJanelaHeMotivo(motivo?: string | null): { ate?: string; duracao?: number } {
+  if (!motivo) return {}
+  const ate = motivo.match(/\[até\s+(\d{1,2}:\d{2})\]/i)?.[1]
+  const durRaw = motivo.match(/\[(\d+)\s*min\]/i)?.[1]
+  const duracao = durRaw ? Number(durRaw) : undefined
+  return { ate, duracao: Number.isFinite(duracao) ? duracao : undefined }
+}
+
 function toDatetimeLocalValue(d = new Date()): string {
   const pad = (n: number) => String(n).padStart(2, '0')
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
@@ -50,6 +59,7 @@ function toDatetimeLocalValue(d = new Date()): string {
 export function PontoEquipe() {
   const toast = useToast()
   const { user } = useAuth()
+  const { subscribe } = useEventStream()
   const [items, setItems] = useState<Ponto.BatidaAdmin[]>([])
   const [total, setTotal] = useState(0)
   const [hoje, setHoje] = useState<Ponto.HojeLista | null>(null)
@@ -149,6 +159,13 @@ export function PontoEquipe() {
   useEffect(() => {
     void carregar()
   }, [carregar])
+
+  useEffect(() => {
+    const unsub = subscribe('ponto.he_atualizada', () => {
+      void carregar(true)
+    })
+    return unsub
+  }, [subscribe, carregar])
 
   const carregarAjustesAudit = useCallback(async () => {
     setCarregandoAjustes(true)
@@ -320,12 +337,21 @@ export function PontoEquipe() {
   async function decidirHe(id: number, aprovar: boolean) {
     setDecidindoHeId(id)
     try {
+      const pend = hesPendentes.find((h) => h.id === id)
+      const hints = extrairJanelaHeMotivo(pend?.motivo)
+      const modoPed =
+        pend?.modo === 'resto_do_dia' || pend?.modo === 'ate_horario' || pend?.modo === 'duracao'
+          ? pend.modo
+          : null
+      const modo = aprovar ? modoPed || heModo : null
       await ponto.decidirHoraExtra(id, {
         aprovar,
-        modo: aprovar ? heModo : null,
-        ate_horario: aprovar && heModo === 'ate_horario' ? heAteHorario : null,
+        modo,
+        ate_horario: aprovar && modo === 'ate_horario' ? hints.ate || heAteHorario : null,
         duracao_minutos:
-          aprovar && heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
+          aprovar && modo === 'duracao'
+            ? Math.max(15, hints.duracao || Number(heDuracaoMin) || 60)
+            : null,
         decisao_motivo: aprovar ? null : 'Negado pelo administrador',
       })
       toast.showSuccess(aprovar ? 'Hora extra liberada.' : 'Pedido de hora extra negado.')
@@ -371,6 +397,7 @@ export function PontoEquipe() {
         fecho_apos_horas: settings.fecho_apos_horas,
         fecho_margem_pos_saida_minutos: settings.fecho_margem_pos_saida_minutos ?? 30,
         jornada_diaria_minutos: settings.jornada_diaria_minutos,
+        he_teto_mensal_minutos: settings.he_teto_mensal_minutos ?? null,
         politica_geolocalizacao: settings.politica_geolocalizacao,
       })
       setSettings(st)
@@ -432,7 +459,7 @@ export function PontoEquipe() {
             <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Digest de hoje
             </p>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
               <PontoMetricCard label="Faltas" value={String(digest?.faltas ?? 0)} tone="warn" />
               <PontoMetricCard label="Atrasos" value={String(digest?.atrasos ?? 0)} tone="warn" />
               <PontoMetricCard
@@ -449,6 +476,12 @@ export function PontoEquipe() {
                 label="Justificativas"
                 value={String(digest?.justificativas_pendentes ?? 0)}
                 hint="pendentes"
+              />
+              <PontoMetricCard
+                label="HE acima do teto"
+                value={String(digest?.he_acima_teto_mensal ?? 0)}
+                hint="mês (pessoas)"
+                tone={(digest?.he_acima_teto_mensal ?? 0) > 0 ? 'warn' : 'neutral'}
               />
             </div>
             {(digest?.itens ?? []).some((i) => i.status === 'falta' || i.atrasado) ? (
@@ -614,6 +647,9 @@ export function PontoEquipe() {
                   <div className="text-sm">
                     <p className="font-medium">{h.atendente_nome ?? h.atendente_id}</p>
                     <p className="text-slate-600 dark:text-slate-300">{h.motivo || 'Sem motivo informado'}</p>
+                    {h.modo ? (
+                      <p className="text-xs text-slate-500">Janela pedida: {h.modo.replace(/_/g, ' ')}</p>
+                    ) : null}
                   </div>
                   <div className="flex gap-2">
                     <Button
@@ -943,6 +979,27 @@ export function PontoEquipe() {
                   })
                 }
               />
+              <Input
+                label="Teto mensal de HE (minutos, global)"
+                type="number"
+                min={30}
+                max={44640}
+                value={
+                  settings.he_teto_mensal_minutos != null ? String(settings.he_teto_mensal_minutos) : ''
+                }
+                onChange={(e) => {
+                  const raw = e.target.value.trim()
+                  setSettings({
+                    ...settings,
+                    he_teto_mensal_minutos: raw ? Math.max(30, Number(raw) || 30) : null,
+                  })
+                }}
+                placeholder="Sem limite global"
+              />
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Vazio = sem teto global. Pode ser sobrescrito por pessoa no cadastro. Ao atingir o teto,
+                novas liberações são bloqueadas.
+              </p>
               <Select
                 label="Política de geolocalização"
                 value={settings.politica_geolocalizacao ?? 'opcional'}

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { ApiError, atendentes, audit, ponto, type Atendentes, type Audit, type Ponto } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { PontoAjudaModal } from '../components/PontoAjudaModal'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
 import { PontoBatidaMapaModal } from '../components/PontoBatidaMapaModal'
 import { PontoMetricCard } from '../components/PontoMetricCard'
@@ -76,6 +78,12 @@ export function PontoEquipe() {
   const [cobData, setCobData] = useState(hojeIso)
   const [cobMotivo, setCobMotivo] = useState('')
   const [concedendoCob, setConcedendoCob] = useState(false)
+  const [setup, setSetup] = useState<Ponto.SetupStatus | null>(null)
+  const [compAno, setCompAno] = useState(() => new Date().getFullYear())
+  const [compMes, setCompMes] = useState(() => new Date().getMonth() + 1)
+  const [competencia, setCompetencia] = useState<Ponto.Competencia | null>(null)
+  const [ciencias, setCiencias] = useState<Ponto.CienciaItem[]>([])
+  const [ajudaAberta, setAjudaAberta] = useState(false)
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
@@ -102,7 +110,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes, cobs] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, cobs, setupSt, comp, cins] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -116,6 +124,9 @@ export function PontoEquipe() {
           ponto.feriados(new Date().getFullYear()),
           ponto.horaExtraAdmin('pendente'),
           ponto.coberturasAdmin('pendente'),
+          ponto.setupStatus(),
+          ponto.competencia(compAno, compMes),
+          ponto.cienciasAdmin(compAno, compMes),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -126,6 +137,9 @@ export function PontoEquipe() {
         setFeriados(fer)
         setHesPendentes(hes)
         setCobPendentes(cobs)
+        setSetup(setupSt)
+        setCompetencia(comp)
+        setCiencias(cins)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -145,7 +159,7 @@ export function PontoEquipe() {
         setLoading(false)
       }
     },
-    [ate, atendenteId, desde, toast],
+    [ate, atendenteId, compAno, compMes, desde, toast],
   )
 
   useEffect(() => {
@@ -488,7 +502,121 @@ export function PontoEquipe() {
       <PageHeader
         title="Ponto da equipe"
         subtitle="Visão do dia, batidas, ajustes auditados e relatórios mensais."
+        actions={
+          <Button type="button" variant="secondary" onClick={() => setAjudaAberta(true)}>
+            Como funciona o ponto
+          </Button>
+        }
       />
+
+      {setup && setup.pendentes > 0 ? (
+        <Card className="mb-4 border-amber-200 bg-amber-50/80 dark:border-amber-900/50 dark:bg-amber-950/30" title="Checklist de configuração">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Defaults: fecho automático desligado até ativar; tolerância sugerida{' '}
+            {setup.tolerancia_sugerida_minutos} min no cadastro do colaborador.
+          </p>
+          <ul className="space-y-2 text-sm">
+            {setup.itens
+              .filter((i) => !i.ok)
+              .map((i) => (
+                <li key={i.codigo} className="flex flex-wrap items-center justify-between gap-2">
+                  <span>
+                    <strong>{i.titulo}</strong> — {i.detalhe}
+                  </span>
+                  {i.destino === 'cadastro_atendentes' ? (
+                    <Link to="/atendentes" className="text-cyan-700 underline dark:text-cyan-300">
+                      Abrir cadastro
+                    </Link>
+                  ) : (
+                    <a href="#ponto-settings" className="text-cyan-700 underline dark:text-cyan-300">
+                      Ir às configurações
+                    </a>
+                  )}
+                </li>
+              ))}
+          </ul>
+        </Card>
+      ) : null}
+
+      <Card className="mb-4" title="Competência mensal">
+        <div className="mb-3 flex flex-wrap items-end gap-3">
+          <Input
+            label="Ano"
+            type="number"
+            value={String(compAno)}
+            onChange={(e) => setCompAno(Number(e.target.value) || new Date().getFullYear())}
+          />
+          <Input
+            label="Mês"
+            type="number"
+            min={1}
+            max={12}
+            value={String(compMes)}
+            onChange={(e) => setCompMes(Math.min(12, Math.max(1, Number(e.target.value) || 1)))}
+          />
+          <Button
+            type="button"
+            disabled={competencia?.fechada}
+            onClick={() => {
+              void (async () => {
+                try {
+                  await ponto.fecharCompetencia(compAno, compMes)
+                  toast.showSuccess('Competência fechada.')
+                  await carregar(true)
+                } catch (err) {
+                  toast.showError(mensagemFalhaParaToast(err, 'Não foi possível fechar.'))
+                }
+              })()
+            }}
+          >
+            Fechar mês
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!competencia?.fechada}
+            onClick={() => {
+              const motivo = window.prompt('Motivo da reabertura:')
+              if (!motivo || motivo.trim().length < 3) return
+              void (async () => {
+                try {
+                  await ponto.reabrirCompetencia(compAno, compMes, { motivo: motivo.trim() })
+                  toast.showSuccess('Competência reaberta.')
+                  await carregar(true)
+                } catch (err) {
+                  toast.showError(mensagemFalhaParaToast(err, 'Não foi possível reabrir.'))
+                }
+              })()
+            }}
+          >
+            Reabrir
+          </Button>
+        </div>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          {competencia?.fechada
+            ? `Fechada${competencia.fechado_por_nome ? ` por ${competencia.fechado_por_nome}` : ''}${
+                competencia.fechado_em ? ` em ${new Date(competencia.fechado_em).toLocaleString('pt-BR')}` : ''
+              }. Ajustes passam a ser marcados como pós-fechamento.`
+            : 'Competência aberta — ajustes normais.'}
+        </p>
+        <p className="mt-3 mb-1 text-sm font-medium text-slate-800 dark:text-slate-100">Ciência da equipe</p>
+        {ciencias.length === 0 ? (
+          <p className="text-sm text-slate-500">Sem colaboradores ativos.</p>
+        ) : (
+          <ul className="max-h-48 space-y-1 overflow-y-auto text-sm">
+            {ciencias.map((c) => (
+              <li key={c.atendente_id} className="flex justify-between gap-2 border-b border-slate-100 py-1 dark:border-slate-800">
+                <span>{c.atendente_nome}</span>
+                <span className={c.confirmada ? 'text-emerald-700 dark:text-emerald-300' : 'text-amber-700 dark:text-amber-300'}>
+                  {c.confirmada
+                    ? `Confirmou${c.confirmado_em ? ` · ${new Date(c.confirmado_em).toLocaleString('pt-BR')}` : ''}`
+                    : 'Pendente'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
 
       <Card className="overflow-hidden border-cyan-200/60 bg-gradient-to-br from-slate-50 via-white to-cyan-50/40 dark:border-cyan-900/40 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">
         {loading && !digest ? (
@@ -1017,6 +1145,7 @@ export function PontoEquipe() {
           </Card>
         ) : null}
 
+        <div id="ponto-settings">
         <Card title="Configurações do ponto">
           {settings ? (
             <div className="space-y-3">
@@ -1107,6 +1236,7 @@ export function PontoEquipe() {
             <p className="text-sm text-slate-500">Carregando…</p>
           )}
         </Card>
+        </div>
 
         <Card title="Feriados da instância">
           <div className="mb-4 flex flex-wrap items-end gap-3">
@@ -1148,6 +1278,7 @@ export function PontoEquipe() {
         </Card>
       </div>
 
+      <PontoAjudaModal open={ajudaAberta} onClose={() => setAjudaAberta(false)} />
       <PontoBatidaMapaModal
         open={mapaBatida != null && mapaBatida.latitude != null && mapaBatida.longitude != null}
         onClose={() => setMapaBatida(null)}

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { ApiError, atendentes, ponto, type Atendentes, type Ponto } from '../api/client'
+import { ApiError, atendentes, audit, ponto, type Atendentes, type Audit, type Ponto } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
@@ -64,6 +64,11 @@ export function PontoEquipe() {
   const [ajusteQuando, setAjusteQuando] = useState(toDatetimeLocalValue())
   const [ajusteMotivo, setAjusteMotivo] = useState('')
   const [salvandoAjuste, setSalvandoAjuste] = useState(false)
+  const [ajustesAudit, setAjustesAudit] = useState<Audit.AuditLogEntry[]>([])
+  const [ajusteAutorId, setAjusteAutorId] = useState('')
+  const [ajusteAuditDesde, setAjusteAuditDesde] = useState(inicioMesIso)
+  const [ajusteAuditAte, setAjusteAuditAte] = useState(hojeIso)
+  const [carregandoAjustes, setCarregandoAjustes] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
@@ -145,6 +150,34 @@ export function PontoEquipe() {
     void carregar()
   }, [carregar])
 
+  const carregarAjustesAudit = useCallback(async () => {
+    setCarregandoAjustes(true)
+    try {
+      const page = await audit.list({
+        entity_type: 'ponto_batida',
+        atendente_id: ajusteAutorId ? Number(ajusteAutorId) : undefined,
+        de: ajusteAuditDesde,
+        ate: ajusteAuditAte,
+        ordenar_por: 'created_at',
+        ordem: 'desc',
+        limit: 50,
+      })
+      setAjustesAudit(
+        page.items.filter((x) =>
+          ['create_ajuste', 'update_ajuste', 'anular'].includes(x.action),
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar o histórico de ajustes.'))
+    } finally {
+      setCarregandoAjustes(false)
+    }
+  }, [ajusteAuditAte, ajusteAuditDesde, ajusteAutorId, toast])
+
+  useEffect(() => {
+    void carregarAjustesAudit()
+  }, [carregarAjustesAudit])
+
   useEffect(() => {
     if (!atendenteId) {
       setCalendario(null)
@@ -211,8 +244,12 @@ export function PontoEquipe() {
   }
 
   async function salvarAjuste() {
-    if (!ajusteAtendente || !ajusteMotivo.trim()) {
-      toast.showWarning('Informe atendente e motivo do ajuste.')
+    if (!ajusteAtendente) {
+      toast.showWarning('Selecione o atendente.')
+      return
+    }
+    if (ajusteMotivo.trim().length < 3) {
+      toast.showWarning('Informe o motivo do ajuste (mínimo 3 caracteres).')
       return
     }
     setSalvandoAjuste(true)
@@ -226,7 +263,7 @@ export function PontoEquipe() {
       })
       toast.showSuccess('Ajuste registrado.')
       setAjusteMotivo('')
-      await carregar(true)
+      await Promise.all([carregar(true), carregarAjustesAudit()])
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o ajuste.'))
     } finally {
@@ -235,14 +272,36 @@ export function PontoEquipe() {
   }
 
   async function anularBatida(id: number) {
-    const motivo = window.prompt('Motivo da anulação (obrigatório):')
-    if (!motivo || motivo.trim().length < 3) return
+    const motivo = window.prompt('Motivo da anulação (obrigatório, mín. 3 caracteres):')
+    if (!motivo || motivo.trim().length < 3) {
+      toast.showWarning('Anulação cancelada — motivo obrigatório.')
+      return
+    }
     try {
       await ponto.anular(id, motivo.trim())
       toast.showSuccess('Batida anulada.')
-      await carregar(true)
+      await Promise.all([carregar(true), carregarAjustesAudit()])
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível anular.'))
+    }
+  }
+
+  async function exportarAjustesCsv() {
+    try {
+      const blob = await audit.exportCsv({
+        entity_type: 'ponto_batida',
+        atendente_id: ajusteAutorId ? Number(ajusteAutorId) : undefined,
+        de: ajusteAuditDesde,
+        ate: ajusteAuditAte,
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `ajustes-ponto-${ajusteAuditDesde}-${ajusteAuditAte}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível exportar os ajustes.'))
     }
   }
 
@@ -581,6 +640,10 @@ export function PontoEquipe() {
         </Card>
 
         <Card title="Ajuste manual">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Toda alteração de batida exige <strong>motivo</strong> (mínimo 3 caracteres) e fica no histórico
+            auditado abaixo e no relatório mensal (PDF/Excel).
+          </p>
           <div className="flex flex-wrap items-end gap-3">
             <Select
               label="Atendente"
@@ -609,15 +672,83 @@ export function PontoEquipe() {
               onChange={(e) => setAjusteQuando(e.target.value)}
             />
             <Input
-              label="Motivo"
+              label="Motivo do ajuste (obrigatório)"
               value={ajusteMotivo}
               onChange={(e) => setAjusteMotivo(e.target.value)}
-              placeholder="Obrigatório"
+              placeholder="Ex.: esquecimento — mínimo 3 caracteres"
             />
-            <Button type="button" disabled={salvandoAjuste} onClick={() => void salvarAjuste()}>
+            <Button
+              type="button"
+              disabled={salvandoAjuste || ajusteMotivo.trim().length < 3 || !ajusteAtendente}
+              onClick={() => void salvarAjuste()}
+            >
               Registrar ajuste
             </Button>
           </div>
+        </Card>
+
+        <Card title="Histórico de ajustes">
+          <div className="mb-3 flex flex-wrap items-end gap-3">
+            <Select
+              label="Autor"
+              value={ajusteAutorId}
+              onChange={(v) => setAjusteAutorId(String(v))}
+              options={[
+                { value: '', label: 'Todos' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Input
+              label="De"
+              type="date"
+              value={ajusteAuditDesde}
+              onChange={(e) => setAjusteAuditDesde(e.target.value)}
+            />
+            <Input
+              label="Até"
+              type="date"
+              value={ajusteAuditAte}
+              onChange={(e) => setAjusteAuditAte(e.target.value)}
+            />
+            <Button type="button" variant="secondary" disabled={carregandoAjustes} onClick={() => void carregarAjustesAudit()}>
+              Filtrar
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarAjustesCsv()}>
+              Exportar CSV
+            </Button>
+          </div>
+          {ajustesAudit.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum ajuste no período.</p>
+          ) : (
+            <ul className="max-h-64 space-y-2 overflow-y-auto text-sm">
+              {ajustesAudit.map((log) => {
+                const payload = (log.payload_json ?? {}) as Record<string, unknown>
+                const motivo = typeof payload.motivo === 'string' ? payload.motivo : '—'
+                const acao =
+                  log.action === 'create_ajuste'
+                    ? 'Criação'
+                    : log.action === 'update_ajuste'
+                      ? 'Alteração'
+                      : log.action === 'anular'
+                        ? 'Anulação'
+                        : log.action
+                return (
+                  <li
+                    key={log.id}
+                    className="rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                  >
+                    <p className="font-medium text-slate-800 dark:text-slate-100">
+                      {acao} · batida #{log.entity_id} · {log.atendente_nome ?? log.atendente_id}
+                    </p>
+                    <p className="text-slate-600 dark:text-slate-300">{motivo}</p>
+                    <p className="text-xs text-slate-500">
+                      {log.created_at ? new Date(log.created_at).toLocaleString('pt-BR') : '—'}
+                    </p>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
         </Card>
 
         <Card title="Histórico">

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -353,7 +353,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const isAdmin = user?.role === 'admin'
   const podeTransferir = !encerrado && (isResponsavel || isAdmin)
   const podeEnviar = chat.estado === 'em_atendimento' && isResponsavel && !encerrado
-  const podeEncerrar = !encerrado && chat.estado === 'em_atendimento' && (isResponsavel || isAdmin)
+  const podeEncerrar = !encerrado && chat.estado === 'em_atendimento' && isResponsavel
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white dark:bg-slate-950">
@@ -451,7 +451,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
           key={`${chat.id}-${demandasReloadKey}`}
           chatId={chat.id}
           api={portalDemandasApi}
-          podeRegistrar={isResponsavel || isAdmin}
+          podeRegistrar={isResponsavel}
           onDemandasChange={() => {
             setDemandasReloadKey((k) => k + 1)
             void carregarDemandasTimeline()

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1505,7 +1505,7 @@ useEffect(() => {
     }
   }
 
-  const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
+  const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && isResponsavel
 
   async function exportarPdfChat() {
     if (!chat || exportandoPdf) return
@@ -1536,7 +1536,7 @@ useEffect(() => {
     podeDefinirEmpresa && !chat?.empresa_id && (chat?.empresas_opcoes?.length ?? 0) > 1
 
   const mostrarBannerDemandaInatividade =
-    Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
+    Boolean(chat?.classificacao_demanda_pendente) && isResponsavel
 
   const podeDigitarMensagem = !encerrado && !chat?.classificacao_demanda_pendente && (modoInterno || podeEnviar)
 
@@ -2129,7 +2129,7 @@ useEffect(() => {
             <WhatsappDemandasPanel
               key={chat.id}
               chatId={chat.id}
-              podeRegistrar={isResponsavel || isAdmin}
+              podeRegistrar={isResponsavel}
               onDemandasChange={refrescarTimelineDemandas}
             />
           </div>


### PR DESCRIPTION
## Summary

Lote **ponto** (C–G + HE antecipada/teto) e **correções de chat** acumulados na `main` desde o deploy **26.08.016**.

### DeskRudder — Melhorias

- Ponto (#968 / #972 / #971): lembretes, resumo semanal e ajustes admin
- Ponto (#966): HE antecipada e teto por colaborador
- Ponto (#976 / #977 / #973): ausências, anexo em justificativa, pausa mínima
- Ponto (#969 / #974 / #982): solicitação HE, teto mensal, SSE `ponto.he_atualizada`
- Ponto (#981 / #980 / #978 / #979): checklist, ajuda, competência e ciência
- Ponto (#975 / #970): export folha RH e cobertura de plantão

### DeskRudder — Correções

- Atendimentos (#996 / #S202608-0007): navbar no desktop com conversa aberta
- Atendimentos (#998 / #S202608-0009): Encerrar / Registrar demanda só para o responsável

### Migrations (Alembic)

`129_merge_he_teto_versao` → `130_ponto_lote_f` → `131_ponto_lote_g` → `132_ponto_he_teto_mensal` → `133_ponto_lote_e`

## Test plan

- [ ] `alembic upgrade head` em instância de teste (cadeia 129–133)
- [ ] Meu ponto / Ponto da equipe: HE, ausências, cobertura, competência, export folha
- [ ] Chat WhatsApp/Portal: navbar desktop; botões Encerrar/Registrar só para responsável
- [ ] SSE: evento `ponto.he_atualizada` após liberação de HE
- [ ] Deploy smoke: `/sobre` com nova versão CalVer; `concluir_solicitacoes_release` no admin-center
