### PR TITLE
fix(alembic): migration 134 idempotente para ponto_dias_convocados (#985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- Deploy: migration do dia convocado (#985) idempotente — instâncias com tabela criada manualmente não travam no `alembic upgrade`
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
 - Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
 - Atendimentos (#S202608-0010): contador de mensagens não lidas no chat alinhado entre sino, lista e conversa; badge some ao responder; divisor «Mensagens não lidas» também no chat do portal

--- a/backend/alembic/versions/134_ponto_dia_convocado_985.py
+++ b/backend/alembic/versions/134_ponto_dia_convocado_985.py
@@ -15,60 +15,116 @@ down_revision = "133_ponto_lote_e"
 branch_labels = None
 depends_on = None
 
+_TABLE = "ponto_dias_convocados"
+
+_INDEXES: tuple[tuple[str, list[str]], ...] = (
+    ("ix_ponto_dias_convocados_tenant_id", ["tenant_id"]),
+    ("ix_ponto_dias_convocados_atendente_id", ["atendente_id"]),
+    ("ix_ponto_dias_convocados_data_ref", ["data_ref"]),
+    ("ix_ponto_dias_convocados_atendente_data", ["atendente_id", "data_ref"]),
+)
+
+
+def _ensure_indexes(insp: sa.Inspector) -> None:
+    if not insp.has_table(_TABLE):
+        return
+    idxs = {i["name"] for i in insp.get_indexes(_TABLE)}
+    for name, columns in _INDEXES:
+        if name not in idxs:
+            op.create_index(name, _TABLE, columns)
+
+
+def _ensure_columns(insp: sa.Inspector) -> None:
+    """Colunas opcionais/ausentes em DDL manual parcial."""
+    if not insp.has_table(_TABLE):
+        return
+    cols = {c["name"] for c in insp.get_columns(_TABLE)}
+    if "tolerancia_minutos" not in cols:
+        op.add_column(_TABLE, sa.Column("tolerancia_minutos", sa.Integer(), nullable=True))
+    if "estado" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
+        )
+    if "criado_por_id" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                "criado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+    if "created_at" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        )
+    if "cancelado_por_id" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                "cancelado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+    if "cancelado_em" not in cols:
+        op.add_column(_TABLE, sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True))
+
 
 def upgrade() -> None:
     bind = op.get_bind()
     insp = sa.inspect(bind)
