### PR TITLE
feat(ponto): dia convocado (#985) e paginacao historico equipe (#1007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - **Acompanhamento**: linha do tempo vertical no detalhe do pedido; skeleton da tabela no Sobre enquanto carrega
 - Provisionamento: URL de ingest gravada no `client.env` usa **loopback** (`127.0.0.1:8001`) por padrão — evita falha de sync quando instância e admin-center estão na mesma VPS
 - Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
+- Ponto (#985): dia convocado — admin agenda trabalho fora da grade com janela própria; calendário, faltas e banco de horas respeitam a exceção
+- Ponto (#S202608-0011): histórico da equipe paginado (20 batidas por página, com total e navegação)
 - Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
 - Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento
 - Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas

--- a/backend/alembic/versions/134_ponto_dia_convocado_985.py
+++ b/backend/alembic/versions/134_ponto_dia_convocado_985.py
@@ -1,0 +1,74 @@
+"""Lote H: dia convocado (#985).
+
+Revision ID: 134_ponto_dia_convocado_985
+Revises: 133_ponto_lote_e
+Create Date: 2026-08-28
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "134_ponto_dia_convocado_985"
+down_revision = "133_ponto_lote_e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_dias_convocados"):
+        return
+    op.create_table(
+        "ponto_dias_convocados",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            sa.Integer(),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "atendente_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("data_ref", sa.Date(), nullable=False),
+        sa.Column("inicio", sa.String(5), nullable=False),
+        sa.Column("fim", sa.String(5), nullable=False),
+        sa.Column("tolerancia_minutos", sa.Integer(), nullable=True),
+        sa.Column("motivo", sa.String(1000), nullable=False),
+        sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
+        sa.Column(
+            "criado_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column(
+            "cancelado_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_ponto_dias_convocados_tenant_id", "ponto_dias_convocados", ["tenant_id"])
+    op.create_index("ix_ponto_dias_convocados_atendente_id", "ponto_dias_convocados", ["atendente_id"])
+    op.create_index("ix_ponto_dias_convocados_data_ref", "ponto_dias_convocados", ["data_ref"])
+    op.create_index(
+        "ix_ponto_dias_convocados_atendente_data",
+        "ponto_dias_convocados",
+        ["atendente_id", "data_ref"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_dias_convocados"):
+        op.drop_table("ponto_dias_convocados")

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -36,6 +36,8 @@ from app.schemas.ponto import (
     PontoCoberturaResposta,
     PontoCompetenciaRead,
     PontoCompetenciaReabrir,
+    PontoDiaConvocadoCreate,
+    PontoDiaConvocadoRead,
     PontoDigestRead,
     PontoEstadoRead,
     PontoFeriadoCreate,
@@ -62,6 +64,7 @@ from app.schemas.ponto import (
 from app.services import ponto as ponto_svc
 from app.services import ponto_ausencia as ausencia_svc
 from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_convocado as convocado_svc
 from app.services import ponto_competencia as comp_svc
 from app.services import ponto_folha as folha_svc
 from app.services import ponto_hora_extra as he_svc
@@ -809,6 +812,52 @@ def remover_ausencia(
 ):
     ausencia_svc.remover_admin(db, admin, ausencia_id)
     return Response(status_code=204)
+
+
+@router.post("/convocados/conceder", response_model=PontoDiaConvocadoRead, status_code=201)
+def conceder_dia_convocado(
+    data: PontoDiaConvocadoCreate,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return convocado_svc.criar_admin(
+        db,
+        admin,
+        atendente_id=data.atendente_id,
+        data_ref=data.data_ref,
+        inicio=data.inicio,
+        fim=data.fim,
+        motivo=data.motivo,
+        tolerancia_minutos=data.tolerancia_minutos,
+    )
+
+
+@router.get("/convocados", response_model=list[PontoDiaConvocadoRead])
+def listar_dias_convocados(
+    atendente_id: int | None = Query(None),
+    desde: date | None = Query(None),
+    ate: date | None = Query(None),
+    estado: str | None = Query("ativa"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return convocado_svc.listar_admin(
+        db,
+        admin,
+        atendente_id=atendente_id,
+        desde=desde,
+        ate=ate,
+        estado=estado,
+    )
+
+
+@router.delete("/convocados/{convocado_id}", response_model=PontoDiaConvocadoRead)
+def cancelar_dia_convocado(
+    convocado_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return convocado_svc.cancelar_admin(db, admin, convocado_id)
 
 
 @router.get("/hora-extra/me/status", response_model=PontoHoraExtraMeStatus)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
 from app.models.ponto_ausencia import PontoAusencia
+from app.models.ponto_dia_convocado import PontoDiaConvocado
 from app.models.ponto_cobertura import PontoCobertura
 from app.models.ponto_competencia import PontoCompetencia, PontoEspelhoCiencia
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
@@ -106,6 +107,7 @@ __all__ = [
     "PontoJustificativa",
     "PontoHoraExtra",
     "PontoAusencia",
+    "PontoDiaConvocado",
     "PontoCobertura",
     "PontoCompetencia",
     "PontoEspelhoCiencia",

--- a/backend/app/models/ponto_dia_convocado.py
+++ b/backend/app/models/ponto_dia_convocado.py
@@ -1,0 +1,30 @@
+"""Dia convocado — trabalho excepcional fora da grade (#985)."""
+
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoDiaConvocado(Base):
+    __tablename__ = "ponto_dias_convocados"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    data_ref = Column(Date, nullable=False, index=True)
+    inicio = Column(String(5), nullable=False)
+    fim = Column(String(5), nullable=False)
+    tolerancia_minutos = Column(Integer, nullable=True)
+    motivo = Column(String(1000), nullable=False)
+    # ativa | cancelada
+    estado = Column(String(20), nullable=False, default="ativa", server_default="ativa")
+    criado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    cancelado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    cancelado_em = Column(DateTime(timezone=True), nullable=True)
+
+    atendente = relationship("Atendente", foreign_keys=[atendente_id])
+    criado_por = relationship("Atendente", foreign_keys=[criado_por_id])
+    cancelado_por = relationship("Atendente", foreign_keys=[cancelado_por_id])

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -147,6 +147,7 @@ class PontoCalendarioDia(BaseModel):
     atrasado: bool = False
     feriado: bool = False
     ausencia_tipo: str | None = None  # ferias | folga_programada
+    dia_convocado: bool = False
     pausa_abaixo_minimo: bool = False
     # #842 — meta de jornada × realizado (cores do calendário)
     segundos_trabalhados: int = 0
@@ -350,6 +351,33 @@ class PontoAusenciaRead(BaseModel):
     decidido_em: datetime | None = None
     decisao_motivo: str | None = None
     created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PontoDiaConvocadoCreate(BaseModel):
+    atendente_id: int = Field(..., ge=1)
+    data_ref: date
+    inicio: str = Field(..., min_length=5, max_length=5)
+    fim: str = Field(..., min_length=5, max_length=5)
+    motivo: str = Field(..., min_length=3, max_length=1000)
+    tolerancia_minutos: int | None = Field(default=None, ge=0, le=240)
+
+
+class PontoDiaConvocadoRead(BaseModel):
+    id: int
+    atendente_id: int
+    atendente_nome: str | None = None
+    data_ref: date
+    inicio: str
+    fim: str
+    tolerancia_minutos: int | None = None
+    motivo: str
+    estado: str
+    criado_por_id: int | None = None
+    created_at: datetime | None = None
+    cancelado_por_id: int | None = None
+    cancelado_em: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -411,14 +411,21 @@ def _primeira_entrada_do_dia(batidas_dia: list[PontoBatida]) -> PontoBatida | No
     return min(entradas, key=lambda b: (_as_utc(b.registrado_em), b.id))
 
 
-def _atrasado_entrada(atendente: Atendente, entrada: PontoBatida | None) -> bool:
+def _atrasado_entrada(
+    atendente: Atendente,
+    entrada: PontoBatida | None,
+    *,
+    conv: "PontoDiaConvocado | None" = None,
+) -> bool:
     """True se a 1ª entrada passou inicio + tolerância (dentro da tol = não atraso)."""
+    from app.services import ponto_convocado as conv_svc
+
     if entrada is None:
         return False
-    if not escala_svc.escala_configurada(atendente):
+    if not conv and not escala_svc.escala_configurada(atendente):
         return False
     local = _as_utc(entrada.registrado_em).astimezone(PONTO_TZ)
-    limite = escala_svc.limite_atraso_em(atendente, local.date())
+    limite = conv_svc.limite_atraso_em(atendente, local.date(), conv)
     if limite is None:
         return False
     return local > limite
@@ -552,17 +559,22 @@ def calendario(
     usa = escala_svc.escala_configurada(atendente)
     from app.services import ponto_ausencia as ausencia_svc
     from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
 
     ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
+    convocados = conv_svc.mapa_convocados(db, atendente.id, desde=desde, ate=ate)
     pausa_min = int(getattr(settings, "pausa_minima_minutos", None) or 0)
     papeis = cob_svc.mapa_papeis_periodo(db, atendente.id, desde=desde, ate=ate)
     dias_out: list[PontoCalendarioDia] = []
     for d in dias_mes:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
         ausencia_tipo = ausencias.get(d)
+        conv = convocados.get(d)
         esp_escala = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
         papel = papeis.get(d)
-        if papel == "solicitante":
+        if conv:
+            esp = True
+        elif papel == "solicitante":
             esp = False
         elif papel == "cobertor":
             esp = True
@@ -571,12 +583,14 @@ def calendario(
         bats = por_dia.get(d, [])
         te = any(b.tipo == "entrada" for b in bats)
         ts = any(b.tipo == "saida" for b in bats)
-        atrasado = _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats))
+        atrasado = _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats), conv=conv)
         intervalos = _intervalos_de_batidas(bats)
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
         pausas = _segundos_pausas_do_dia(bats)
         esperado_visual = bool(esp and not feriado and not ausencia_tipo)
-        if (usa or papel == "cobertor") and esperado_visual:
+        if conv and esperado_visual:
+            esperados = conv_svc.segundos_esperados_convocado(conv) or meta_default
+        elif (usa or papel == "cobertor") and esperado_visual:
             esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
             esperados = meta_default
@@ -585,7 +599,8 @@ def calendario(
         else:
             esperados = 0
         # Sem jornada esperada: dia com batidas compara à meta; dia vazio fica neutro
-        esperado_para_cor = esperado_visual if (usa or papel) else bool(te or ts)
+        usa_para_cor = usa or papel == "cobertor" or conv is not None
+        esperado_para_cor = esperado_visual if usa_para_cor else bool(te or ts)
         dias_out.append(
             PontoCalendarioDia(
                 data=d,
@@ -593,7 +608,7 @@ def calendario(
                 tem_entrada=te,
                 tem_saida=ts,
                 status=_status_dia(  # type: ignore[arg-type]
-                    usa_escala=usa or papel == "cobertor",
+                    usa_escala=usa_para_cor,
                     esperado=esp,
                     tem_entrada=te,
                     tem_saida=ts,
@@ -604,6 +619,7 @@ def calendario(
                 atrasado=atrasado,
                 feriado=feriado,
                 ausencia_tipo=ausencia_tipo,
+                dia_convocado=conv is not None,
                 pausa_abaixo_minimo=_pausa_abaixo_minimo(
                     tem_entrada=te, segundos_pausa=pausas, pausa_minima_minutos=pausa_min
                 ),
@@ -633,7 +649,7 @@ def calendario(
 
 def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     from app.services import ponto_ausencia as ausencia_svc
-    from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     hoje = datetime.now(PONTO_TZ).date()
@@ -654,7 +670,8 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     for a in atendentes:
         usa = escala_svc.escala_configurada(a)
         ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, a.id, hoje)
-        esperado = cob_svc.eh_dia_esperado_efetivo(db, a, hoje) if not feriado_hoje else False
+        conv = conv_svc.convocado_ativo_no_dia(db, a.id, hoje)
+        esperado = conv_svc.eh_dia_esperado_efetivo(db, a, hoje) if not feriado_hoje else False
         entrada = _entrada_da_jornada_aberta(db, a.id)
         inicio, fim = _bounds_periodo(hoje, hoje)
         bats = (
@@ -668,9 +685,9 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
         )
         te = any(b.tipo == "entrada" for b in bats)
         ts = any(b.tipo == "saida" for b in bats)
-        atrasado = _atrasado_entrada(a, _primeira_entrada_do_dia(bats))
+        atrasado = _atrasado_entrada(a, _primeira_entrada_do_dia(bats), conv=conv)
         st = _status_dia(
-            usa_escala=usa or esperado,
+            usa_escala=usa or esperado or conv is not None,
             esperado=esperado,
             tem_entrada=te,
             tem_saida=ts,
@@ -743,7 +760,7 @@ def banco_horas(
     ate: date,
 ) -> PontoBancoHorasRead:
     from app.services import ponto_ausencia as ausencia_svc
-    from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
 
     if ate < desde:
         raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
@@ -751,6 +768,7 @@ def banco_horas(
     settings = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
     meta_default = int(getattr(settings, "jornada_diaria_minutos", None) or 480) * 60
     ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
+    convocados = conv_svc.mapa_convocados(db, atendente.id, desde=desde, ate=ate)
     dias_escala = 0
     dias_feriado = 0
     esperado = 0
@@ -760,9 +778,10 @@ def banco_horas(
         if feriado or d in ausencias:
             if feriado:
                 dias_feriado += 1
-        elif cob_svc.eh_dia_esperado_efetivo(db, atendente, d):
+        elif conv_svc.eh_dia_esperado_efetivo(db, atendente, d):
             dias_escala += 1
-            seg = escala_svc.segundos_esperados_dia(atendente, d)
+            conv = convocados.get(d)
+            seg = conv_svc.segundos_esperados_efetivo(db, atendente, d, conv)
             esperado += seg if seg > 0 else meta_default
         d += timedelta(days=1)
 
@@ -806,14 +825,16 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
     from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
 
     ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, atendente.id, hoje)
+    conv = conv_svc.convocado_ativo_no_dia(db, atendente.id, hoje)
     jornada_ativa = escala_svc.escala_configurada(atendente) or (
         cob_svc.papel_cobertura_aprovada(db, atendente.id, hoje) is not None
-    )
+    ) or conv is not None
     esperado = None
     if not feriado and not ausencia_tipo:
-        esperado = cob_svc.eh_dia_esperado_efetivo(db, atendente, hoje)
+        esperado = conv_svc.eh_dia_esperado_efetivo(db, atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
     inicio, fim = _bounds_periodo(hoje, hoje)
@@ -849,19 +870,23 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     # Modo nenhum: sem avisos de falta/atraso/lembretes de tolerância (#959 / #968)
     if jornada_ativa:
         if esperado is True and not tem_entrada_hoje and entrada is None:
-            liberacao = escala_svc.liberacao_entrada_em(atendente, hoje)
+            liberacao = conv_svc.liberacao_entrada_em(atendente, hoje, conv)
             if liberacao is not None and agora_local >= liberacao:
                 sem_entrada = True
                 lembrete_entrada = True
-                limite = escala_svc.limite_atraso_em(atendente, hoje)
+                limite = conv_svc.limite_atraso_em(atendente, hoje, conv)
                 if limite is not None and agora_local <= limite:
                     msgs.append("Janela de entrada — registre o ponto agora.")
+                elif conv:
+                    msgs.append(
+                        "Hoje é dia convocado pela empresa e ainda não há entrada registrada."
+                    )
                 else:
                     msgs.append(
                         "Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada."
                     )
 
-        if _atrasado_entrada(atendente, primeira):
+        if _atrasado_entrada(atendente, primeira, conv=conv):
             msgs.append("Entrada registrada após o horário previsto (fora da tolerância).")
 
     if online and entrada is None:
@@ -879,8 +904,8 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
                 f"Jornada aberta há cerca de {horas_aberta:.0f} h — lembre-se de registrar a saída."
             )
         elif jornada_ativa:
-            inicio_saida = escala_svc.liberacao_saida_lembrete_em(atendente, hoje)
-            saida_prev = escala_svc.saida_prevista_em(atendente, hoje)
+            inicio_saida = conv_svc.liberacao_saida_lembrete_em(atendente, hoje, conv)
+            saida_prev = conv_svc.saida_prevista_em(atendente, hoje, conv)
             if inicio_saida is not None and agora_local >= inicio_saida:
                 lembrete_saida = True
                 if saida_prev is not None and agora_local >= saida_prev:
@@ -913,15 +938,20 @@ def _contar_atrasos_periodo(
     desde: date,
     ate: date,
 ) -> int:
-    if not escala_svc.escala_configurada(atendente):
-        return 0
+    from app.services import ponto_convocado as conv_svc
+
+    usa = escala_svc.escala_configurada(atendente)
     n = 0
     d = desde
     while d <= ate:
         if ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d):
             d += timedelta(days=1)
             continue
-        if not escala_svc.eh_dia_de_trabalho(atendente, d):
+        conv = conv_svc.convocado_ativo_no_dia(db, atendente.id, d)
+        if not conv and not usa:
+            d += timedelta(days=1)
+            continue
+        if not conv and not escala_svc.eh_dia_de_trabalho(atendente, d):
             d += timedelta(days=1)
             continue
         ini, fim = _bounds_periodo(d, d)
@@ -934,7 +964,7 @@ def _contar_atrasos_periodo(
             )
             .all()
         )
-        if _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats)):
+        if _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats), conv=conv):
             n += 1
         d += timedelta(days=1)
     return n

--- a/backend/app/services/ponto_convocado.py
+++ b/backend/app/services/ponto_convocado.py
@@ -1,0 +1,320 @@
+"""Dia convocado — trabalho fora da grade (#985)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.core.business_calendar import parse_hhmm
+from app.models.atendente import Atendente
+from app.models.ponto_dia_convocado import PontoDiaConvocado
+from app.schemas.ponto import PontoDiaConvocadoRead
+from app.services import escala as escala_svc
+from app.services.escala import PONTO_TZ
+
+
+def _to_read(row: PontoDiaConvocado) -> PontoDiaConvocadoRead:
+    return PontoDiaConvocadoRead(
+        id=row.id,
+        atendente_id=row.atendente_id,
+        atendente_nome=row.atendente.nome if row.atendente else None,
+        data_ref=row.data_ref,
+        inicio=row.inicio,
+        fim=row.fim,
+        tolerancia_minutos=row.tolerancia_minutos,
+        motivo=row.motivo,
+        estado=row.estado,
+        criado_por_id=row.criado_por_id,
+        created_at=row.created_at,
+        cancelado_por_id=row.cancelado_por_id,
+        cancelado_em=row.cancelado_em,
+    )
+
+
+def _validar_horario(inicio: str, fim: str) -> tuple[str, str]:
+    ini = parse_hhmm(inicio)
+    fim_p = parse_hhmm(fim)
+    if not ini or not fim_p:
+        raise HTTPException(status_code=400, detail="Horários inválidos (use HH:MM).")
+    if (ini[0], ini[1]) >= (fim_p[0], fim_p[1]):
+        raise HTTPException(status_code=400, detail="O início deve ser anterior ao fim (sem cruzar meia-noite).")
+    return f"{ini[0]:02d}:{ini[1]:02d}", f"{fim_p[0]:02d}:{fim_p[1]:02d}"
+
+
+def janela_horario(row: PontoDiaConvocado) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    ini = parse_hhmm(row.inicio)
+    fim = parse_hhmm(row.fim)
+    if ini and fim and (fim[0], fim[1]) > (ini[0], ini[1]):
+        return ini, fim
+    return None
+
+
+def tolerancia_efetiva(atendente: Atendente, row: PontoDiaConvocado) -> int:
+    if row.tolerancia_minutos is not None:
+        return max(0, int(row.tolerancia_minutos))
+    return int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+
+
+def segundos_esperados_convocado(row: PontoDiaConvocado) -> int:
+    janela = janela_horario(row)
+    if not janela:
+        return 0
+    pe, ps = janela
+    ini = pe[0] * 3600 + pe[1] * 60
+    fim = ps[0] * 3600 + ps[1] * 60
+    return max(0, fim - ini)
+
+
+def limite_atraso_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    if conv:
+        janela = janela_horario(conv)
+        if not janela:
+            return None
+        pe, _ = janela
+        tol = tolerancia_efetiva(atendente, conv)
+        return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) + timedelta(
+            minutes=tol
+        )
+    return escala_svc.limite_atraso_em(atendente, dia)
+
+
+def liberacao_entrada_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    if conv:
+        janela = janela_horario(conv)
+        if not janela:
+            return None
+        pe, _ = janela
+        tol = tolerancia_efetiva(atendente, conv)
+        return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) - timedelta(
+            minutes=tol
+        )
+    return escala_svc.liberacao_entrada_em(atendente, dia)
+
+
+def saida_prevista_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    if conv:
+        janela = janela_horario(conv)
+        if not janela:
+            return None
+        _, ps = janela
+        return datetime.combine(dia, time(hour=ps[0], minute=ps[1]), tzinfo=PONTO_TZ)
+    return escala_svc.saida_prevista_em(atendente, dia)
+
+
+def liberacao_saida_lembrete_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    saida = saida_prevista_em(atendente, dia, conv)
+    if saida is None:
+        return None
+    if conv:
+        tol = tolerancia_efetiva(atendente, conv)
+        return saida - timedelta(minutes=tol)
+    return escala_svc.liberacao_saida_lembrete_em(atendente, dia)
+
+
+def convocado_ativo_no_dia(db: Session, atendente_id: int, dia: date) -> PontoDiaConvocado | None:
+    return (
+        db.query(PontoDiaConvocado)
+        .filter(
+            PontoDiaConvocado.atendente_id == atendente_id,
+            PontoDiaConvocado.data_ref == dia,
+            PontoDiaConvocado.estado == "ativa",
+        )
+        .first()
+    )
+
+
+def mapa_convocados(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> dict[date, PontoDiaConvocado]:
+    rows = (
+        db.query(PontoDiaConvocado)
+        .filter(
+            PontoDiaConvocado.atendente_id == atendente_id,
+            PontoDiaConvocado.estado == "ativa",
+            PontoDiaConvocado.data_ref >= desde,
+            PontoDiaConvocado.data_ref <= ate,
+        )
+        .all()
+    )
+    return {r.data_ref: r for r in rows}
+
+
+def eh_dia_esperado_efetivo(db: Session, atendente: Atendente, dia: date) -> bool:
+    """Dia esperado incluindo convocação (#985) e cobertura (#970)."""
+    if convocado_ativo_no_dia(db, atendente.id, dia):
+        return True
+    from app.services import ponto_cobertura as cob_svc
+
+    return cob_svc.eh_dia_esperado_efetivo(db, atendente, dia)
+
+
+def segundos_esperados_efetivo(
+    db: Session, atendente: Atendente, dia: date, conv: PontoDiaConvocado | None = None
+) -> int:
+    row = conv or convocado_ativo_no_dia(db, atendente.id, dia)
+    if row:
+        seg = segundos_esperados_convocado(row)
+        if seg > 0:
+            return seg
+    return escala_svc.segundos_esperados_dia(atendente, dia)
+
+
+def _atendente_tenant(db: Session, tenant_id: int, atendente_id: int) -> Atendente:
+    a = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == tenant_id,
+            Atendente.role != "saas_ops",
+            Atendente.ativo.is_(True),
+        )
+        .first()
+    )
+    if not a:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    return a
+
+
+def _checar_conflitos(
+    db: Session,
+    *,
+    tenant_id: int,
+    atendente_id: int,
+    data_ref: date,
+) -> None:
+    from app.services import ponto_ausencia as ausencia_svc
+
+    if ausencia_svc.tipo_ausencia_aprovada_no_dia(db, atendente_id, data_ref):
+        raise HTTPException(
+            status_code=400,
+            detail="Já há férias ou folga programada nesta data.",
+        )
+    existente = convocado_ativo_no_dia(db, atendente_id, data_ref)
+    if existente:
+        raise HTTPException(status_code=400, detail="Já existe convocação ativa nesta data.")
+
+
+def criar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int,
+    data_ref: date,
+    inicio: str,
+    fim: str,
+    motivo: str,
+    tolerancia_minutos: int | None = None,
+) -> PontoDiaConvocadoRead:
+    if data_ref < date.today():
+        raise HTTPException(status_code=400, detail="A data deve ser hoje ou futura.")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(status_code=400, detail="Informe o motivo (mínimo 3 caracteres).")
+    ini_s, fim_s = _validar_horario(inicio, fim)
+    alvo = _atendente_tenant(db, admin.tenant_id, atendente_id)
+    _checar_conflitos(db, tenant_id=admin.tenant_id, atendente_id=alvo.id, data_ref=data_ref)
+    if tolerancia_minutos is not None and tolerancia_minutos < 0:
+        raise HTTPException(status_code=400, detail="Tolerância inválida.")
+    row = PontoDiaConvocado(
+        tenant_id=admin.tenant_id,
+        atendente_id=alvo.id,
+        data_ref=data_ref,
+        inicio=ini_s,
+        fim=fim_s,
+        tolerancia_minutos=tolerancia_minutos,
+        motivo=motivo_limpo[:1000],
+        estado="ativa",
+        criado_por_id=admin.id,
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_dia_convocado",
+        row.id,
+        "create",
+        admin.id,
+        payload={
+            "atendente_id": alvo.id,
+            "data_ref": str(data_ref),
+            "inicio": ini_s,
+            "fim": fim_s,
+            "motivo": motivo_limpo,
+        },
+    )
+    db.commit()
+    return _to_read(
+        db.query(PontoDiaConvocado)
+        .options(joinedload(PontoDiaConvocado.atendente))
+        .filter(PontoDiaConvocado.id == row.id)
+        .first()  # type: ignore[arg-type]
+    )
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None = None,
+    desde: date | None = None,
+    ate: date | None = None,
+    estado: str | None = "ativa",
+) -> list[PontoDiaConvocadoRead]:
+    q = (
+        db.query(PontoDiaConvocado)
+        .options(joinedload(PontoDiaConvocado.atendente))
+        .filter(PontoDiaConvocado.tenant_id == admin.tenant_id)
+    )
+    if atendente_id is not None:
+        q = q.filter(PontoDiaConvocado.atendente_id == atendente_id)
+    if desde is not None:
+        q = q.filter(PontoDiaConvocado.data_ref >= desde)
+    if ate is not None:
+        q = q.filter(PontoDiaConvocado.data_ref <= ate)
+    if estado:
+        q = q.filter(PontoDiaConvocado.estado == estado)
+    rows = q.order_by(PontoDiaConvocado.data_ref.asc(), PontoDiaConvocado.id.asc()).limit(200).all()
+    return [_to_read(r) for r in rows]
+
+
+def cancelar_admin(db: Session, admin: Atendente, convocado_id: int) -> PontoDiaConvocadoRead:
+    row = (
+        db.query(PontoDiaConvocado)
+        .options(joinedload(PontoDiaConvocado.atendente))
+        .filter(
+            PontoDiaConvocado.id == convocado_id,
+            PontoDiaConvocado.tenant_id == admin.tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Convocação não encontrada")
+    if row.estado != "ativa":
+        raise HTTPException(status_code=400, detail="Esta convocação já foi cancelada.")
+    if row.data_ref < date.today():
+        raise HTTPException(status_code=400, detail="Só é possível cancelar convocações de hoje em diante.")
+    row.estado = "cancelada"
+    row.cancelado_por_id = admin.id
+    row.cancelado_em = datetime.now(timezone.utc)
+    registrar_audit(
+        db,
+        "ponto_dia_convocado",
+        row.id,
+        "cancelar",
+        admin.id,
+        payload={"atendente_id": row.atendente_id, "data_ref": str(row.data_ref)},
+    )
+    db.commit()
+    db.refresh(row)
+    return _to_read(row)

--- a/backend/tests/test_ponto_dia_convocado_985.py
+++ b/backend/tests/test_ponto_dia_convocado_985.py
@@ -1,0 +1,180 @@
+"""Dia convocado — trabalho fora da grade (#985)."""
+
+from datetime import date, datetime, timedelta, timezone
+
+from app.services.escala import PONTO_TZ
+
+
+def _folga_total(client, headers, atendente_id: int):
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={"modo_jornada": "nenhum", "usa_escala": False},
+    )
+
+
+def test_convocado_folga_gera_falta_e_esperado(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    amanha = date.today() + timedelta(days=1)
+    r = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": amanha.isoformat(),
+            "inicio": "09:00",
+            "fim": "13:00",
+            "motivo": "Inventário no posto",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["estado"] == "ativa"
+    assert body["inicio"] == "09:00"
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={amanha.year}&mes={amanha.month}",
+        headers=user,
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == amanha.isoformat())
+    assert dia["esperado"] is True
+    assert dia["dia_convocado"] is True
+    assert dia["status"] == "falta"
+    assert dia["segundos_esperados"] == 4 * 3600
+
+
+def test_convocado_atraso_usa_janela_propria(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    alvo = date.today() + timedelta(days=2)
+    assert (
+        client.post(
+            "/v1/ponto/convocados/conceder",
+            headers=admin,
+            json={
+                "atendente_id": a1.id,
+                "data_ref": alvo.isoformat(),
+                "inicio": "08:00",
+                "fim": "12:00",
+                "motivo": "Plantão",
+                "tolerancia_minutos": 0,
+            },
+        ).status_code
+        == 201
+    )
+    entrada = datetime(alvo.year, alvo.month, alvo.day, 8, 30, tzinfo=PONTO_TZ)
+    bat = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": entrada.astimezone(timezone.utc).isoformat(),
+            "motivo": "teste convocado atraso",
+        },
+    )
+    assert bat.status_code == 201, bat.text
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={alvo.year}&mes={alvo.month}",
+        headers=user,
+    )
+    dia = next(d for d in cal.json()["dias"] if d["data"] == alvo.isoformat())
+    assert dia["atrasado"] is True
+
+
+def test_convocado_cancelar_futuro(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    futuro = date.today() + timedelta(days=5)
+    criado = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": futuro.isoformat(),
+            "inicio": "10:00",
+            "fim": "14:00",
+            "motivo": "Evento",
+        },
+    )
+    assert criado.status_code == 201
+    cid = criado.json()["id"]
+    cancel = client.delete(f"/v1/ponto/convocados/{cid}", headers=admin)
+    assert cancel.status_code == 200
+    assert cancel.json()["estado"] == "cancelada"
+    lista = client.get("/v1/ponto/convocados?estado=ativa", headers=admin)
+    assert all(x["id"] != cid for x in lista.json())
+
+
+def test_convocado_cancelar_reverte_calendario(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    futuro = date.today() + timedelta(days=4)
+    criado = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": futuro.isoformat(),
+            "inicio": "09:00",
+            "fim": "13:00",
+            "motivo": "Inventário",
+        },
+    )
+    assert criado.status_code == 201
+    cid = criado.json()["id"]
+    cal1 = client.get(
+        f"/v1/ponto/me/calendario?ano={futuro.year}&mes={futuro.month}",
+        headers=user,
+    )
+    dia1 = next(d for d in cal1.json()["dias"] if d["data"] == futuro.isoformat())
+    assert dia1["esperado"] is True
+    assert client.delete(f"/v1/ponto/convocados/{cid}", headers=admin).status_code == 200
+    cal2 = client.get(
+        f"/v1/ponto/me/calendario?ano={futuro.year}&mes={futuro.month}",
+        headers=user,
+    )
+    dia2 = next(d for d in cal2.json()["dias"] if d["data"] == futuro.isoformat())
+    assert dia2["esperado"] is False
+    assert dia2["dia_convocado"] is False
+    assert dia2["status"] in ("folga", "livre")
+
+
+def test_convocado_conflita_com_ausencia(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    dia = date.today() + timedelta(days=3)
+    assert (
+        client.post(
+            "/v1/ponto/ausencias/conceder",
+            headers=admin,
+            json={
+                "atendente_id": a1.id,
+                "tipo": "folga_programada",
+                "desde": dia.isoformat(),
+                "ate": dia.isoformat(),
+                "motivo": "Folga",
+            },
+        ).status_code
+        == 201
+    )
+    r = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": dia.isoformat(),
+            "inicio": "08:00",
+            "fim": "12:00",
+            "motivo": "Conflito",
+        },
+    )
+    assert r.status_code == 400

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -807,6 +807,15 @@ export const ponto = {
     }),
   removerAusencia: (id: number) =>
     api<void>(`/ponto/ausencias/${id}`, { method: 'DELETE' }),
