### PR TITLE
feat(solicitacoes): UI Minhas solicitações e loopback ingest (#802 #803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 Formato baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
 Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging`.
@@ -17,6 +17,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- **Minhas solicitações** e bloco no **Sobre**: lista em tabela com badges; no Sobre só as **5 mais recentes** com atalho **Ver todas**; filtros por tipo, fase, status e busca; detalhe com timeline e mensagem de status por fase
+- **Nova solicitação**: seletor visual de tipo (chips), textos em pt-BR, anexos removíveis antes do envio e imagens coladas listadas com opção de remover
+- **Acompanhamento**: linha do tempo vertical no detalhe do pedido; skeleton da tabela no Sobre enquanto carrega
+- Provisionamento: URL de ingest gravada no `client.env` usa **loopback** (`127.0.0.1:8001`) por padrão — evita falha de sync quando instância e admin-center estão na mesma VPS
 - Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
 - Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
 - Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,7 +35,9 @@ LOG_LEVEL=INFO
 #
 # Instância cliente (não o control-plane): cópia das sugestões para o SaaS
 # SAAS_INSTANCE_SLUG=cliente01
-# SAAS_CONTROL_PLANE_INGEST_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+# Na mesma VPS que o admin-center, use loopback (gravado automaticamente no provisionamento):
+# SAAS_CONTROL_PLANE_INGEST_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes
+# Instância remota: https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
 # SAAS_INSTANCE_INGEST_TOKEN=
 # SAAS_TRIAGEM_PULL_INTERVAL_SECONDS=60
 # Token MCP legado (instância comercial). Preferir token pessoal gerado em /saas/conta.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -116,8 +116,11 @@ class Settings(BaseSettings):
     SAAS_CONTROL_PLANE_INGEST_URL: str | None = None
     SAAS_INSTANCE_INGEST_TOKEN: str | None = None
     SAAS_INSTANCE_SLUG: str | None = None
-    # Só no control-plane: URL pública que as instâncias devem usar (escrita no client.env).
+    # Só no control-plane: URL pública (documentação / instâncias remotas).
     SAAS_INGEST_PUBLIC_URL: str | None = None
+    # URL gravada no client.env para pull/push server-to-server na mesma VPS (evita Cloudflare no worker).
+    # Vazio = usa SAAS_INGEST_PUBLIC_URL / api.{domínio}.
+    SAAS_INGEST_LOOPBACK_URL: str = "http://127.0.0.1:8001/v1/saas/ingest/solicitacoes"
     # Instância cliente: intervalo do pull autenticado da triagem SaaS (#856).
     SAAS_TRIAGEM_PULL_INTERVAL_SECONDS: int = 60
     # Control-plane: token longo para o MCP do Cursor (não JWT). Vazio = só login saas_ops.

--- a/backend/app/services/saas_provisionamento.py
+++ b/backend/app/services/saas_provisionamento.py
@@ -161,9 +161,9 @@ def montar_comandos_ops(row: ClienteSaaS) -> str | None:
     port = row.api_port
     port_txt = str(port) if port is not None else "<api_port>"
     slug = row.slug
-    from app.services.saas_solicitacao_ingest import ingest_url_publica
+    from app.services.saas_solicitacao_ingest import ingest_url_para_client_env
 
-    ingest_url = ingest_url_publica()
+    ingest_url = ingest_url_para_client_env()
     return (
         f"# Na raiz do repositório no host de deploy\n"
         f"./deploy/scripts/provision-client.sh --slug {slug} --base-domain {base} --api-port {port_txt}\n"

--- a/backend/app/services/saas_solicitacao_ingest.py
+++ b/backend/app/services/saas_solicitacao_ingest.py
@@ -55,6 +55,14 @@ def ingest_url_publica() -> str:
     return f"https://api.{base}/v1/saas/ingest/solicitacoes"
 
 
+def ingest_url_para_client_env() -> str:
+    """URL escrita no client.env da instância (worker server-to-server)."""
+    loopback = (settings.SAAS_INGEST_LOOPBACK_URL or "").strip()
+    if loopback:
+        return loopback.rstrip("/")
+    return ingest_url_publica()
+
+
 def instance_slug_local() -> str:
     slug = (settings.SAAS_INSTANCE_SLUG or "").strip().lower()
     if slug:
@@ -504,7 +512,7 @@ def escrever_ingest_no_client_env(row: ClienteSaaS, *, token: str | None = None)
         return
     text = env_path.read_text(encoding="utf-8")
     text = _set_env_line(text, "SAAS_INSTANCE_SLUG", row.slug)
-    text = _set_env_line(text, "SAAS_CONTROL_PLANE_INGEST_URL", ingest_url_publica())
+    text = _set_env_line(text, "SAAS_CONTROL_PLANE_INGEST_URL", ingest_url_para_client_env())
     if token:
         text = _set_env_line(text, "SAAS_INSTANCE_INGEST_TOKEN", token)
     env_path.write_text(text, encoding="utf-8")

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -976,3 +976,17 @@ def test_versao_alvo_rotulo_so_apos_release(client, seed_base, auth_headers, mon
         json={"versao_alvo": "2026.09.01"},
     )
     assert inexistente.status_code == 404
+
+
+def test_ingest_url_para_client_env_prefere_loopback(monkeypatch):
+    from app.config import settings
+    from app.services.saas_solicitacao_ingest import ingest_url_para_client_env, ingest_url_publica
+
+    monkeypatch.setattr(
+        settings,
+        "SAAS_INGEST_LOOPBACK_URL",
+        "http://127.0.0.1:8001/v1/saas/ingest/solicitacoes",
+    )
+    assert ingest_url_para_client_env() == "http://127.0.0.1:8001/v1/saas/ingest/solicitacoes"
+    monkeypatch.setattr(settings, "SAAS_INGEST_LOOPBACK_URL", "")
+    assert ingest_url_para_client_env() == ingest_url_publica()

--- a/deploy/admin-center/README.md
+++ b/deploy/admin-center/README.md
@@ -48,7 +48,7 @@ Painel DuplexSoft continua em `/opt/dx-connect/frontend/dist` (API `api-duplexso
 
 1. Migrar tabelas SaaS + mídia `solicitacao_media` + `protocol_sequences` (`kind=S`) + contas `saas_ops` para o Postgres do `admin-center`
 2. Criar licença `clientes_saas` slug `duplexsoft` e token de ingest
-3. Na DuplexSoft (`backend/.env`): `SAAS_CONTROL_PLANE=false`, `SAAS_INSTANCE_SLUG=duplexsoft`, `SAAS_CONTROL_PLANE_INGEST_URL` + `SAAS_INSTANCE_INGEST_TOKEN`
+3. Na DuplexSoft (`backend/.env`): `SAAS_CONTROL_PLANE=false`, `SAAS_INSTANCE_SLUG=duplexsoft`, `SAAS_CONTROL_PLANE_INGEST_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes` + `SAAS_INSTANCE_INGEST_TOKEN`
 4. Desativar contas `saas_ops` na BD DuplexSoft (ficam só na comercial)
 5. Health esperado: `api.deskrudder.com.br` → `saas_control_plane: true`; `api-duplexsoft…` → `false`
 

--- a/deploy/admin-center/client.env.example
+++ b/deploy/admin-center/client.env.example
@@ -46,6 +46,8 @@ SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
 # Clientes novos começam em 8002; 8001 é desta API comercial
 SAAS_PROVISION_API_PORT_START=8002
 SAAS_INGEST_PUBLIC_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+# Gravada no client.env das instâncias na mesma VPS (worker server-to-server). Vazio = usa URL pública.
+SAAS_INGEST_LOOPBACK_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes
 SAAS_NOTIFY_EMAIL=comercial@deskrudder.com.br
 SAAS_TRIAL_DAYS=14
 SAAS_RENEWAL_ALERT_DAYS_BEFORE=14

--- a/deploy/clients/_template/client.env.example
+++ b/deploy/clients/_template/client.env.example
@@ -52,6 +52,8 @@ SEED_ADMIN_PASSWORD=ALTERE_SENHA_ADMIN_INICIAL
 SAAS_MODULOS=helpdesk
 
 # Fila de sugestões → control-plane DeskRudder (#855 / #856). Preenchido no provisionamento.
+# Na mesma VPS que o admin-center, o control-plane grava loopback (127.0.0.1:8001) para o worker
+# não passar pelo Cloudflare. Instância remota: deixe SAAS_INGEST_LOOPBACK_URL vazio no admin-center.
 SAAS_INSTANCE_SLUG=exemplo
 SAAS_CONTROL_PLANE_INGEST_URL=
 SAAS_INSTANCE_INGEST_TOKEN=

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -116,9 +116,11 @@ No `client.env` (provisionamento):
 
 ```
 SAAS_INSTANCE_SLUG=<slug da licença>
-SAAS_CONTROL_PLANE_INGEST_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+SAAS_CONTROL_PLANE_INGEST_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes
 SAAS_INSTANCE_INGEST_TOKEN=<gerado no painel SaaS, nunca no browser>
 ```
+
+Na **mesma VPS** que o admin-center, use a URL **loopback** acima no `backend/.env` da instância (o worker `saas-triagem-pull` chama a API sem passar pelo Cloudflare). O provisionamento grava essa URL automaticamente quando `SAAS_INGEST_LOOPBACK_URL` está definido no control-plane (padrão). Instância em **outro servidor**: deixe `SAAS_INGEST_LOOPBACK_URL` vazio no admin-center e use a URL pública `https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes`.
 
 Sem URL/token/slug, o pedido local continua; a cópia simplesmente não é enviada. Falha HTTP não faz rollback — a outbox (`webhook_outbox`, eventos `saas.solicitacao` e `saas.solicitacao.media`) tenta de novo. O JSON vai primeiro; a mídia (prints/anexos) segue em multipart para não meter ficheiros no payload JSON.
 
@@ -139,7 +141,8 @@ No control-plane (`SAAS_CONTROL_PLANE=true`), a abertura grava directo na tabela
 - `POST /v1/saas/me/mcp-token` — gera o token Cursor desta conta (plaintext uma vez). `GET` estado; `DELETE` revoga.
 - `GET/POST /v1/saas/usuarios` e `PATCH /v1/saas/usuarios/{id}` — equipa `saas_ops` (nome, e-mail, activo). `POST …/senha-temporaria` devolve senha uma vez. Não são atendentes da instância do cliente.
 - `POST /v1/saas/clientes/{id}/gerar-token-ingest` — devolve o plaintext **uma vez** e escreve no `client.env` se a pasta do cliente já existir.
-- `SAAS_INGEST_PUBLIC_URL` (opcional) — URL escrita no env das instâncias; por omissão `https://api.{SAAS_PROVISION_BASE_DOMAIN}/v1/saas/ingest/solicitacoes`.
+- `SAAS_INGEST_PUBLIC_URL` (opcional) — URL pública documentada; usada no `client.env` só se `SAAS_INGEST_LOOPBACK_URL` estiver vazio.
+- `SAAS_INGEST_LOOPBACK_URL` (control-plane, padrão `http://127.0.0.1:8001/v1/saas/ingest/solicitacoes`) — gravada no `client.env` das instâncias na mesma VPS.
 
 Handoff Cursor é #857: o Cursor **puxa** a fila (MCP `deskrudder-saas`) contra a **API do control-plane**, não o contrário.
 

--- a/frontend/src/components/release/ReleaseNotesView.tsx
+++ b/frontend/src/components/release/ReleaseNotesView.tsx
@@ -7,6 +7,8 @@ import { Button } from '../../components/ui/Button'
 import { VoltarButton } from '../../components/ui/VoltarButton'
 import { BrandLogo } from '../../brand'
 import { PageContainer } from '../../components/ui/PageContainer'
+import { SolicitacoesMelhoriaListaTable } from '../solicitacoes/SolicitacoesMelhoriaListaTable'
+import { SolicitacoesMelhoriaListaSkeleton } from '../solicitacoes/SolicitacoesMelhoriaListaSkeleton'
 
 const CATEGORY_LABEL: Record<string, string> = {
   melhorias: 'Melhorias',
@@ -117,15 +119,9 @@ export type ReleaseNotesViewProps = {
   showProductTags?: boolean
 }
 
-function formatWhen(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
-  } catch {
-    return iso
-  }
-}
+/** Lista compartilhada de versão + histórico (#674 / #920). */
 
-/** Lista partilhada de versão + histórico (#674 / #920). */
+const PREVIEW_MINHAS = 5
 export function ReleaseNotesView({
   backTo,
   backLabel = 'Voltar',
@@ -141,11 +137,13 @@ export function ReleaseNotesView({
 }: ReleaseNotesViewProps) {
   const navigate = useNavigate()
   const [minhas, setMinhas] = useState<SolicitacoesMelhoria.ListaItem[]>([])
+  const [loadingMinhas, setLoadingMinhas] = useState(showSugestoesCta)
   const pastReleases = (notes?.releases ?? []).filter((r) => r.version !== notes?.current?.version)
 
   useEffect(() => {
     if (!showSugestoesCta) return
     let cancelled = false
+    setLoadingMinhas(true)
     void solicitacoesMelhoria
       .minhas()
       .then((rows) => {
@@ -153,6 +151,9 @@ export function ReleaseNotesView({
       })
       .catch(() => {
         if (!cancelled) setMinhas([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingMinhas(false)
       })
     return () => {
       cancelled = true
@@ -201,40 +202,52 @@ export function ReleaseNotesView({
             >
               Enviar sugestão / relatar problema
             </Button>
+            {loadingMinhas ? null : minhas.length > 0 ? (
+              <Link
+                to="/minhas-solicitacoes"
+                className="text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+              >
+                Minhas solicitações ({minhas.length})
+              </Link>
+            ) : null}
           </div>
         ) : null}
       </Card>
 
       {showSugestoesCta ? (
-        <Card title="Minhas solicitações">
-          {minhas.length === 0 ? (
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Ainda não enviou nenhum pedido. Use o botão acima para sugerir uma melhoria ou relatar um problema.
-            </p>
-          ) : (
-            <ul className="divide-y divide-slate-100 dark:divide-slate-800">
-              {minhas.slice(0, 8).map((item) => (
-                <li key={item.id}>
-                  <Link
-                    to={`/minhas-solicitacoes/${item.id}`}
-                    className="flex flex-wrap items-baseline justify-between gap-2 py-3 text-sm hover:text-cyan-700 dark:hover:text-cyan-400"
-                  >
-                    <span className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</span>
-                    <span className="text-xs text-slate-500">
-                      {item.status_rotulo} · {formatWhen(item.created_at)}
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          )}
-          {minhas.length > 8 ? (
-            <p className="pt-2 text-sm">
-              <Link to="/minhas-solicitacoes" className="font-medium text-cyan-700 hover:underline dark:text-cyan-400">
+        <Card
+          title="Minhas solicitações"
+          description={
+            loadingMinhas
+              ? 'Carregando…'
+              : minhas.length > 0
+                ? `${Math.min(minhas.length, PREVIEW_MINHAS)} mais recente${minhas.length === 1 ? '' : 's'}`
+                : undefined
+          }
+          titleActions={
+            !loadingMinhas && minhas.length > PREVIEW_MINHAS ? (
+              <Link
+                to="/minhas-solicitacoes"
+                className="text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+              >
                 Ver todas →
               </Link>
+            ) : null
+          }
+          bodyClassName={loadingMinhas || minhas.length > 0 ? 'overflow-x-auto p-0' : 'p-6'}
+        >
+          {loadingMinhas ? (
+            <SolicitacoesMelhoriaListaSkeleton rows={PREVIEW_MINHAS} />
+          ) : minhas.length === 0 ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Você ainda não enviou nenhum pedido. Use o botão acima para sugerir uma melhoria ou relatar um problema.
             </p>
-          ) : null}
+          ) : (
+            <SolicitacoesMelhoriaListaTable
+              items={minhas.slice(0, PREVIEW_MINHAS)}
+              itemPath={(solicitacaoId) => `/minhas-solicitacoes/${solicitacaoId}`}
+            />
+          )}
         </Card>
       ) : null}
 

--- a/frontend/src/components/release/SolicitacaoDescricao.tsx
+++ b/frontend/src/components/release/SolicitacaoDescricao.tsx
@@ -29,15 +29,15 @@ export function SolicitacaoDescricao({
   descricao: string
   anexos?: Anexo[] | SolicitacoesMelhoria.Anexo[]
 }) {
-  const ficheiros = anexos.filter((a) => a.papel !== 'inline')
+  const arquivosAnexo = anexos.filter((a) => a.papel !== 'inline')
   return (
     <div className="space-y-4">
       <KbMarkdownPreview markdown={descricao} emptyLabel="Sem descrição." />
-      {ficheiros.length > 0 ? (
+      {arquivosAnexo.length > 0 ? (
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Anexos</p>
           <ul className="space-y-3">
-            {ficheiros.map((a) => {
+            {arquivosAnexo.map((a) => {
               const href = solicitacoesMelhoria.mediaUrl(a.url)
               if (isImage(a.content_type)) {
                 return (

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaBadges.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaBadges.tsx
@@ -1,0 +1,29 @@
+import {
+  classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
+  rotuloStatusSolicitacao,
+  rotuloTipoSolicitacao,
+} from '../../lib/saasSolicitacoes'
+
+type Props = {
+  tipo: string
+  status: string
+  statusRotulo?: string
+}
+
+export function SolicitacoesMelhoriaBadges({ tipo, status, statusRotulo }: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span
+        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(tipo)}`}
+      >
+        {rotuloTipoSolicitacao(tipo)}
+      </span>
+      <span
+        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(status)}`}
+      >
+        {statusRotulo || rotuloStatusSolicitacao(status)}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaSkeleton.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaSkeleton.tsx
@@ -1,0 +1,23 @@
+type Props = {
+  rows?: number
+}
+
+/** Placeholder da tabela enquanto carrega Minhas solicitações no Sobre. */
+export function SolicitacoesMelhoriaListaSkeleton({ rows = 4 }: Props) {
+  return (
+    <div className="divide-y divide-slate-100 dark:divide-slate-800" aria-busy="true" aria-label="Carregando solicitações">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex flex-wrap items-center gap-4 px-4 py-4 sm:px-6">
+          <div className="h-5 w-20 animate-pulse rounded-full bg-slate-100 dark:bg-slate-800" />
+          <div className="h-4 w-24 animate-pulse rounded bg-slate-100 font-mono dark:bg-slate-800" />
+          <div className="min-w-[12rem] flex-1 space-y-2">
+            <div className="h-4 w-full max-w-md animate-pulse rounded bg-slate-100 dark:bg-slate-800" />
+            <div className="h-3 w-32 animate-pulse rounded bg-slate-100 dark:bg-slate-800" />
+          </div>
+          <div className="h-5 w-28 animate-pulse rounded-full bg-slate-100 dark:bg-slate-800" />
+          <div className="h-4 w-24 animate-pulse rounded bg-slate-100 dark:bg-slate-800" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaTable.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaTable.tsx
@@ -1,0 +1,89 @@
+import { useNavigate } from 'react-router-dom'
+import type { SolicitacoesMelhoria } from '../../api/client'
+import {
+  classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
+  rotuloStatusSolicitacao,
+  rotuloTipoSolicitacao,
+} from '../../lib/saasSolicitacoes'
+
+function formatWhen(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  } catch {
+    return iso
+  }
+}
+
+type Props = {
+  items: SolicitacoesMelhoria.ListaItem[]
+  /** Rota do detalhe, ex.: `/minhas-solicitacoes/${id}` */
+  itemPath: (id: number) => string
+}
+
+/** Tabela de solicitações do cliente — mesma linguagem visual do painel admin SaaS. */
+export function SolicitacoesMelhoriaListaTable({ items, itemPath }: Props) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[640px] text-left text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Tipo</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Protocolo</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Título</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Status</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Quando</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          {items.map((item) => (
+            <tr
+              key={item.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => navigate(itemPath(item.id))}
+              onKeyDown={(ev) => {
+                if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault()
+                  navigate(itemPath(item.id))
+                }
+              }}
+              className={`cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 ${
+                item.tipo === 'problema'
+                  ? 'border-l-2 border-l-rose-400/80'
+                  : 'border-l-2 border-l-sky-400/60'
+              }`}
+            >
+              <td className="px-4 py-3 sm:px-6">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(item.tipo)}`}
+                >
+                  {rotuloTipoSolicitacao(item.tipo)}
+                </span>
+              </td>
+              <td className="px-4 py-3 font-mono text-sm text-cyan-800 dark:text-cyan-300 sm:px-6">
+                {item.protocolo || '—'}
+              </td>
+              <td className="px-4 py-3 sm:px-6">
+                <p className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</p>
+                {item.versao_alvo_rotulo ? (
+                  <p className="mt-0.5 text-xs text-emerald-700 dark:text-emerald-300">{item.versao_alvo_rotulo}</p>
+                ) : null}
+              </td>
+              <td className="px-4 py-3 sm:px-6">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.status)}`}
+                >
+                  {item.status_rotulo || rotuloStatusSolicitacao(item.status)}
+                </span>
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-slate-500 sm:px-6">{formatWhen(item.created_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaTimeline.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaTimeline.tsx
@@ -1,0 +1,83 @@
+import type { SolicitacoesMelhoria } from '../../api/client'
+import { classesBadgeStatusSolicitacao } from '../../lib/saasSolicitacoes'
+
+function fmt(dt: string): string {
+  try {
+    return new Date(dt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  } catch {
+    return dt
+  }
+}
+
+type TimelineEntry =
+  | { kind: 'historico'; id: number; created_at: string; data: SolicitacoesMelhoria.Historico }
+  | { kind: 'comentario'; id: number; created_at: string; data: SolicitacoesMelhoria.Comentario }
+
+function montarTimeline(
+  historico: SolicitacoesMelhoria.Historico[],
+  comentarios: SolicitacoesMelhoria.Comentario[],
+): TimelineEntry[] {
+  const items: TimelineEntry[] = [
+    ...historico.map((h) => ({ kind: 'historico' as const, id: h.id, created_at: h.created_at, data: h })),
+    ...comentarios.map((c) => ({ kind: 'comentario' as const, id: c.id, created_at: c.created_at, data: c })),
+  ]
+  return items.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+}
+
+type Props = {
+  historico: SolicitacoesMelhoria.Historico[]
+  comentarios: SolicitacoesMelhoria.Comentario[]
+}
+
+/** Linha do tempo vertical — status + comentários em ordem cronológica. */
+export function SolicitacoesMelhoriaTimeline({ historico, comentarios }: Props) {
+  const items = montarTimeline(historico, comentarios)
+
+  if (items.length === 0) {
+    return <p className="text-sm text-slate-500">Ainda não há atualizações neste pedido.</p>
+  }
+
+  return (
+    <ol className="relative border-l-2 border-slate-200 pl-6 dark:border-slate-700">
+      {items.map((item) => {
+        const isComentario = item.kind === 'comentario'
+        const dotClass = isComentario
+          ? 'bg-cyan-500 ring-cyan-100 dark:ring-cyan-950/60'
+          : 'bg-slate-400 ring-slate-100 dark:bg-slate-500 dark:ring-slate-900/80'
+
+        return (
+          <li key={`${item.kind}-${item.id}`} className="relative pb-6 last:pb-0">
+            <span
+              className={`absolute -left-[calc(0.75rem+1px)] top-1.5 size-3 rounded-full ring-4 ${dotClass}`}
+              aria-hidden
+            />
+            {item.kind === 'historico' ? (
+              <div className="rounded-lg border border-slate-100 bg-slate-50/80 p-3 text-sm dark:border-slate-800 dark:bg-slate-800/40">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.data.status_novo)}`}
+                  >
+                    {item.data.status_novo_rotulo}
+                  </span>
+                  <span className="text-xs text-slate-400">{fmt(item.created_at)}</span>
+                </div>
+                {item.data.mensagem_publica ? (
+                  <p className="mt-2 whitespace-pre-wrap text-slate-600 dark:text-slate-300">
+                    {item.data.mensagem_publica}
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-cyan-100 bg-white p-3 text-sm shadow-sm dark:border-cyan-900/40 dark:bg-slate-900/60">
+                <p className="text-xs font-medium text-slate-500">
+                  {item.data.autor_nome || 'Equipe'} · {fmt(item.created_at)}
+                </p>
+                <p className="mt-1 whitespace-pre-wrap text-slate-700 dark:text-slate-200">{item.data.corpo}</p>
+              </div>
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,25 +1,40 @@
-import { type HTMLAttributes } from 'react'
+import { type HTMLAttributes, type ReactNode } from 'react'
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   title?: string
   description?: string
+  /** Ações à direita do título (ex.: link). */
+  titleActions?: ReactNode
+  /** Classes do corpo (ex.: `p-0` para tabela edge-to-edge). */
+  bodyClassName?: string
 }
 
-export function Card({ title, description, className = '', children, ...props }: CardProps) {
+export function Card({
+  title,
+  description,
+  titleActions,
+  bodyClassName = 'p-6',
+  className = '',
+  children,
+  ...props
+}: CardProps) {
   return (
     <div
       className={`rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900/95 dark:shadow-none dark:ring-1 dark:ring-white/5 ${className}`}
       {...props}
     >
-      {title && (
-        <div className="border-b border-slate-200 px-6 py-4 dark:border-slate-800">
-          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
-          {description ? (
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
-          ) : null}
+      {title ? (
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 px-6 py-4 dark:border-slate-800">
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
+            {description ? (
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+            ) : null}
+          </div>
+          {titleActions ? <div className="shrink-0">{titleActions}</div> : null}
         </div>
-      )}
-      <div className="p-6">{children}</div>
+      ) : null}
+      <div className={bodyClassName}>{children}</div>
     </div>
   )
 }

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -48,7 +48,7 @@ export function PageContainer({
 
 type PageHeaderProps = {
   title: string
-  subtitle?: string
+  subtitle?: ReactNode
   actions?: ReactNode
 }
 
@@ -58,7 +58,11 @@ export function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
     <div className="flex flex-wrap items-start justify-between gap-4">
       <div className="min-w-0">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">{title}</h1>
-        {subtitle ? <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{subtitle}</p> : null}
+        {subtitle ? (
+          <div className={`mt-2 ${typeof subtitle === 'string' ? 'text-sm text-slate-600 dark:text-slate-400' : ''}`}>
+            {subtitle}
+          </div>
+        ) : null}
       </div>
       {actions ? <div className="shrink-0">{actions}</div> : null}
     </div>

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -51,6 +51,37 @@ export const SAAS_SOLICITACAO_FASES = [
 
 export type SaasSolicitacaoFase = (typeof SAAS_SOLICITACAO_FASES)[number]['value']
 
+/** Espelha FASES_STATUS do backend (solicitacao_melhoria_copy.py). */
+const FASE_STATUS: Record<SaasSolicitacaoFase, readonly string[]> = {
+  aguardando: ['aberta', 'em_analise', 'planejada'],
+  desenvolvimento: ['em_desenvolvimento'],
+  finalizadas: ['concluida', 'nao_sera_desenvolvida'],
+}
+
+export function statusNaFase(status: string, fase: SaasSolicitacaoFase): boolean {
+  return FASE_STATUS[fase]?.includes(status) ?? false
+}
+
+export function classesCardMensagemStatus(status: string): string {
+  const base = 'rounded-lg border-l-4 p-3 text-sm'
+  if (status === 'concluida') {
+    return `${base} border-emerald-500 bg-emerald-50 text-emerald-900 dark:border-emerald-500 dark:bg-emerald-950/40 dark:text-emerald-100`
+  }
+  if (status === 'nao_sera_desenvolvida') {
+    return `${base} border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-500 dark:bg-rose-950/40 dark:text-rose-100`
+  }
+  if (status === 'em_desenvolvimento') {
+    return `${base} border-cyan-500 bg-cyan-50 text-cyan-900 dark:border-cyan-500 dark:bg-cyan-950/40 dark:text-cyan-100`
+  }
+  if (status === 'planejada') {
+    return `${base} border-violet-500 bg-violet-50 text-violet-900 dark:border-violet-500 dark:bg-violet-950/40 dark:text-violet-100`
+  }
+  if (status === 'em_analise') {
+    return `${base} border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-500 dark:bg-sky-950/40 dark:text-sky-100`
+  }
+  return `${base} border-slate-400 bg-slate-50 text-slate-700 dark:border-slate-600 dark:bg-slate-800/60 dark:text-slate-200`
+}
+
 const BADGE: Record<string, string> = {
   aberta:
     'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70',

--- a/frontend/src/pages/MinhasSolicitacoes.tsx
+++ b/frontend/src/pages/MinhasSolicitacoes.tsx
@@ -1,37 +1,111 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { solicitacoesMelhoria, type SolicitacoesMelhoria } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { VoltarButton } from '../components/ui/VoltarButton'
-import { TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { INPUT_FIELD_CLASS, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { PageLoading } from '../components/ui/PageLoading'
 import { useToast } from '../components/ui/Toast'
 import { SolicitacaoDescricao } from '../components/release/SolicitacaoDescricao'
+import { SolicitacoesMelhoriaBadges } from '../components/solicitacoes/SolicitacoesMelhoriaBadges'
+import { SolicitacoesMelhoriaListaTable } from '../components/solicitacoes/SolicitacoesMelhoriaListaTable'
+import { SolicitacoesMelhoriaTimeline } from '../components/solicitacoes/SolicitacoesMelhoriaTimeline'
 import { useAuth } from '../contexts/AuthContext'
+import {
+  classesCardMensagemStatus,
+  SAAS_SOLICITACAO_FASES,
+  SAAS_SOLICITACAO_STATUS,
+  statusNaFase,
+  type SaasSolicitacaoFase,
+} from '../lib/saasSolicitacoes'
 
 const STATUS_FINAIS = new Set(['concluida', 'nao_sera_desenvolvida'])
 
-function fmt(dt: string): string {
-  try {
-    return new Date(dt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
-  } catch {
-    return dt
-  }
+function FiltroChip({
+  active,
+  onClick,
+  children,
+  count,
+  tone,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+  count?: number
+  tone?: 'sky' | 'rose' | 'default'
+}) {
+  const toneActive =
+    tone === 'sky'
+      ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-400 dark:bg-sky-950/50 dark:text-sky-100'
+      : tone === 'rose'
+        ? 'border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-400 dark:bg-rose-950/50 dark:text-rose-100'
+        : 'border-cyan-500 bg-cyan-50 text-cyan-950 dark:border-cyan-400 dark:bg-cyan-950/40 dark:text-cyan-50'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? toneActive
+          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800/60'
+      }`}
+    >
+      {children}
+      {count != null ? (
+        <span className={`tabular-nums text-xs ${active ? 'opacity-80' : 'text-slate-400 dark:text-slate-500'}`}>
+          {count}
+        </span>
+      ) : null}
+    </button>
+  )
 }
 
-/** Lista + detalhe das solicitações do utilizador (#803). */
+function contarPorFase(items: SolicitacoesMelhoria.ListaItem[], fase: SaasSolicitacaoFase): number {
+  return items.filter((item) => statusNaFase(item.status, fase)).length
+}
+
+/** Lista + detalhe das solicitações do usuário (#803). */
 export function MinhasSolicitacoesPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
   const { user } = useAuth()
   const [lista, setLista] = useState<SolicitacoesMelhoria.ListaItem[]>([])
   const [detalhe, setDetalhe] = useState<SolicitacoesMelhoria.Detalhe | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadingDetalhe, setLoadingDetalhe] = useState(false)
   const [resposta, setResposta] = useState('')
   const [enviando, setEnviando] = useState(false)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+
+  const tipoFiltro = searchParams.get('tipo') || ''
+  const faseFiltro = (searchParams.get('fase') || '') as SaasSolicitacaoFase | ''
+  const statusFiltro = searchParams.get('status') || ''
+
+  function patchFiltros(next: Record<string, string | null>) {
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev)
+        for (const [k, v] of Object.entries(next)) {
+          if (v == null || v === '') p.delete(k)
+          else p.set(k, v)
+        }
+        return p
+      },
+      { replace: true },
+    )
+  }
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim().toLowerCase()), 300)
+    return () => clearTimeout(t)
+  }, [busca])
 
   const carregarLista = useCallback(() => {
     return solicitacoesMelhoria
@@ -54,19 +128,47 @@ export function MinhasSolicitacoesPage() {
   useEffect(() => {
     if (!id) {
       setDetalhe(null)
+      setLoadingDetalhe(false)
       return
     }
     let cancel = false
+    setLoadingDetalhe(true)
     void solicitacoesMelhoria
       .get(Number(id))
       .then((d) => {
         if (!cancel) setDetalhe(d)
       })
       .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Falha ao abrir solicitação')))
+      .finally(() => {
+        if (!cancel) setLoadingDetalhe(false)
+      })
     return () => {
       cancel = true
     }
   }, [id, toast])
+
+  const resumo = useMemo(
+    () => ({
+      total: lista.length,
+      sugestoes: lista.filter((i) => i.tipo === 'sugestao').length,
+      problemas: lista.filter((i) => i.tipo === 'problema').length,
+      aguardando: contarPorFase(lista, 'aguardando'),
+      desenvolvimento: contarPorFase(lista, 'desenvolvimento'),
+      finalizadas: contarPorFase(lista, 'finalizadas'),
+    }),
+    [lista],
+  )
+
+  const listaFiltrada = useMemo(() => {
+    return lista.filter((item) => {
+      if (tipoFiltro && item.tipo !== tipoFiltro) return false
+      if (statusFiltro && item.status !== statusFiltro) return false
+      if (faseFiltro && !statusNaFase(item.status, faseFiltro)) return false
+      if (!debouncedBusca) return true
+      const hay = `${item.titulo} ${item.protocolo || ''}`.toLowerCase()
+      return hay.includes(debouncedBusca)
+    })
+  }, [lista, tipoFiltro, faseFiltro, statusFiltro, debouncedBusca])
 
   async function enviarResposta() {
     if (!detalhe || !resposta.trim()) return
@@ -91,27 +193,48 @@ export function MinhasSolicitacoesPage() {
     !STATUS_FINAIS.has(detalhe.status) &&
     detalhe.autor_atendente_id === user?.id
 
-  if (id && detalhe) {
+  if (id) {
+    if (loadingDetalhe && !detalhe) {
+      return (
+        <PageContainer>
+          <PageLoading label="Abrindo solicitação…" />
+        </PageContainer>
+      )
+    }
+
+    if (!detalhe) {
+      return (
+        <PageContainer>
+          <VoltarButton onClick={() => navigate('/minhas-solicitacoes')} label="Voltar à lista" />
+          <p className="text-sm text-slate-500">Não foi possível carregar este pedido.</p>
+        </PageContainer>
+      )
+    }
+
     return (
       <PageContainer>
-          <PageHeader
+        <PageHeader
           title={`${detalhe.protocolo || 'Pedido'} · ${detalhe.titulo}`}
-          subtitle={`${detalhe.tipo === 'problema' ? 'Problema' : 'Sugestão'} · ${detalhe.status_rotulo}`}
+          subtitle={
+            <SolicitacoesMelhoriaBadges
+              tipo={detalhe.tipo}
+              status={detalhe.status}
+              statusRotulo={detalhe.status_rotulo}
+            />
+          }
         />
         <VoltarButton onClick={() => navigate('/minhas-solicitacoes')} label="Voltar à lista" />
 
         <Card className="space-y-3 p-5">
           <SolicitacaoDescricao descricao={detalhe.descricao} anexos={detalhe.anexos} />
-          <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600 dark:bg-slate-800/60 dark:text-slate-300">
-            {detalhe.mensagem_status}
-          </p>
+          <p className={classesCardMensagemStatus(detalhe.status)}>{detalhe.mensagem_status}</p>
           {detalhe.versao_alvo_rotulo ? (
             <p className="rounded-lg bg-emerald-50 p-3 text-sm font-medium text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100">
               {detalhe.versao_alvo_rotulo}
             </p>
           ) : null}
           {detalhe.status === 'nao_sera_desenvolvida' && detalhe.motivo_nao_desenvolvimento ? (
-            <p className="text-sm text-slate-600 dark:text-slate-300">
+            <p className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-100">
               <span className="font-medium">Motivo: </span>
               {detalhe.motivo_nao_desenvolvimento}
             </p>
@@ -120,23 +243,7 @@ export function MinhasSolicitacoesPage() {
 
         <section className="space-y-3">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Acompanhamento</h2>
-          <div className="space-y-2">
-            {detalhe.historico.map((h) => (
-              <Card key={`h-${h.id}`} className="p-3 text-sm">
-                <p className="font-medium text-slate-800 dark:text-slate-100">{h.status_novo_rotulo}</p>
-                {h.mensagem_publica ? (
-                  <p className="mt-1 whitespace-pre-wrap text-slate-600 dark:text-slate-300">{h.mensagem_publica}</p>
-                ) : null}
-                <p className="mt-1 text-xs text-slate-400">{fmt(h.created_at)}</p>
-              </Card>
-            ))}
-            {detalhe.comentarios.map((c) => (
-              <Card key={`c-${c.id}`} className="p-3 text-sm">
-                <p className="text-xs font-medium text-slate-500">{c.autor_nome || 'Equipe'} · {fmt(c.created_at)}</p>
-                <p className="mt-1 whitespace-pre-wrap text-slate-700 dark:text-slate-200">{c.corpo}</p>
-              </Card>
-            ))}
-          </div>
+          <SolicitacoesMelhoriaTimeline historico={detalhe.historico} comentarios={detalhe.comentarios} />
         </section>
 
         {podeResponder ? (
@@ -177,10 +284,10 @@ export function MinhasSolicitacoesPage() {
         </Link>
       </div>
       {loading ? (
-        <p className="text-sm text-slate-500">A carregar…</p>
+        <PageLoading label="Carregando solicitações…" />
       ) : lista.length === 0 ? (
         <Card className="p-8 text-center text-sm text-slate-500">
-          Ainda não tem pedidos.{' '}
+          Você ainda não enviou nenhum pedido.{' '}
           <Link to="/sobre/nova-solicitacao" className="text-cyan-700 underline dark:text-cyan-400">
             Enviar sugestão
           </Link>
@@ -191,26 +298,127 @@ export function MinhasSolicitacoesPage() {
           .
         </Card>
       ) : (
-        <div className="space-y-2">
-          {lista.map((item) => (
-            <Link key={item.id} to={`/minhas-solicitacoes/${item.id}`} className="block">
-              <Card className="p-4 transition hover:ring-1 hover:ring-cyan-400/50">
-                <div className="flex flex-wrap items-baseline justify-between gap-2">
-                  <h3 className="font-semibold text-slate-900 dark:text-slate-50">
-                    <span className="font-mono text-xs font-medium text-cyan-700 dark:text-cyan-400">
-                      {item.protocolo || 'Pendente'}
-                    </span>{' '}
-                    {item.titulo}
-                  </h3>
-                  <span className="text-xs font-medium text-slate-500">{item.status_rotulo}</span>
-                </div>
-                <p className="mt-1 text-xs text-slate-400">
-                  {item.tipo === 'problema' ? 'Problema' : 'Sugestão'} · {fmt(item.created_at)}
-                  {item.versao_alvo_rotulo ? ` · ${item.versao_alvo_rotulo}` : ''}
+        <div className="space-y-4">
+          <Card>
+            <div className="space-y-4">
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Tipo
                 </p>
-              </Card>
-            </Link>
-          ))}
+                <div className="flex flex-wrap gap-2">
+                  <FiltroChip active={!tipoFiltro} count={resumo.total} onClick={() => patchFiltros({ tipo: null })}>
+                    Todos
+                  </FiltroChip>
+                  <FiltroChip
+                    active={tipoFiltro === 'sugestao'}
+                    count={resumo.sugestoes}
+                    tone="sky"
+                    onClick={() => patchFiltros({ tipo: tipoFiltro === 'sugestao' ? null : 'sugestao' })}
+                  >
+                    Sugestões
+                  </FiltroChip>
+                  <FiltroChip
+                    active={tipoFiltro === 'problema'}
+                    count={resumo.problemas}
+                    tone="rose"
+                    onClick={() => patchFiltros({ tipo: tipoFiltro === 'problema' ? null : 'problema' })}
+                  >
+                    Problemas
+                  </FiltroChip>
+                </div>
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Fase
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <FiltroChip active={!faseFiltro} onClick={() => patchFiltros({ fase: null })}>
+                    Todas
+                  </FiltroChip>
+                  {SAAS_SOLICITACAO_FASES.map((f) => (
+                    <FiltroChip
+                      key={f.value}
+                      active={faseFiltro === f.value}
+                      count={
+                        f.value === 'aguardando'
+                          ? resumo.aguardando
+                          : f.value === 'desenvolvimento'
+                            ? resumo.desenvolvimento
+                            : resumo.finalizadas
+                      }
+                      onClick={() => patchFiltros({ fase: faseFiltro === f.value ? null : f.value })}
+                    >
+                      {f.label}
+                    </FiltroChip>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Status
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <FiltroChip active={!statusFiltro} onClick={() => patchFiltros({ status: null })}>
+                    Todos
+                  </FiltroChip>
+                  {SAAS_SOLICITACAO_STATUS.map((s) => (
+                    <FiltroChip
+                      key={s.value}
+                      active={statusFiltro === s.value}
+                      count={lista.filter((i) => i.status === s.value).length}
+                      onClick={() => patchFiltros({ status: statusFiltro === s.value ? null : s.value })}
+                    >
+                      {s.label}
+                    </FiltroChip>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="busca-solicitacoes" className="mb-2 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Buscar
+                </label>
+                <input
+                  id="busca-solicitacoes"
+                  type="search"
+                  value={busca}
+                  onChange={(e) => setBusca(e.target.value)}
+                  placeholder="Título ou protocolo…"
+                  className={INPUT_FIELD_CLASS}
+                />
+              </div>
+            </div>
+          </Card>
+
+          {listaFiltrada.length === 0 ? (
+            <Card className="p-6 text-center text-sm text-slate-500">
+              Nenhum pedido corresponde aos filtros atuais.{' '}
+              <button
+                type="button"
+                className="text-cyan-700 underline dark:text-cyan-400"
+                onClick={() => {
+                  setBusca('')
+                  patchFiltros({ tipo: null, fase: null, status: null })
+                }}
+              >
+                Limpar filtros
+              </button>
+            </Card>
+          ) : (
+            <Card bodyClassName="overflow-x-auto p-0">
+              <p className="border-b border-slate-100 px-6 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                {listaFiltrada.length === lista.length
+                  ? `${lista.length} pedido${lista.length === 1 ? '' : 's'}`
+                  : `${listaFiltrada.length} de ${lista.length} pedidos`}
+              </p>
+              <SolicitacoesMelhoriaListaTable
+                items={listaFiltrada}
+                itemPath={(solicitacaoId) => `/minhas-solicitacoes/${solicitacaoId}`}
+              />
+            </Card>
+          )}
         </div>
       )}
     </PageContainer>

--- a/frontend/src/pages/SolicitacaoMelhoriaNova.tsx
+++ b/frontend/src/pages/SolicitacaoMelhoriaNova.tsx
@@ -8,7 +8,6 @@ import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
 import { PageContainer } from '../components/ui/PageContainer'
 import { VoltarButton } from '../components/ui/VoltarButton'
-import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 
 const ACCEPT_ANEXO = 'image/png,image/jpeg,image/webp,image/gif,application/pdf,video/mp4,video/webm,video/quicktime'
@@ -67,9 +66,9 @@ export function SolicitacaoMelhoriaNovaPage() {
       .catch(() => undefined)
   }, [])
 
-  async function enviarFicheiro(file: File, papel: 'inline' | 'anexo') {
+  async function enviarArquivo(file: File, papel: 'inline' | 'anexo') {
     if (anexos.length >= MAX_ANEXOS) {
-      toast.showError('Pode anexar no máximo 20 ficheiros neste pedido.')
+      toast.showError('Você pode anexar no máximo 20 arquivos neste pedido.')
       return
     }
     setUploading(true)
@@ -82,13 +81,26 @@ export function SolicitacaoMelhoriaNovaPage() {
         setModo('editar')
         toast.showSuccess('Imagem colada no texto.')
       } else {
-        toast.showSuccess('Ficheiro anexado.')
+        toast.showSuccess('Arquivo anexado.')
       }
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar o ficheiro.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar o arquivo.'))
     } finally {
       setUploading(false)
       if (anexoInputRef.current) anexoInputRef.current.value = ''
+    }
+  }
+
+  function removerAnexo(anexo: SolicitacoesMelhoria.Anexo) {
+    setAnexos((cur) => cur.filter((a) => a.id !== anexo.id))
+    if (anexo.papel === 'inline' && anexo.url) {
+      const escaped = anexo.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      setDescricao((d) =>
+        d
+          .replace(new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)\\s*`, 'g'), '')
+          .replace(new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)`, 'g'), '')
+          .trim(),
+      )
     }
   }
 
@@ -100,7 +112,7 @@ export function SolicitacaoMelhoriaNovaPage() {
         const file = item.getAsFile()
         if (file) {
           e.preventDefault()
-          void enviarFicheiro(file, 'inline')
+          void enviarArquivo(file, 'inline')
         }
         return
       }
@@ -137,8 +149,8 @@ export function SolicitacaoMelhoriaNovaPage() {
       })
       toast.showSuccess(
         row.protocolo
-          ? `Pedido ${row.protocolo} enviado. Pode acompanhar em Minhas solicitações.`
-          : 'Pedido enviado. Pode acompanhar em Minhas solicitações.',
+          ? `Pedido ${row.protocolo} enviado. Você pode acompanhar em Minhas solicitações.`
+          : 'Pedido enviado. Você pode acompanhar em Minhas solicitações.',
       )
       navigate(`/minhas-solicitacoes/${row.id}`)
     } catch (err) {
@@ -151,6 +163,7 @@ export function SolicitacaoMelhoriaNovaPage() {
   }
 
   const anexosLista = anexos.filter((a) => a.papel !== 'inline')
+  const anexosInline = anexos.filter((a) => a.papel === 'inline')
 
   return (
     <PageContainer className="flex h-full min-h-0 w-full flex-col" spacing="none">
@@ -164,16 +177,41 @@ export function SolicitacaoMelhoriaNovaPage() {
       <div className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900/95 dark:shadow-none dark:ring-1 dark:ring-white/5">
         <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-hidden p-5 sm:p-6">
           <div className="grid shrink-0 items-start gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,3fr)]">
-            <Select
-              label="Tipo"
-              className="[&>button]:box-border [&>button]:h-10 [&>button]:rounded-lg [&>button]:py-0"
-              value={tipo}
-              onChange={(v) => setTipo(String(v) as SolicitacoesMelhoria.Tipo)}
-              options={[
-                { value: 'sugestao', label: 'Sugestão de melhoria' },
-                { value: 'problema', label: 'Relatar problema' },
-              ]}
-            />
+            <div>
+              <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Tipo</p>
+              <div className="flex flex-wrap gap-2">
+                {(
+                  [
+                    { value: 'sugestao' as const, label: 'Sugestão', tone: 'sky' as const },
+                    { value: 'problema' as const, label: 'Problema', tone: 'rose' as const },
+                  ] as const
+                ).map((opt) => {
+                  const ativo = tipo === opt.value
+                  const toneClass =
+                    opt.tone === 'sky'
+                      ? ativo
+                        ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-400 dark:bg-sky-950/50 dark:text-sky-100'
+                        : ''
+                      : ativo
+                        ? 'border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-400 dark:bg-rose-950/50 dark:text-rose-100'
+                        : ''
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setTipo(opt.value)}
+                      className={`inline-flex items-center rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                        ativo
+                          ? toneClass
+                          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300 dark:hover:border-slate-600'
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
             <Input
               label="Título"
               className="box-border h-10"
@@ -250,7 +288,7 @@ export function SolicitacaoMelhoriaNovaPage() {
                   value={descricao}
                   onChange={(e) => setDescricao(e.target.value)}
                   onPaste={onPaste}
-                  placeholder="Explique o contexto, o que esperava e o impacto. Cole prints (Ctrl+V) à medida que descreve os passos."
+                  placeholder="Explique o contexto, o que esperava e o impacto. Cole prints (Ctrl+V) enquanto descreve os passos."
                   maxLength={20000}
                 />
               ) : (
@@ -261,12 +299,39 @@ export function SolicitacaoMelhoriaNovaPage() {
             </div>
           </div>
 
-          {anexosLista.length > 0 ? (
-            <ul className="shrink-0 space-y-1 text-sm text-slate-600 dark:text-slate-300">
-              {anexosLista.map((a) => (
-                <li key={a.id}>Anexo: {a.nome_original}</li>
-              ))}
-            </ul>
+          {anexos.length > 0 ? (
+            <div className="shrink-0 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Arquivos neste pedido</p>
+              <ul className="flex flex-wrap gap-2">
+                {anexos.map((a) => (
+                  <li
+                    key={a.id}
+                    className="inline-flex max-w-full items-center gap-1 rounded-lg border border-slate-200 bg-slate-50 pl-3 pr-1 py-1 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200"
+                  >
+                    <span className="truncate">
+                      {a.papel === 'inline' ? 'Imagem no texto: ' : ''}
+                      {a.nome_original}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removerAnexo(a)}
+                      className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+                      aria-label={`Remover ${a.nome_original}`}
+                      title="Remover"
+                    >
+                      <svg className="size-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+                        <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+                      </svg>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {anexosInline.length > 0 && anexosLista.length > 0 ? (
+                <p className="text-xs text-slate-500">
+                  Remover uma imagem colada no texto também limpa a marcação na descrição.
+                </p>
+              ) : null}
+            </div>
           ) : null}
 
           {erro ? <p className="shrink-0 text-sm text-rose-600 dark:text-rose-400">{erro}</p> : null}
@@ -289,7 +354,7 @@ export function SolicitacaoMelhoriaNovaPage() {
               className="hidden"
               onChange={(e) => {
                 const f = e.target.files?.[0]
-                if (f) void enviarFicheiro(f, 'anexo')
+                if (f) void enviarArquivo(f, 'anexo')
               }}
             />
           </div>


### PR DESCRIPTION
## Summary

- **Minhas solicitações** (#803): tabela com badges (tipo/status), filtros por tipo/fase/status, busca, detalhe com timeline vertical e mensagem de status por fase
- **Sobre** (#802): preview das 5 mais recentes, skeleton ao carregar, atalhos para lista completa
- **Nova solicitação**: chips de tipo, anexos removíveis antes do envio, copy pt-BR
- **Sync**: `SAAS_INGEST_LOOPBACK_URL` gravada no `client.env` por padrão (`127.0.0.1:8001`) para instâncias na mesma VPS

Closes #802
Closes #803

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `npm run build` (frontend)
- [x] `pytest tests/test_saas_solicitacoes.py` (27 passed, incl. loopback URL)
- [ ] Sobre: skeleton → tabela com 5 itens + “Ver todas”
- [ ] Minhas solicitações: filtros, busca, abrir detalhe com timeline
- [ ] Nova solicitação: anexar/remover arquivo e imagem colada antes de enviar

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** — limpeza de mídia órfã no servidor (sem DELETE API) fica para backlog se necessário
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável — N/A
- [ ] Comentário na issue fechada ou no PR lista links dos follow-ups criados