-    if insp.has_table("ponto_dias_convocados"):
-        return
-    op.create_table(
-        "ponto_dias_convocados",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column(
-            "tenant_id",
-            sa.Integer(),
-            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
-            nullable=False,
-        ),
-        sa.Column(
-            "atendente_id",
-            sa.Integer(),
-            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("data_ref", sa.Date(), nullable=False),
-        sa.Column("inicio", sa.String(5), nullable=False),
-        sa.Column("fim", sa.String(5), nullable=False),
-        sa.Column("tolerancia_minutos", sa.Integer(), nullable=True),
-        sa.Column("motivo", sa.String(1000), nullable=False),
-        sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
-        sa.Column(
-            "criado_por_id",
-            sa.Integer(),
-            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
-        sa.Column(
-            "cancelado_por_id",
-            sa.Integer(),
-            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True),
-    )
-    op.create_index("ix_ponto_dias_convocados_tenant_id", "ponto_dias_convocados", ["tenant_id"])
-    op.create_index("ix_ponto_dias_convocados_atendente_id", "ponto_dias_convocados", ["atendente_id"])
-    op.create_index("ix_ponto_dias_convocados_data_ref", "ponto_dias_convocados", ["data_ref"])
-    op.create_index(
-        "ix_ponto_dias_convocados_atendente_data",
-        "ponto_dias_convocados",
-        ["atendente_id", "data_ref"],
-    )
+
+    if not insp.has_table(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "tenant_id",
+                sa.Integer(),
+                sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("data_ref", sa.Date(), nullable=False),
+            sa.Column("inicio", sa.String(5), nullable=False),
+            sa.Column("fim", sa.String(5), nullable=False),
+            sa.Column("tolerancia_minutos", sa.Integer(), nullable=True),
+            sa.Column("motivo", sa.String(1000), nullable=False),
+            sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
+            sa.Column(
+                "criado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+            sa.Column(
+                "cancelado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True),
+        )
+        for name, columns in _INDEXES:
+            op.create_index(name, _TABLE, columns)
+    else:
+        _ensure_columns(insp)
+        _ensure_indexes(insp)
 
 
 def downgrade() -> None:
     bind = op.get_bind()
     insp = sa.inspect(bind)
-    if insp.has_table("ponto_dias_convocados"):
-        op.drop_table("ponto_dias_convocados")
+    if insp.has_table(_TABLE):
+        op.drop_table(_TABLE)

--- a/backend/tests/test_alembic_134_idempotent.py
+++ b/backend/tests/test_alembic_134_idempotent.py
@@ -1,0 +1,154 @@
+"""Idempotência da migration 134 — ponto_dias_convocados (#985)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import event
+from sqlalchemy.pool import StaticPool
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1] / "alembic" / "versions" / "134_ponto_dia_convocado_985.py"
+)
+
+_OPTIONAL_COLUMNS = frozenset(
+    {
+        "tolerancia_minutos",
+        "estado",
+        "criado_por_id",
+        "created_at",
+        "cancelado_por_id",
+        "cancelado_em",
+    }
+)
+
+_EXPECTED_INDEXES = frozenset(
+    {
+        "ix_ponto_dias_convocados_tenant_id",
+        "ix_ponto_dias_convocados_atendente_id",
+        "ix_ponto_dias_convocados_data_ref",
+        "ix_ponto_dias_convocados_atendente_data",
+    }
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_134", _MIGRATION_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sqlite_engine():
+    engine = sa.create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _pragma_fk(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
+
+
+def _bootstrap_parents(conn) -> None:
+    conn.execute(sa.text("CREATE TABLE tenants (id INTEGER PRIMARY KEY)"))
+    conn.execute(sa.text("CREATE TABLE atendentes (id INTEGER PRIMARY KEY)"))
+    conn.execute(sa.text("INSERT INTO tenants (id) VALUES (1)"))
+    conn.execute(sa.text("INSERT INTO atendentes (id) VALUES (1)"))
+
+
+def _run_upgrade(migration, engine) -> None:
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            migration.upgrade()
+
+
+def _create_partial_convocados_table(conn) -> None:
+    """Núcleo obrigatório + FKs como INTEGER (DDL manual típico); faltam opcionais simples."""
+    conn.execute(
+        sa.text(
+            """
+            CREATE TABLE ponto_dias_convocados (
+                id INTEGER PRIMARY KEY,
+                tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+                atendente_id INTEGER NOT NULL REFERENCES atendentes(id),
+                data_ref DATE NOT NULL,
+                inicio VARCHAR(5) NOT NULL,
+                fim VARCHAR(5) NOT NULL,
+                motivo VARCHAR(1000) NOT NULL,
+                criado_por_id INTEGER,
+                cancelado_por_id INTEGER
+            )
+            """
+        )
+    )
+
+
+def _create_full_convocados_table_without_indexes(conn) -> None:
+    conn.execute(
+        sa.text(
+            """
+            CREATE TABLE ponto_dias_convocados (
+                id INTEGER PRIMARY KEY,
+                tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+                atendente_id INTEGER NOT NULL REFERENCES atendentes(id),
+                data_ref DATE NOT NULL,
+                inicio VARCHAR(5) NOT NULL,
+                fim VARCHAR(5) NOT NULL,
+                tolerancia_minutos INTEGER,
+                motivo VARCHAR(1000) NOT NULL,
+                estado VARCHAR(20) NOT NULL DEFAULT 'ativa',
+                criado_por_id INTEGER REFERENCES atendentes(id),
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                cancelado_por_id INTEGER REFERENCES atendentes(id),
+                cancelado_em DATETIME
+            )
+            """
+        )
+    )
+
+
+def _assert_schema_complete(engine) -> None:
+    insp = sa.inspect(engine)
+    assert insp.has_table("ponto_dias_convocados")
+    cols = {c["name"] for c in insp.get_columns("ponto_dias_convocados")}
+    assert _OPTIONAL_COLUMNS.issubset(cols)
+    idxs = {i["name"] for i in insp.get_indexes("ponto_dias_convocados")}
+    assert _EXPECTED_INDEXES.issubset(idxs)
+
+
+def test_134_upgrade_idempotente_tabela_parcial():
+    """DDL manual com núcleo + FKs como INTEGER; upgrade duas vezes completa opcionais simples."""
+    migration = _load_migration()
+    engine = _sqlite_engine()
+    with engine.begin() as conn:
+        _bootstrap_parents(conn)
+        _create_partial_convocados_table(conn)
+
+    _run_upgrade(migration, engine)
+    _run_upgrade(migration, engine)
+    _assert_schema_complete(engine)
+
+
+def test_134_upgrade_idempotente_tabela_completa_sem_indices():
+    """Tabela completa criada manualmente sem índices: upgrade duas vezes cria índices."""
+    migration = _load_migration()
+    engine = _sqlite_engine()
+    with engine.begin() as conn:
+        _bootstrap_parents(conn)
+        _create_full_convocados_table_without_indexes(conn)
+
+    _run_upgrade(migration, engine)
+    _run_upgrade(migration, engine)
+    _assert_schema_complete(engine)

--- a/docs/ALEMBIC_MIGRATIONS.md
+++ b/docs/ALEMBIC_MIGRATIONS.md
@@ -30,3 +30,39 @@ Se `history`/`heads` já falhar, há inconsistência de `revision`/`down_revisio
 
 Se `alembic heads` listar **mais de uma** revision, `alembic upgrade head` falha no deploy. Crie uma migration de **merge** (sem DDL) com `down_revision` em tupla apontando para cada head — ver `029_merge_ticket_parent_and_outbox_heads.py`.
 
+## Hotfix manual (DDL antes do deploy)
+
+Em produção, às vezes é necessário aplicar SQL manual **antes** do release (ex.: coluna faltando que quebra login). Regras:
+
+1. **Preferir** `ALTER TABLE … ADD COLUMN IF NOT EXISTS` (Postgres) — alinhado ao que a migration idempotente faria no próximo deploy.
+2. **Não** alterar `alembic_version` à mão, salvo `alembic stamp` planejado com o time.
+3. Migrations idempotentes do repo (`has_table`, `_ensure_columns`, `_ensure_indexes`) **não** recriam colunas obrigatórias ausentes — só completam colunas opcionais e índices quando a tabela já existe.
+
+### Exemplo: `134_ponto_dia_convocado_985` (#985)
+
+Se `ponto_dias_convocados` foi criada manualmente:
+
+| Situação | O que a migration faz |
+|----------|------------------------|
+| Tabela não existe | `CREATE TABLE` + índices |
+| Tabela existe, faltam colunas opcionais (`tolerancia_minutos`, `estado`, `criado_por_id`, `created_at`, `cancelado_*`) | `ADD COLUMN` só das ausentes |
+| Tabela existe, faltam índices | `CREATE INDEX` dos ausentes |
+| Tabela existe **sem** colunas obrigatórias (`tenant_id`, `atendente_id`, `data_ref`, `inicio`, `fim`, `motivo`) | **Não corrige** — o DDL manual deve incluir o núcleo; ajuste o SQL na VPS ou recrie a tabela |
+
+SQL mínimo aceitável para hotfix manual (Postgres):
+
+```sql
+CREATE TABLE IF NOT EXISTS ponto_dias_convocados (
+    id SERIAL PRIMARY KEY,
+    tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+    atendente_id INTEGER NOT NULL REFERENCES atendentes(id) ON DELETE CASCADE,
+    data_ref DATE NOT NULL,
+    inicio VARCHAR(5) NOT NULL,
+    fim VARCHAR(5) NOT NULL,
+    motivo VARCHAR(1000) NOT NULL
+);
+-- Colunas opcionais e índices: o deploy (migration 134) completa se faltarem.
+```
+
+Teste automatizado: `backend/tests/test_alembic_134_idempotent.py`.
+


### PR DESCRIPTION
## Summary

- Torna a migration `134_ponto_dia_convocado_985` idempotente: cria tabela/índices se ausentes ou completa colunas opcionais e índices quando `ponto_dias_convocados` já existe por DDL manual
- Documenta limites e SQL mínimo de hotfix em `docs/ALEMBIC_MIGRATIONS.md`
- Adiciona testes automatizados de idempotência (`test_alembic_134_idempotent.py`)

Relacionado: #985 (deploy seguro em instâncias com schema pré-aplicado na VPS)

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `alembic heads` → único head `134_ponto_dia_convocado_985`
- [x] `pytest tests/test_alembic_134_idempotent.py` — 2 passed
- [x] `pytest tests/test_ponto_dia_convocado_985.py` — 5 passed

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] N/A — hotfix de deploy/infra; #985 já entregue na feature; este PR só endurece a migration antes do próximo release
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável — N/A
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados — N/A