+  convocadosAdmin: (params?: { atendente_id?: number; desde?: string; ate?: string; estado?: string }) =>
+    api<Ponto.DiaConvocado[]>(withParams('/ponto/convocados', params)),
+  concederDiaConvocado: (data: Ponto.DiaConvocadoCreate) =>
+    api<Ponto.DiaConvocado>('/ponto/convocados/conceder', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  cancelarDiaConvocado: (id: number) =>
+    api<Ponto.DiaConvocado>(`/ponto/convocados/${id}`, { method: 'DELETE' }),
   horaExtraMeStatus: () => api<Ponto.HoraExtraMeStatus>('/ponto/hora-extra/me/status'),
   minhasHoraExtra: () => api<Ponto.HoraExtra[]>('/ponto/hora-extra/me'),
   solicitarHoraExtra: (data?: Ponto.HoraExtraCreate) =>
@@ -4970,6 +4979,7 @@ export namespace Ponto {
     atrasado?: boolean
     feriado?: boolean
     ausencia_tipo?: string | null
+    dia_convocado?: boolean
     pausa_abaixo_minimo?: boolean
     segundos_trabalhados?: number
     segundos_esperados?: number
@@ -5176,6 +5186,29 @@ export namespace Ponto {
     decidido_em?: string | null
     decisao_motivo?: string | null
     created_at?: string | null
+  }
+  export interface DiaConvocadoCreate {
+    atendente_id: number
+    data_ref: string
+    inicio: string
+    fim: string
+    motivo: string
+    tolerancia_minutos?: number | null
+  }
+  export interface DiaConvocado {
+    id: number
+    atendente_id: number
+    atendente_nome?: string | null
+    data_ref: string
+    inicio: string
+    fim: string
+    tolerancia_minutos?: number | null
+    motivo: string
+    estado: string
+    criado_por_id?: number | null
+    created_at?: string | null
+    cancelado_por_id?: number | null
+    cancelado_em?: string | null
   }
   export interface CoberturaCreate {
     cobertor_id: number

--- a/frontend/src/components/PontoCalendarioMes.tsx
+++ b/frontend/src/components/PontoCalendarioMes.tsx
@@ -223,6 +223,7 @@ export function PontoCalendarioMes({
               : detalhe.ausencia_tipo === 'folga_programada'
                 ? ' · Folga programada'
                 : ''}
+            {detalhe.dia_convocado ? ' · Dia convocado' : ''}
             {detalhe.pausa_abaixo_minimo ? ' · Pausa abaixo do mínimo' : ''}
           </p>
           <p className="mt-2 text-xs text-cyan-700 dark:text-cyan-300">

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -7,6 +7,7 @@ import { PontoAjudaModal } from '../components/PontoAjudaModal'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
 import { PontoBatidaMapaModal } from '../components/PontoBatidaMapaModal'
 import { PontoMetricCard } from '../components/PontoMetricCard'
+import { PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
@@ -62,12 +63,14 @@ function toDatetimeLocalValue(d = new Date()): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
+
 export function PontoEquipe() {
   const toast = useToast()
   const { user } = useAuth()
   const { subscribe } = useEventStream()
   const [items, setItems] = useState<Ponto.BatidaAdmin[]>([])
   const [total, setTotal] = useState(0)
+  const [histPage, setHistPage] = useState(1)
   const [hoje, setHoje] = useState<Ponto.HojeLista | null>(null)
   const [equipe, setEquipe] = useState<Atendentes.Atendente[]>([])
   const [atendenteId, setAtendenteId] = useState('')
@@ -106,6 +109,14 @@ export function PontoEquipe() {
   const [ausAte, setAusAte] = useState(hojeIso)
   const [ausMotivo, setAusMotivo] = useState('')
   const [concedendoAus, setConcedendoAus] = useState(false)
+  const [convAtendente, setConvAtendente] = useState('')
+  const [convData, setConvData] = useState(hojeIso)
+  const [convInicio, setConvInicio] = useState('08:00')
+  const [convFim, setConvFim] = useState('12:00')
+  const [convTolerancia, setConvTolerancia] = useState('')
+  const [convMotivo, setConvMotivo] = useState('')
+  const [convocados, setConvocados] = useState<Ponto.DiaConvocado[]>([])
+  const [concedendoConv, setConcedendoConv] = useState(false)
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
   const [heDuracaoMin, setHeDuracaoMin] = useState('60')
@@ -131,12 +142,13 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes, aus, cobs, setupSt, comp, cins] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, aus, cobs, convs, setupSt, comp, cins] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
             ate,
-            limit: 100,
+            offset: (histPage - 1) * PAGE_SIZE_PADRAO,
+            limit: PAGE_SIZE_PADRAO,
           }),
           ponto.hoje(),
           ponto.justificativasAdmin('pendente'),
@@ -146,12 +158,16 @@ export function PontoEquipe() {
           ponto.horaExtraAdmin('pendente'),
           ponto.ausenciasAdmin('pendente'),
           ponto.coberturasAdmin('pendente'),
+          ponto.convocadosAdmin({ estado: 'ativa' }),
           ponto.setupStatus(),
           ponto.competencia(compAno, compMes),
           ponto.cienciasAdmin(compAno, compMes),
         ])
         setItems(hist.items)
         setTotal(hist.total)
+        if (hist.items.length === 0 && histPage > 1 && hist.total > 0) {
+          setHistPage(histPage - 1)
+        }
         setHoje(dia)
         setJustifs(js)
         setDigest(dig)
@@ -160,6 +176,7 @@ export function PontoEquipe() {
         setHesPendentes(hes)
         setAusPendentes(aus)
         setCobPendentes(cobs)
+        setConvocados(convs)
         setSetup(setupSt)
         setCompetencia(comp)
         setCiencias(cins)
@@ -182,7 +199,7 @@ export function PontoEquipe() {
         setLoading(false)
       }
     },
-    [ate, atendenteId, compAno, compMes, desde, toast],
+    [ate, atendenteId, compAno, compMes, desde, histPage, toast],
   )
 
   useEffect(() => {
@@ -425,6 +442,45 @@ export function PontoEquipe() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar a ausência.'))
     } finally {
       setConcedendoAus(false)
+    }
+  }
+
+  async function concederConv() {
+    if (!convAtendente) {
+      toast.showWarning('Selecione o colaborador.')
+      return
+    }
+    if (!convMotivo.trim() || convMotivo.trim().length < 3) {
+      toast.showWarning('Informe o motivo (mínimo 3 caracteres).')
+      return
+    }
+    setConcedendoConv(true)
+    try {
+      await ponto.concederDiaConvocado({
+        atendente_id: Number(convAtendente),
+        data_ref: convData,
+        inicio: convInicio,
+        fim: convFim,
+        motivo: convMotivo.trim(),
+        tolerancia_minutos: convTolerancia.trim() ? Number(convTolerancia) : null,
+      })
+      toast.showSuccess('Dia convocado agendado.')
+      setConvMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar o dia convocado.'))
+    } finally {
+      setConcedendoConv(false)
+    }
+  }
+
+  async function cancelarConv(id: number) {
+    try {
+      await ponto.cancelarDiaConvocado(id)
+      toast.showSuccess('Convocação cancelada.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cancelar a convocação.'))
     }
   }
 
