### PR TITLE
fix(chat): contador de mensagens não lidas alinhado (S202608-0010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
 - Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
+- Atendimentos (#S202608-0010): contador de mensagens não lidas no chat alinhado entre sino, lista e conversa; badge some ao responder; divisor «Mensagens não lidas» também no chat do portal
 - Sobre: deixa de listar itens **Interno / Infra** (deploy, LICENSE, docs internos) — só Melhorias e Correções de produto
 - Sobre: versão **26.08.015** sem repetir notas já publicadas em releases anteriores
 

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -9,9 +9,9 @@ from sqlalchemy.orm import Session, joinedload
 from app.database import get_db
 from app.models import Ticket, TicketMensagem, Atendente
 from app.models.ticket_read import TicketRead
-from app.models.whatsapp_chat_read import WhatsappChatRead
-from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
-from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
+from app.models.whatsapp_chat import WhatsappChat
+from app.models.portal_chat import PortalChat
+from app.services import chat_nao_lidas as chat_nao_lidas_svc
 from app.schemas.notificacoes import NotificacaoResumo, NotificacaoItem, NotificacaoItensResponse
 from app.schemas.atendente_notificacao import NotificacaoPreferenciasRead, NotificacaoPreferenciasUpdate
 from app.core.auth import obter_atendente_atual
@@ -121,28 +121,6 @@ def _last_unread_message_at_subq(atendente_id: int):
     )
 
 
-def _wpp_resposta_pendente_exprs(atendente_id: int):
-    seen_at = (
-        select(WhatsappChatRead.last_seen_at)
-        .where(
-            WhatsappChatRead.chat_id == WhatsappChat.id,
-            WhatsappChatRead.atendente_id == atendente_id,
-        )
-        .limit(1)
-        .scalar_subquery()
-    )
-    inbound_last = (
-        select(func.max(WhatsappMensagem.created_at))
-        .where(
-            WhatsappMensagem.chat_id == WhatsappChat.id,
-            WhatsappMensagem.direcao == "inbound",
-        )
-        .scalar_subquery()
-    )
-    eff_seen = func.coalesce(seen_at, WhatsappChat.atendimento_inicio_at, WhatsappChat.created_at)
-    return inbound_last, eff_seen
-
-
 def _preview_ultima_nao_lida(db: Session, ticket: Ticket, atendente_id: int) -> str | None:
     ls = (
         db.query(TicketRead.last_seen_at)
@@ -185,46 +163,6 @@ def _count_wpp_fila(db: Session, atendente: Atendente) -> int:
     return int(db.execute(stmt).scalar_one())
 
 
-def _count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
-    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
-    stmt = (
-        select(func.count())
-        .select_from(WhatsappChat)
-        .where(
-            WhatsappChat.estado == "em_atendimento",
-            WhatsappChat.atendente_id == atendente.id,
-            inbound_last.isnot(None),
-            eff_seen < inbound_last,
-        )
-    )
-    if atendente.role != "admin":
-        vis = ids_setores_visiveis_atendente(db, atendente)
-        stmt = stmt.where(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
-    return int(db.execute(stmt).scalar_one())
-
-
-def _portal_resposta_pendente_exprs(atendente_id: int):
-    seen_at = (
-        select(PortalChatReadModel.last_seen_at)
-        .where(
-            PortalChatReadModel.chat_id == PortalChat.id,
-            PortalChatReadModel.atendente_id == atendente_id,
-        )
-        .limit(1)
-        .scalar_subquery()
-    )
-    inbound_last = (
-        select(func.max(PortalMensagem.created_at))
-        .where(
-            PortalMensagem.chat_id == PortalChat.id,
-            PortalMensagem.direcao == "inbound",
-        )
-        .scalar_subquery()
-    )
-    eff_seen = func.coalesce(seen_at, PortalChat.atendimento_inicio_at, PortalChat.created_at)
-    return inbound_last, eff_seen
-
-
 def _count_portal_fila(db: Session, atendente: Atendente) -> int:
     stmt = (
         select(func.count())
@@ -235,47 +173,6 @@ def _count_portal_fila(db: Session, atendente: Atendente) -> int:
         vis = ids_setores_visiveis_atendente(db, atendente)
         stmt = stmt.where(or_(PortalChat.setor_id.is_(None), PortalChat.setor_id.in_(vis)))
     return int(db.execute(stmt).scalar_one())
-
-
-def _count_portal_respostas_pendentes(db: Session, atendente: Atendente) -> int:
-    inbound_last, eff_seen = _portal_resposta_pendente_exprs(atendente.id)
-    stmt = (
-        select(func.count())
-        .select_from(PortalChat)
-        .where(
-            PortalChat.estado == "em_atendimento",
-            PortalChat.atendente_id == atendente.id,
-            inbound_last.isnot(None),
-            eff_seen < inbound_last,
-        )
-    )
-    if atendente.role != "admin":
-        vis = ids_setores_visiveis_atendente(db, atendente)
-        stmt = stmt.where(or_(PortalChat.setor_id.is_(None), PortalChat.setor_id.in_(vis)))
-    return int(db.execute(stmt).scalar_one())
-
-
-def _wpp_unread_count_for_chat(db: Session, chat_id: int, atendente_id: int) -> int:
-    c = db.query(WhatsappChat.id, WhatsappChat.created_at, WhatsappChat.atendimento_inicio_at).filter(WhatsappChat.id == chat_id).first()
-    if not c:
-        return 0
-    row = (
-        db.query(WhatsappChatRead.last_seen_at, WhatsappChatRead.last_seen_mensagem_id)
-        .filter(WhatsappChatRead.chat_id == chat_id, WhatsappChatRead.atendente_id == atendente_id)
-        .first()
-    )
-    ls = row[0] if row else None
-    cursor_id = row[1] if row else None
-    q = db.query(func.count(WhatsappMensagem.id)).filter(
-        WhatsappMensagem.chat_id == chat_id,
-        WhatsappMensagem.direcao == "inbound",
-    )
-    if cursor_id is not None:
-        q = q.filter(WhatsappMensagem.id > cursor_id)
-    else:
-        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-        q = q.filter(WhatsappMensagem.created_at > eff)
-    return int(q.scalar() or 0)
 
 
 def build_notificacao_itens(
@@ -332,16 +229,15 @@ def build_notificacao_itens(
                 )
             )
 
-    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
+    ultima_nao_lida_at = chat_nao_lidas_svc.wpp_ultima_nao_lida_at_subq(atendente.id)
     stmt_wpp = (
         select(WhatsappChat)
         .where(
             WhatsappChat.estado == "em_atendimento",
             WhatsappChat.atendente_id == atendente.id,
-            inbound_last.isnot(None),
-            eff_seen < inbound_last,
+            chat_nao_lidas_svc.exists_wpp_inbound_nao_lido(atendente.id),
         )
-        .order_by(inbound_last.desc(), WhatsappChat.id.desc())
+        .order_by(ultima_nao_lida_at.desc(), WhatsappChat.id.desc())
         .limit(limit)
     )
     if atendente.role != "admin":
@@ -349,7 +245,7 @@ def build_notificacao_itens(
         stmt_wpp = stmt_wpp.where(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
     chats = db.execute(stmt_wpp).scalars().all()
     for c in chats:
-        uc = _wpp_unread_count_for_chat(db, c.id, atendente.id)
+        uc = chat_nao_lidas_svc.contar_nao_lidas_whatsapp_por_id(db, c.id, atendente.id)
         if uc <= 0:
             uc = 1
         nome = (c.cliente_nome or "").strip() or c.wa_id
@@ -428,9 +324,9 @@ def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoRe
     sem = _count_sem_responsavel(db, atendente)
     nao = _count_tickets_com_nao_lidas(db, atendente)
     wpp_fila = _count_wpp_fila(db, atendente)
-    wpp_resp = _count_wpp_respostas_pendentes(db, atendente)
+    wpp_resp = chat_nao_lidas_svc.count_wpp_respostas_pendentes(db, atendente)
     portal_fila = _count_portal_fila(db, atendente)
-    portal_resp = _count_portal_respostas_pendentes(db, atendente)
+    portal_resp = chat_nao_lidas_svc.count_portal_respostas_pendentes(db, atendente)
     chat_interno = chat_interno_svc.contar_total_nao_lidas_atendente(db, atendente)
     he_pend = 0
     if atendente.role == "admin":

--- a/backend/app/api/portal_chats.py
+++ b/backend/app/api/portal_chats.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Upload
 from fastapi.responses import FileResponse
 from datetime import datetime
 
-from sqlalchemy import func, or_
+from sqlalchemy import or_
 from sqlalchemy.orm import Session, joinedload
 
 from app.config import settings
@@ -16,7 +16,7 @@ from app.core.auth import obter_atendente_atual
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
+from app.models.portal_chat import PortalChat, PortalMensagem
 from app.models.setor import Setor
 from app.schemas.portal_chat import (
     PortalChatDemandaCreate,
@@ -27,6 +27,7 @@ from app.schemas.portal_chat import (
     PortalChatRead,
     PortalTransferirChatBody,
 )
+from app.services.chat_nao_lidas import contar_nao_lidas_portal
 from app.services.portal_auto_messages import try_auto_msg_assumido
 from app.services.portal_chat import (
     assumir_portal_chat,
@@ -73,39 +74,12 @@ def _ultima_mensagem_preview(db: Session, chat_id: int) -> str | None:
     return _preview_corpo(corpo)
 
 
-def _nao_lidas_portal(
-    db: Session, c: PortalChat, atendente_id: int
-) -> tuple[int, datetime | None, int | None]:
-    row = (
-        db.query(PortalChatReadModel.last_seen_at, PortalChatReadModel.last_seen_mensagem_id)
-        .filter(
-            PortalChatReadModel.chat_id == c.id,
-            PortalChatReadModel.atendente_id == atendente_id,
-        )
-        .first()
-    )
-    ls = row[0] if row else None
-    cursor_id = row[1] if row else None
-    q = db.query(func.count(PortalMensagem.id)).filter(
-        PortalMensagem.chat_id == c.id,
-        PortalMensagem.direcao == "inbound",
-    )
-    if cursor_id is not None:
-        q = q.filter(PortalMensagem.id > cursor_id)
-    else:
-        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-        if eff is None:
-            return 0, ls, cursor_id
-        q = q.filter(PortalMensagem.created_at > eff)
-    return int(q.scalar() or 0), ls, cursor_id
-
-
 def _chat_read(db: Session, c: PortalChat, *, atendente_id: int | None = None) -> PortalChatRead:
     nao_lidas = 0
     last_seen: datetime | None = None
     last_seen_msg: int | None = None
     if atendente_id is not None:
-        nao_lidas, last_seen, last_seen_msg = _nao_lidas_portal(db, c, atendente_id)
+        nao_lidas, last_seen, last_seen_msg = contar_nao_lidas_portal(db, c, atendente_id)
     return PortalChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -448,6 +422,7 @@ def enviar_mensagem(
 ):
     c = _get_chat(db, chat_id)
     msg = registrar_mensagem_atendente(db, c, atendente, body.corpo)
+    marcar_visto_portal_chat(db, chat_id, atendente.id)
     db.commit()
     db.refresh(msg)
     msg = (
@@ -458,6 +433,9 @@ def enviar_mensagem(
     )
     assert msg is not None
     emit_portal_chat_mensagem_from_models(db, c, msg, exclude_atendente_id=atendente.id)
+    from app.services.realtime_emit import emit_notificacao_contagem
+
+    emit_notificacao_contagem(db, [atendente.id])
     return _mensagem_read(msg)
 
 
@@ -513,6 +491,7 @@ async def enviar_mensagem_midia(
         midia_nome_arquivo=nome_guardado,
         caption=caption,
     )
+    marcar_visto_portal_chat(db, chat_id, atendente.id)
     db.commit()
     db.refresh(msg)
     msg = (
@@ -523,6 +502,9 @@ async def enviar_mensagem_midia(
     )
     assert msg is not None
     emit_portal_chat_mensagem_from_models(db, c, msg, exclude_atendente_id=atendente.id)
+    from app.services.realtime_emit import emit_notificacao_contagem
+
+    emit_notificacao_contagem(db, [atendente.id])
     return _mensagem_read(msg)
 
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -17,7 +17,6 @@ from app.models.setor import Setor
 from app.models.rede import Rede
 from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
 from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem, WhatsappSettings
-from app.models.whatsapp_chat_read import WhatsappChatRead as WhatsappChatReadModel
 from app.schemas.lista_paginada import ListaPaginada
 from app.schemas.whatsapp_chat import (
     WhatsappAbrirTicketBody,
@@ -62,6 +61,7 @@ from app.services.whatsapp_auto_messages import (
 from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+from app.services.chat_nao_lidas import contar_nao_lidas_whatsapp, marcar_leitura_whatsapp
 from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
@@ -437,9 +437,25 @@ def _enviar_texto_whatsapp(
         status_entrega=status_inicial_outbound_whatsapp(wa_message_id=sent_wa_id) if evento_sistema is None else None,
     )
     db.add(m)
+    if (
+        atendente is not None
+        and evento_sistema is None
+        and chat.atendente_id is not None
+        and chat.atendente_id == atendente.id
+    ):
+        marcar_leitura_whatsapp(db, chat.id, atendente.id)
     db.commit()
     db.refresh(m)
     emit_chat_mensagem_from_models(db, chat, m, exclude_atendente_id=atendente.id if atendente else None)
+    if (
+        atendente is not None
+        and evento_sistema is None
+        and chat.atendente_id is not None
+        and chat.atendente_id == atendente.id
+    ):
+        from app.services.realtime_emit import emit_notificacao_contagem
+
+        emit_notificacao_contagem(db, [atendente.id])
     return m
 
 
@@ -633,34 +649,6 @@ def _criar_funcionario_rede(
     return f
 
 
-def _nao_lidas_whatsapp(
-    db: Session, c: WhatsappChat, atendente_id: int
-) -> tuple[int, datetime | None, int | None]:
-    """Inbound após o cursor de leitura (#951)."""
-    row = (
-        db.query(WhatsappChatReadModel.last_seen_at, WhatsappChatReadModel.last_seen_mensagem_id)
-        .filter(
-            WhatsappChatReadModel.chat_id == c.id,
-            WhatsappChatReadModel.atendente_id == atendente_id,
-        )
-        .first()
-    )
-    ls = row[0] if row else None
-    cursor_id = row[1] if row else None
-    q = db.query(func.count(WhatsappMensagem.id)).filter(
-        WhatsappMensagem.chat_id == c.id,
-        WhatsappMensagem.direcao == "inbound",
-    )
-    if cursor_id is not None:
-        q = q.filter(WhatsappMensagem.id > cursor_id)
-    else:
-        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-        if eff is None:
-            return 0, ls, cursor_id
-        q = q.filter(WhatsappMensagem.created_at > eff)
-    return int(q.scalar() or 0), ls, cursor_id
-
-
 def _chat_read(
     db: Session,
     c: WhatsappChat,
@@ -677,7 +665,7 @@ def _chat_read(
     last_seen: datetime | None = None
     last_seen_msg: int | None = None
     if atendente_id is not None:
-        nao_lidas, last_seen, last_seen_msg = _nao_lidas_whatsapp(db, c, atendente_id)
+        nao_lidas, last_seen, last_seen_msg = contar_nao_lidas_whatsapp(db, c, atendente_id)
     return WhatsappChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -2185,6 +2173,8 @@ async def enviar_mensagem_midia(
     )
     db.add(m)
     _sair_pausa_inatividade_por_atividade(c)
+    if c.atendente_id is not None and c.atendente_id == atendente.id:
+        marcar_leitura_whatsapp(db, c.id, atendente.id)
     db.commit()
     m2 = (
         db.query(WhatsappMensagem)
@@ -2194,6 +2184,9 @@ async def enviar_mensagem_midia(
     )
     assert m2 is not None
     emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    from app.services.realtime_emit import emit_notificacao_contagem
+
+    emit_notificacao_contagem(db, [atendente.id])
     return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
 
 
@@ -2257,26 +2250,7 @@ def marcar_chat_visto(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
 
     now = datetime.now(timezone.utc)
-    max_msg_id = (
-        db.query(func.max(WhatsappMensagem.id)).filter(WhatsappMensagem.chat_id == chat_id).scalar()
-    )
-    row = (
-        db.query(WhatsappChatReadModel)
-        .filter(WhatsappChatReadModel.chat_id == chat_id, WhatsappChatReadModel.atendente_id == atendente.id)
-        .first()
-    )
-    if row:
-        row.last_seen_at = now
-        row.last_seen_mensagem_id = max_msg_id
-    else:
-        db.add(
-            WhatsappChatReadModel(
-                chat_id=chat_id,
-                atendente_id=atendente.id,
-                last_seen_at=now,
-                last_seen_mensagem_id=max_msg_id,
-            )
-        )
+    marcar_leitura_whatsapp(db, chat_id, atendente.id, now=now)
     # ✓✓ azul no WhatsApp do cliente: só o responsável, em atendimento
     if (
         c.estado == "em_atendimento"

--- a/backend/app/services/chat_nao_lidas.py
+++ b/backend/app/services/chat_nao_lidas.py
@@ -1,0 +1,284 @@
+"""Contagem de inbound não lido e cursor de leitura por atendente (#951 / #S202608-0010)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import and_, exists, func, or_, select
+from sqlalchemy.orm import Session
+
+from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.models.atendente import Atendente
+from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+from app.models.whatsapp_chat_read import WhatsappChatRead as WhatsappChatReadModel
+
+
+# --- WhatsApp: expressões SQL reutilizáveis ---
+
+
+def wpp_seen_msg_id_subq(atendente_id: int):
+    return (
+        select(WhatsappChatReadModel.last_seen_mensagem_id)
+        .where(
+            WhatsappChatReadModel.chat_id == WhatsappChat.id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def wpp_seen_at_subq(atendente_id: int):
+    return (
+        select(WhatsappChatReadModel.last_seen_at)
+        .where(
+            WhatsappChatReadModel.chat_id == WhatsappChat.id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def wpp_eff_seen_ts(atendente_id: int):
+    return func.coalesce(
+        wpp_seen_at_subq(atendente_id),
+        WhatsappChat.atendimento_inicio_at,
+        WhatsappChat.created_at,
+    )
+
+
+def _wpp_inbound_contavel_filters():
+    return (
+        WhatsappMensagem.direcao == "inbound",
+        or_(WhatsappMensagem.evento_sistema.is_(None), WhatsappMensagem.evento_sistema == ""),
+        WhatsappMensagem.apagada_em.is_(None),
+    )
+
+
+def _wpp_inbound_apos_cursor_clause(atendente_id: int):
+    seen_msg_id = wpp_seen_msg_id_subq(atendente_id)
+    eff_ts = wpp_eff_seen_ts(atendente_id)
+    return or_(
+        and_(seen_msg_id.isnot(None), WhatsappMensagem.id > seen_msg_id),
+        and_(seen_msg_id.is_(None), WhatsappMensagem.created_at > eff_ts),
+    )
+
+
+def exists_wpp_inbound_nao_lido(atendente_id: int):
+    return exists(
+        select(WhatsappMensagem.id).where(
+            WhatsappMensagem.chat_id == WhatsappChat.id,
+            *_wpp_inbound_contavel_filters(),
+            _wpp_inbound_apos_cursor_clause(atendente_id),
+        )
+    )
+
+
+def wpp_ultima_nao_lida_at_subq(atendente_id: int):
+    return (
+        select(func.max(WhatsappMensagem.created_at))
+        .where(
+            WhatsappMensagem.chat_id == WhatsappChat.id,
+            *_wpp_inbound_contavel_filters(),
+            _wpp_inbound_apos_cursor_clause(atendente_id),
+        )
+        .scalar_subquery()
+    )
+
+
+def _ler_cursor_whatsapp(
+    db: Session, chat_id: int, atendente_id: int
+) -> tuple[datetime | None, int | None]:
+    row = (
+        db.query(WhatsappChatReadModel.last_seen_at, WhatsappChatReadModel.last_seen_mensagem_id)
+        .filter(
+            WhatsappChatReadModel.chat_id == chat_id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    if not row:
+        return None, None
+    return row[0], row[1]
+
+
+def contar_nao_lidas_whatsapp(
+    db: Session, c: WhatsappChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    """Inbound contável após o cursor de leitura do atendente."""
+    ls, cursor_id = _ler_cursor_whatsapp(db, c.id, atendente_id)
+    q = db.query(func.count(WhatsappMensagem.id)).filter(
+        WhatsappMensagem.chat_id == c.id,
+        *_wpp_inbound_contavel_filters(),
+    )
+    if cursor_id is not None:
+        q = q.filter(WhatsappMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(WhatsappMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def contar_nao_lidas_whatsapp_por_id(db: Session, chat_id: int, atendente_id: int) -> int:
+    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        return 0
+    n, _, _ = contar_nao_lidas_whatsapp(db, c, atendente_id)
+    return n
+
+
+def marcar_leitura_whatsapp(
+    db: Session,
+    chat_id: int,
+    atendente_id: int,
+    *,
+    now: datetime | None = None,
+) -> None:
+    ts = now or datetime.now(timezone.utc)
+    max_msg_id = (
+        db.query(func.max(WhatsappMensagem.id)).filter(WhatsappMensagem.chat_id == chat_id).scalar()
+    )
+    row = (
+        db.query(WhatsappChatReadModel)
+        .filter(
+            WhatsappChatReadModel.chat_id == chat_id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    if row:
+        row.last_seen_at = ts
+        row.last_seen_mensagem_id = max_msg_id
+    else:
+        db.add(
+            WhatsappChatReadModel(
+                chat_id=chat_id,
+                atendente_id=atendente_id,
+                last_seen_at=ts,
+                last_seen_mensagem_id=max_msg_id,
+            )
+        )
+
+
+def count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.estado == "em_atendimento",
+            WhatsappChat.atendente_id == atendente.id,
+            exists_wpp_inbound_nao_lido(atendente.id),
+        )
+    )
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
+    return int(db.execute(stmt).scalar_one())
+
+
+# --- Portal ---
+
+
+def portal_seen_msg_id_subq(atendente_id: int):
+    return (
+        select(PortalChatReadModel.last_seen_mensagem_id)
+        .where(
+            PortalChatReadModel.chat_id == PortalChat.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def portal_seen_at_subq(atendente_id: int):
+    return (
+        select(PortalChatReadModel.last_seen_at)
+        .where(
+            PortalChatReadModel.chat_id == PortalChat.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def portal_eff_seen_ts(atendente_id: int):
+    return func.coalesce(
+        portal_seen_at_subq(atendente_id),
+        PortalChat.atendimento_inicio_at,
+        PortalChat.created_at,
+    )
+
+
+def _portal_inbound_contavel_filters():
+    return (
+        PortalMensagem.direcao == "inbound",
+        or_(PortalMensagem.evento_sistema.is_(None), PortalMensagem.evento_sistema == ""),
+    )
+
+
+def _portal_inbound_apos_cursor_clause(atendente_id: int):
+    seen_msg_id = portal_seen_msg_id_subq(atendente_id)
+    eff_ts = portal_eff_seen_ts(atendente_id)
+    return or_(
+        and_(seen_msg_id.isnot(None), PortalMensagem.id > seen_msg_id),
+        and_(seen_msg_id.is_(None), PortalMensagem.created_at > eff_ts),
+    )
+
+
+def exists_portal_inbound_nao_lido(atendente_id: int):
+    return exists(
+        select(PortalMensagem.id).where(
+            PortalMensagem.chat_id == PortalChat.id,
+            *_portal_inbound_contavel_filters(),
+            _portal_inbound_apos_cursor_clause(atendente_id),
+        )
+    )
+
+
+def contar_nao_lidas_portal(
+    db: Session, c: PortalChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    row = (
+        db.query(PortalChatReadModel.last_seen_at, PortalChatReadModel.last_seen_mensagem_id)
+        .filter(
+            PortalChatReadModel.chat_id == c.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(PortalMensagem.id)).filter(
+        PortalMensagem.chat_id == c.id,
+        *_portal_inbound_contavel_filters(),
+    )
+    if cursor_id is not None:
+        q = q.filter(PortalMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(PortalMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def count_portal_respostas_pendentes(db: Session, atendente: Atendente) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(PortalChat)
+        .where(
+            PortalChat.estado == "em_atendimento",
+            PortalChat.atendente_id == atendente.id,
+            exists_portal_inbound_nao_lido(atendente.id),
+        )
+    )
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(or_(PortalChat.setor_id.is_(None), PortalChat.setor_id.in_(vis)))
+    return int(db.execute(stmt).scalar_one())

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -100,6 +100,107 @@ def test_meus_e_visto_contam_nao_lidas(client, seed_base, auth_headers):
     assert row2["nao_lidas_count"] == 0
 
 
+def test_enviar_ao_cliente_zera_nao_lidas(client, seed_base, auth_headers, monkeypatch, db_session):
+    """#S202608-0010: resposta outbound pelo responsável zera nao_lidas_count."""
+    seq = {"n": 0}
+
+    def fake_send(*_a, **_k):
+        seq["n"] += 1
+        return True, None, f"wa-reply-nl-{seq['n']}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "nl-reply",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "nl-reply"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666556", msg_id="nl-r1", text="oi"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    assert client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"]).status_code == 200
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666556", msg_id="nl-r2", text="preciso de ajuda"),
+        headers=h,
+    )
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row = next(c for c in meus if c["id"] == cid)
+    assert row["nao_lidas_count"] >= 1
+
+    r_send = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Claro, como posso ajudar?"},
+        headers=auth_headers["a1"],
+    )
+    assert r_send.status_code == 201
+
+    meus2 = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row2 = next(c for c in meus2 if c["id"] == cid)
+    assert row2["nao_lidas_count"] == 0
+
+    from app.api.notificacoes import build_notificacao_resumo
+
+    resumo = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo.wpp_respostas_count == 0
+
+
+def test_wpp_respostas_resumo_alinhado_com_meus(client, seed_base, auth_headers, db_session):
+    """#S202608-0010: sino (resumo/itens) e lista meus usam a mesma regra de não lidas."""
+    from app.api.notificacoes import build_notificacao_itens, build_notificacao_resumo
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "nl-align"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "nl-align"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666777", msg_id="nl-align-1", text="oi"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    assert client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"]).status_code == 200
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666777", msg_id="nl-align-2", text="nova"),
+        headers=h,
+    )
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row = next(c for c in meus if c["id"] == cid)
+    assert row["nao_lidas_count"] >= 1
+
+    resumo = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo.wpp_respostas_count >= 1
+
+    itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
+    wpp_itens = [i for i in itens if i.tipo == "wpp_chats_com_resposta" and i.chat_id == cid]
+    assert len(wpp_itens) >= 1
+    assert wpp_itens[0].count >= 1
+
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    meus2 = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row2 = next(c for c in meus2 if c["id"] == cid)
+    assert row2["nao_lidas_count"] == 0
+    resumo2 = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo2.wpp_respostas_count == 0
+
+
 def test_listar_encerrados_filtra_e_respeita_rbac(client, seed_base, auth_headers):
     client.patch(
         "/v1/settings/whatsapp",

--- a/frontend/src/lib/chatUnreadDivider.ts
+++ b/frontend/src/lib/chatUnreadDivider.ts
@@ -1,0 +1,47 @@
+/** Primeira inbound não lida para o divisor visual (#951 / #S202608-0010). */
+export type ChatUnreadCursor = {
+  nao_lidas_count?: number
+  last_seen_mensagem_id?: number | null
+  last_seen_at?: string | null
+  atendimento_inicio_at?: string | null
+  created_at?: string | null
+}
+
+export type MensagemUnreadCursor = {
+  id: number
+  direcao: string
+  evento_sistema?: string | null
+  apagada?: boolean
+  created_at?: string | null
+}
+
+export function primeiraInboundNaoLidaMsgId(
+  msgs: MensagemUnreadCursor[],
+  chat: ChatUnreadCursor,
+): number | null {
+  if ((chat.nao_lidas_count ?? 0) <= 0) return null
+
+  const cursorId = chat.last_seen_mensagem_id
+  if (cursorId != null) {
+    const primeira = msgs.find(
+      (m) =>
+        m.direcao === 'inbound' &&
+        !m.evento_sistema &&
+        !m.apagada &&
+        m.id > cursorId,
+    )
+    return primeira?.id ?? null
+  }
+
+  const eff = chat.last_seen_at || chat.atendimento_inicio_at || chat.created_at || null
+  const effMs = eff ? new Date(eff).getTime() : 0
+  const primeira = msgs.find(
+    (m) =>
+      m.direcao === 'inbound' &&
+      !m.evento_sistema &&
+      !m.apagada &&
+      m.created_at &&
+      new Date(m.created_at).getTime() > effMs,
+  )
+  return primeira?.id ?? null
+}

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -165,11 +165,13 @@ export function ChatListaAtendendo() {
     const u2 = subscribe('chat.mensagem', refresh)
     const u3 = subscribe('portal.chat.fila', refresh)
     const u4 = subscribe('portal.chat.mensagem', refresh)
+    const u5 = subscribe('notificacao.contagem', refresh)
     return () => {
       u1()
       u2()
       u3()
       u4()
+      u5()
     }
   }, [subscribe, load])
 

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -26,6 +26,7 @@ import {
   rotuloResponsavelChat,
 } from '../../lib/whatsappChatMeta'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
+import { primeiraInboundNaoLidaMsgId } from '../../lib/chatUnreadDivider'
 import { WhatsappDemandaTimelineMarco } from '../whatsapp/WhatsappDemandaTimelineMarco'
 import { ACCEPT_ANEXO, type TipoAnexoPicker } from '../whatsapp/WhatsappBarraAnexos'
 import { WhatsappComposerBar } from '../whatsapp/WhatsappComposerBar'
@@ -97,6 +98,25 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const fimRef = useRef<HTMLDivElement>(null)
   const lastMsgIdRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const [divisorNaoLidasMsgId, setDivisorNaoLidasMsgId] = useState<number | null>(null)
+  const chatRef = useRef<PortalChats.Chat | null>(null)
+  const userIdRef = useRef(user?.id)
+
+  useEffect(() => {
+    chatRef.current = chat
+  }, [chat])
+
+  useEffect(() => {
+    userIdRef.current = user?.id
+  }, [user?.id])
+
+  const ehResponsavelPeloChat = useCallback((c: PortalChats.Chat | null, usuarioId?: number) => {
+    return (
+      c?.estado === 'em_atendimento' &&
+      c.atendente_id != null &&
+      c.atendente_id === usuarioId
+    )
+  }, [])
 
   const carregarDemandasTimeline = useCallback(async () => {
     if (!Number.isFinite(chatId)) return
@@ -109,7 +129,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   }, [chatId])
 
   const carregarMensagens = useCallback(
-    async (opts?: { sinceId?: number; replace?: boolean }) => {
+    async (opts?: { sinceId?: number; replace?: boolean; marcarVisto?: boolean }) => {
       if (!Number.isFinite(chatId)) return
       const sinceId = opts?.sinceId
       const rows = await portalChats.mensagens(chatId, sinceId)
@@ -124,8 +144,10 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
           return merged
         })
       }
-      await portalChats.marcarVisto(chatId).catch(() => undefined)
-      void refetchPendenciasResumo()
+      if (opts?.marcarVisto) {
+        await portalChats.marcarVisto(chatId).catch(() => undefined)
+        void refetchPendenciasResumo()
+      }
     },
     [chatId],
   )
@@ -133,54 +155,85 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const load = useCallback(async () => {
     if (!Number.isFinite(chatId)) return
     setLoading(true)
+    setDivisorNaoLidasMsgId(null)
     try {
       const c = await portalChats.get(chatId)
       setChat(c)
-      await Promise.all([carregarMensagens({ replace: true }), carregarDemandasTimeline()])
+      const rows = await portalChats.mensagens(chatId)
+      setMensagens(rows)
+      lastMsgIdRef.current = rows.at(-1)?.id ?? 0
+      const primeiraId = primeiraInboundNaoLidaMsgId(rows, c)
+      if (primeiraId != null) setDivisorNaoLidasMsgId(primeiraId)
+      await portalChats.marcarVisto(chatId).catch(() => undefined)
+      void refetchPendenciasResumo()
+      await carregarDemandasTimeline()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar o chat.'))
     } finally {
       setLoading(false)
     }
-  }, [carregarDemandasTimeline, carregarMensagens, chatId, toast])
+  }, [carregarDemandasTimeline, chatId, toast])
 
   const pollMensagens = useCallback(async () => {
     if (!Number.isFinite(chatId)) return
+    const responsavel = ehResponsavelPeloChat(chatRef.current, userIdRef.current)
     try {
       const sinceId = lastMsgIdRef.current > 0 ? lastMsgIdRef.current : undefined
-      await carregarMensagens(sinceId != null ? { sinceId } : { replace: true })
+      await carregarMensagens(
+        sinceId != null
+          ? { sinceId, marcarVisto: responsavel }
+          : { replace: true, marcarVisto: responsavel },
+      )
     } catch {
       /* silencioso */
     }
-  }, [carregarMensagens, chatId])
+  }, [carregarMensagens, chatId, ehResponsavelPeloChat])
 
   useEffect(() => {
     setChat(null)
     setMensagens([])
     setDemandasTimeline([])
     setTexto('')
+    setDivisorNaoLidasMsgId(null)
     lastMsgIdRef.current = 0
     void load()
   }, [chatId, load])
 
   useEffect(() => {
+    if (!divisorNaoLidasMsgId || loading) return
+    const t = window.setTimeout(() => {
+      document.getElementById('portal-nao-lidas')?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }, 80)
+    return () => window.clearTimeout(t)
+  }, [divisorNaoLidasMsgId, loading])
+
+  useEffect(() => {
+    if (divisorNaoLidasMsgId) return
     fimRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [mensagens, demandasTimeline])
+  }, [mensagens, demandasTimeline, divisorNaoLidasMsgId])
 
   useEffect(() => {
     const refresh = () => void load()
     const u1 = subscribe('portal.chat.mensagem', (payload) => {
-      if (Number(payload?.chat_id) === chatId) {
-        void pollMensagens()
-        void carregarDemandasTimeline()
+      if (Number(payload?.chat_id) !== chatId) return
+      const msg = payload.mensagem as PortalChats.Mensagem | undefined
+      const c = chatRef.current
+      if (
+        msg?.direcao === 'inbound' &&
+        ehResponsavelPeloChat(c, userIdRef.current)
+      ) {
+        void portalChats.marcarVisto(chatId).catch(() => undefined)
+        void refetchPendenciasResumo()
       }
+      void pollMensagens()
+      void carregarDemandasTimeline()
     })
     const u2 = subscribe('portal.chat.fila', refresh)
     return () => {
       u1()
       u2()
     }
-  }, [subscribe, chatId, load, pollMensagens, carregarDemandasTimeline])
+  }, [subscribe, chatId, load, pollMensagens, carregarDemandasTimeline, ehResponsavelPeloChat])
 
   useEffect(() => {
     const intervalMs = useFallback ? 8_000 : 4_000
@@ -494,6 +547,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
 
               const isInbound = m.direcao === 'inbound'
               const isTransferencia = m.evento_sistema === 'transferencia'
+              const mostrarDivisorNaoLidas = divisorNaoLidasMsgId === m.id
 
               if (isTransferencia) {
                 return (
@@ -509,7 +563,22 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
               }
 
               return (
-                <div key={m.id} className={`flex w-full ${isInbound ? 'justify-start' : 'justify-end'}`}>
+                <div key={m.id} className="w-full space-y-3">
+                  {mostrarDivisorNaoLidas && (
+                    <div
+                      id="portal-nao-lidas"
+                      className="flex w-full items-center gap-3 py-1"
+                      role="separator"
+                      aria-label="Mensagens não lidas"
+                    >
+                      <div className="h-px flex-1 bg-cyan-500/50" />
+                      <span className="shrink-0 rounded-full bg-cyan-600 px-3 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white shadow-sm">
+                        Mensagens não lidas
+                      </span>
+                      <div className="h-px flex-1 bg-cyan-500/50" />
+                    </div>
+                  )}
+                <div className={`flex w-full ${isInbound ? 'justify-start' : 'justify-end'}`}>
                   <div className={`max-w-[85%] space-y-1 ${isInbound ? 'items-start' : 'items-end'}`}>
                     <div
                       className={`rounded-2xl px-3 py-2 text-sm shadow-sm ${
@@ -534,6 +603,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
                       {m.created_at ? ` · ${formatarHora(m.created_at)}` : ''}
                     </p>
                   </div>
+                </div>
                 </div>
               )
             })

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -27,6 +27,7 @@ import {
   saveWhatsappScroll,
   scrollWhatsappToBottom,
 } from '../../lib/whatsappScrollMemory'
+import { primeiraInboundNaoLidaMsgId } from '../../lib/chatUnreadDivider'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
@@ -875,6 +876,10 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
   }, [])
 
+  const atualizarSidebarAposEnvioCliente = useCallback(() => {
+    void carregarSidebar()
+  }, [carregarSidebar])
+
 
 
   // Carregar conversa e mensagens
@@ -955,30 +960,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
     carregar()
       .then(async (data) => {
         if (data && (data.chat.nao_lidas_count ?? 0) > 0) {
-          const cursorId = data.chat.last_seen_mensagem_id
-          let primeira: WhatsappChats.Mensagem | undefined
-          if (cursorId != null) {
-            primeira = data.msgs.find(
-              (m) =>
-                m.direcao === 'inbound' &&
-                !m.evento_sistema &&
-                !m.apagada &&
-                m.id > cursorId,
-            )
-          } else {
-            const eff =
-              data.chat.last_seen_at || data.chat.atendimento_inicio_at || data.chat.created_at || null
-            const effMs = eff ? new Date(eff).getTime() : 0
-            primeira = data.msgs.find(
-              (m) =>
-                m.direcao === 'inbound' &&
-                !m.evento_sistema &&
-                !m.apagada &&
-                m.created_at &&
-                new Date(m.created_at).getTime() > effMs,
-            )
-          }
-          if (primeira) setDivisorNaoLidasMsgId(primeira.id)
+          const primeiraId = primeiraInboundNaoLidaMsgId(data.msgs, data.chat)
+          if (primeiraId != null) setDivisorNaoLidasMsgId(primeiraId)
         }
         await whatsappChats.marcarVisto(id)
         void carregarSidebar()
@@ -1220,6 +1203,9 @@ useEffect(() => {
 
       stickToBottomRef.current = true
       await carregar()
+      if (!modoInterno) {
+        atualizarSidebarAposEnvioCliente()
+      }
 
     } catch (err) {
 
@@ -1292,6 +1278,7 @@ useEffect(() => {
       setMsgRespondida(null)
       stickToBottomRef.current = true
       await carregar()
+      atualizarSidebarAposEnvioCliente()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar áudio.'))
     } finally {
@@ -1326,6 +1313,7 @@ useEffect(() => {
       setLegendaMidia('')
       stickToBottomRef.current = true
       await carregar()
+      atualizarSidebarAposEnvioCliente()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
     } finally {
@@ -1381,6 +1369,7 @@ useEffect(() => {
       setMsgRespondida(null)
       stickToBottomRef.current = true
       await carregar()
+      atualizarSidebarAposEnvioCliente()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar figurinha'))
     } finally {


### PR DESCRIPTION
## Summary

- Alinha contador de mensagens não lidas entre sino, lista **Atendendo** e conversa (WhatsApp + Portal) — pedido #S202608-0010
- Centraliza regra de leitura/não lidas em `services/chat_nao_lidas.py` (cursor por `last_seen_mensagem_id`, #951)
- Badge zera ao responder ou marcar visto; divisor «Mensagens não lidas» no Portal; lista escuta `notificacao.contagem`
- Auto-visto em tempo real (SSE/poll) só para o **responsável** pelo chat

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `test_meus_e_visto_contam_nao_lidas` — inbound sobe contador; `/visto` zera
- [x] `test_enviar_ao_cliente_zera_nao_lidas` — resposta do responsável zera badge e sino
- [x] `test_wpp_respostas_resumo_alinhado_com_meus` — paridade lista ↔ notificações
- [x] `npm run build` — frontend OK
- [ ] Manual: abrir chat com não lidas → ver divisor; responder → badge some na lista e no sino
- [ ] Manual: admin acompanha chat de outro → não zera pendência do responsável

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

> Sem follow-ups de backlog — escopo fechado na solicitação SaaS #S202608-0010.