@@ -978,6 +1034,68 @@ export function PontoEquipe() {
           )}
         </Card>
 
+        <Card title="Dia convocado (fora da grade)">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Marque um dia de folga na escala como trabalho esperado, com janela própria de entrada e saída.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Colaborador"
+              value={convAtendente}
+              onChange={(v) => setConvAtendente(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Input label="Data" type="date" value={convData} onChange={(e) => setConvData(e.target.value)} />
+            <Input
+              label="Início"
+              type="time"
+              value={convInicio}
+              onChange={(e) => setConvInicio(e.target.value)}
+            />
+            <Input label="Fim" type="time" value={convFim} onChange={(e) => setConvFim(e.target.value)} />
+            <Input
+              label="Tolerância (min, opcional)"
+              type="number"
+              min={0}
+              max={240}
+              value={convTolerancia}
+              onChange={(e) => setConvTolerancia(e.target.value)}
+            />
+            <Input label="Motivo" value={convMotivo} onChange={(e) => setConvMotivo(e.target.value)} />
+            <Button type="button" disabled={concedendoConv} onClick={() => void concederConv()}>
+              Agendar
+            </Button>
+          </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Convocações ativas</p>
+          {convocados.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhuma convocação ativa.</p>
+          ) : (
+            <ul className="space-y-3">
+              {convocados.map((c) => (
+                <li
+                  key={c.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">{c.atendente_nome ?? c.atendente_id}</p>
+                    <p className="text-slate-600 dark:text-slate-300">
+                      {c.data_ref} · {c.inicio} → {c.fim}
+                      {c.tolerancia_minutos != null ? ` · tol. ${c.tolerancia_minutos} min` : ''}
+                    </p>
+                    <p className="text-slate-500">{c.motivo}</p>
+                  </div>
+                  <Button type="button" variant="ghost" onClick={() => void cancelarConv(c.id)}>
+                    Cancelar
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
         <Card title="Hora extra (WhatsApp após jornada)">
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
             Conceda HE com antecedência ou libere pedidos após o fim da jornada. Modos: resto do dia, até um horário ou
@@ -1188,15 +1306,41 @@ export function PontoEquipe() {
             <Select
               label="Atendente"
               value={atendenteId}
-              onChange={(v) => setAtendenteId(String(v))}
+              onChange={(v) => {
+                setAtendenteId(String(v))
+                setHistPage(1)
+              }}
               options={[
                 { value: '', label: 'Todos' },
                 ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
               ]}
             />
-            <Input label="De" type="date" value={desde} onChange={(e) => setDesde(e.target.value)} />
-            <Input label="Até" type="date" value={ate} onChange={(e) => setAte(e.target.value)} />
-            <Button type="button" variant="secondary" onClick={() => void carregar()}>
+            <Input
+              label="De"
+              type="date"
+              value={desde}
+              onChange={(e) => {
+                setDesde(e.target.value)
+                setHistPage(1)
+              }}
+            />
+            <Input
+              label="Até"
+              type="date"
+              value={ate}
+              onChange={(e) => {
+                setAte(e.target.value)
+                setHistPage(1)
+              }}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                setHistPage(1)
+                void carregar()
+              }}
+            >
               Filtrar
             </Button>
             <Button type="button" variant="secondary" onClick={() => void exportarCsv()}>
@@ -1216,7 +1360,9 @@ export function PontoEquipe() {
             </Button>
           </div>
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
-            {total} batida{total === 1 ? '' : 's'} no filtro
+            {total === 0
+              ? '0 batidas no filtro'
+              : `${(histPage - 1) * PAGE_SIZE_PADRAO + 1}–${Math.min(histPage * PAGE_SIZE_PADRAO, total)} de ${total} batida${total === 1 ? '' : 's'} no filtro`}
             {banco ? (
               <>
                 {' '}
@@ -1289,6 +1435,31 @@ export function PontoEquipe() {
               </tbody>
             </table>
           </div>
+          {total > PAGE_SIZE_PADRAO ? (
+            <div className="mt-4 flex flex-wrap items-center justify-end gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={histPage <= 1}
+                onClick={() => setHistPage((p) => p - 1)}
+                className="px-2 py-1 text-xs"
+              >
+                Anterior
+              </Button>
+              <span className="tabular-nums">
+                {histPage} / {Math.ceil(total / PAGE_SIZE_PADRAO)}
+              </span>
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={histPage >= Math.ceil(total / PAGE_SIZE_PADRAO)}
+                onClick={() => setHistPage((p) => p + 1)}
+                className="px-2 py-1 text-xs"
+              >
+                Próxima
+              </Button>
+            </div>
+          ) : null}
         </Card>
 
         {atendenteId ? (
@@ -1301,6 +1472,7 @@ export function PontoEquipe() {
                 setDiaCal(iso)
                 setDesde(iso)
                 setAte(iso)
+                setHistPage(1)
               }}
               onMesAnterior={() => {
                 if (calMes <= 1) {


### PR DESCRIPTION
## Summary
- **#985**: dia convocado — admin agenda trabalho fora da grade com janela propria; calendario, faltas, atrasos, alertas e banco de horas respeitam a excecao
- **#1007** / **#S202608-0011**: historico da equipe paginado (20 batidas por pagina, contador e navegacao Anterior/Proxima)
- Migration 134_ponto_dia_convocado_985, API POST/GET/DELETE /ponto/convocados, UI em PontoEquipe e calendario mensal

Closes #985
Closes #1007

## Test plan
- [x] pytest -q tests/test_ponto_dia_convocado_985.py (5 passed)
- [x] lembic heads — head unico 134_ponto_dia_convocado_985
- [x] 
pm run build (frontend)
- [ ] Admin: conceder dia convocado em folga; calendario mostra excecao; atraso na janela gera alerta
- [ ] Admin: cancelar dia convocado futuro reverte calendario
- [ ] Historico da equipe: paginacao 20/pagina, total e botoes Anterior/Proxima
- [ ] Conflito com ausencia programada bloqueia concessao

Made with [Cursor](https://cursor.com)