### PR TITLE
release: main → staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - **Acompanhamento**: linha do tempo vertical no detalhe do pedido; skeleton da tabela no Sobre enquanto carrega
 - Provisionamento: URL de ingest gravada no `client.env` usa **loopback** (`127.0.0.1:8001`) por padrão — evita falha de sync quando instância e admin-center estão na mesma VPS
 - Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
+- Ponto (#985): dia convocado — admin agenda trabalho fora da grade com janela própria; calendário, faltas e banco de horas respeitam a exceção
+- Ponto (#S202608-0011): histórico da equipe paginado (20 batidas por página, com total e navegação)
 - Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
 - Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento
 - Ponto (#975 / #970): **export contábil/folha RH** (CSV e Excel) com matrícula, previsto/realizado, atrasos, faltas, HE, banco e ajustes; **cobertura de plantão** (A pede → B aceita → admin homologa, ou admin agenda direto) refletida no calendário e nas faltas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- Deploy: migration do dia convocado (#985) idempotente — instâncias com tabela criada manualmente não travam no `alembic upgrade`
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
 - Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
 - Atendimentos (#S202608-0010): contador de mensagens não lidas no chat alinhado entre sino, lista e conversa; badge some ao responder; divisor «Mensagens não lidas» também no chat do portal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
 - Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
+- Atendimentos (#S202608-0010): contador de mensagens não lidas no chat alinhado entre sino, lista e conversa; badge some ao responder; divisor «Mensagens não lidas» também no chat do portal
 - Sobre: deixa de listar itens **Interno / Infra** (deploy, LICENSE, docs internos) — só Melhorias e Correções de produto
 - Sobre: versão **26.08.015** sem repetir notas já publicadas em releases anteriores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 Formato baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
 Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging`.
@@ -17,6 +17,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- **Minhas solicitações** e bloco no **Sobre**: lista em tabela com badges; no Sobre só as **5 mais recentes** com atalho **Ver todas**; filtros por tipo, fase, status e busca; detalhe com timeline e mensagem de status por fase
+- **Nova solicitação**: seletor visual de tipo (chips), textos em pt-BR, anexos removíveis antes do envio e imagens coladas listadas com opção de remover
+- **Acompanhamento**: linha do tempo vertical no detalhe do pedido; skeleton da tabela no Sobre enquanto carrega
+- Provisionamento: URL de ingest gravada no `client.env` usa **loopback** (`127.0.0.1:8001`) por padrão — evita falha de sync quando instância e admin-center estão na mesma VPS
 - Ponto (#976 / #977 / #973): férias e folga programada (pedido do colaborador ou agendamento admin); justificativa com anexo (imagem/PDF); alerta de pausa abaixo do mínimo configurável
 - Ponto (#969 / #974 / #982): colaborador **solicita hora extra** com janela desejada; teto mensal (global ou por pessoa) bloqueia novas liberações; digest e Meu ponto mostram consumo; avisos em tempo real (`ponto.he_atualizada`)
 - Ponto (#981 / #980 / #978 / #979): checklist de configuração pós-deploy; ajuda **Como funciona o ponto**; **fechamento de competência** mensal (reabrir com motivo; ajustes pós-fechamento marcados); **ciência** do colaborador no espelho após o fechamento

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,7 +35,9 @@ LOG_LEVEL=INFO
 #
 # Instância cliente (não o control-plane): cópia das sugestões para o SaaS
 # SAAS_INSTANCE_SLUG=cliente01
-# SAAS_CONTROL_PLANE_INGEST_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+# Na mesma VPS que o admin-center, use loopback (gravado automaticamente no provisionamento):
+# SAAS_CONTROL_PLANE_INGEST_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes
+# Instância remota: https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
 # SAAS_INSTANCE_INGEST_TOKEN=
 # SAAS_TRIAGEM_PULL_INTERVAL_SECONDS=60
 # Token MCP legado (instância comercial). Preferir token pessoal gerado em /saas/conta.

--- a/backend/alembic/versions/134_ponto_dia_convocado_985.py
+++ b/backend/alembic/versions/134_ponto_dia_convocado_985.py
@@ -1,0 +1,74 @@
+"""Lote H: dia convocado (#985).
+
+Revision ID: 134_ponto_dia_convocado_985
+Revises: 133_ponto_lote_e
+Create Date: 2026-08-28
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "134_ponto_dia_convocado_985"
+down_revision = "133_ponto_lote_e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_dias_convocados"):
+        return
+    op.create_table(
+        "ponto_dias_convocados",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            sa.Integer(),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "atendente_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("data_ref", sa.Date(), nullable=False),
+        sa.Column("inicio", sa.String(5), nullable=False),
+        sa.Column("fim", sa.String(5), nullable=False),
+        sa.Column("tolerancia_minutos", sa.Integer(), nullable=True),
+        sa.Column("motivo", sa.String(1000), nullable=False),
+        sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
+        sa.Column(
+            "criado_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column(
+            "cancelado_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_ponto_dias_convocados_tenant_id", "ponto_dias_convocados", ["tenant_id"])
+    op.create_index("ix_ponto_dias_convocados_atendente_id", "ponto_dias_convocados", ["atendente_id"])
+    op.create_index("ix_ponto_dias_convocados_data_ref", "ponto_dias_convocados", ["data_ref"])
+    op.create_index(
+        "ix_ponto_dias_convocados_atendente_data",
+        "ponto_dias_convocados",
+        ["atendente_id", "data_ref"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_dias_convocados"):
+        op.drop_table("ponto_dias_convocados")

--- a/backend/alembic/versions/134_ponto_dia_convocado_985.py
+++ b/backend/alembic/versions/134_ponto_dia_convocado_985.py
@@ -15,60 +15,116 @@ down_revision = "133_ponto_lote_e"
 branch_labels = None
 depends_on = None
 
+_TABLE = "ponto_dias_convocados"
+
+_INDEXES: tuple[tuple[str, list[str]], ...] = (
+    ("ix_ponto_dias_convocados_tenant_id", ["tenant_id"]),
+    ("ix_ponto_dias_convocados_atendente_id", ["atendente_id"]),
+    ("ix_ponto_dias_convocados_data_ref", ["data_ref"]),
+    ("ix_ponto_dias_convocados_atendente_data", ["atendente_id", "data_ref"]),
+)
+
+
+def _ensure_indexes(insp: sa.Inspector) -> None:
+    if not insp.has_table(_TABLE):
+        return
+    idxs = {i["name"] for i in insp.get_indexes(_TABLE)}
+    for name, columns in _INDEXES:
+        if name not in idxs:
+            op.create_index(name, _TABLE, columns)
+
+
+def _ensure_columns(insp: sa.Inspector) -> None:
+    """Colunas opcionais/ausentes em DDL manual parcial."""
+    if not insp.has_table(_TABLE):
+        return
+    cols = {c["name"] for c in insp.get_columns(_TABLE)}
+    if "tolerancia_minutos" not in cols:
+        op.add_column(_TABLE, sa.Column("tolerancia_minutos", sa.Integer(), nullable=True))
+    if "estado" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
+        )
+    if "criado_por_id" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                "criado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+    if "created_at" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        )
+    if "cancelado_por_id" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                "cancelado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+    if "cancelado_em" not in cols:
+        op.add_column(_TABLE, sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True))
+
 
 def upgrade() -> None:
     bind = op.get_bind()
     insp = sa.inspect(bind)
-    if insp.has_table("ponto_dias_convocados"):
-        return
-    op.create_table(
-        "ponto_dias_convocados",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column(
-            "tenant_id",
-            sa.Integer(),
-            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
-            nullable=False,
-        ),
-        sa.Column(
-            "atendente_id",
-            sa.Integer(),
-            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("data_ref", sa.Date(), nullable=False),
-        sa.Column("inicio", sa.String(5), nullable=False),
-        sa.Column("fim", sa.String(5), nullable=False),
-        sa.Column("tolerancia_minutos", sa.Integer(), nullable=True),
-        sa.Column("motivo", sa.String(1000), nullable=False),
-        sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
-        sa.Column(
-            "criado_por_id",
-            sa.Integer(),
-            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
-        sa.Column(
-            "cancelado_por_id",
-            sa.Integer(),
-            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-        sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True),
-    )
-    op.create_index("ix_ponto_dias_convocados_tenant_id", "ponto_dias_convocados", ["tenant_id"])
-    op.create_index("ix_ponto_dias_convocados_atendente_id", "ponto_dias_convocados", ["atendente_id"])
-    op.create_index("ix_ponto_dias_convocados_data_ref", "ponto_dias_convocados", ["data_ref"])
-    op.create_index(
-        "ix_ponto_dias_convocados_atendente_data",
-        "ponto_dias_convocados",
-        ["atendente_id", "data_ref"],
-    )
+
+    if not insp.has_table(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "tenant_id",
+                sa.Integer(),
+                sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("data_ref", sa.Date(), nullable=False),
+            sa.Column("inicio", sa.String(5), nullable=False),
+            sa.Column("fim", sa.String(5), nullable=False),
+            sa.Column("tolerancia_minutos", sa.Integer(), nullable=True),
+            sa.Column("motivo", sa.String(1000), nullable=False),
+            sa.Column("estado", sa.String(20), nullable=False, server_default="ativa"),
+            sa.Column(
+                "criado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+            sa.Column(
+                "cancelado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("cancelado_em", sa.DateTime(timezone=True), nullable=True),
+        )
+        for name, columns in _INDEXES:
+            op.create_index(name, _TABLE, columns)
+    else:
+        _ensure_columns(insp)
+        _ensure_indexes(insp)
 
 
 def downgrade() -> None:
     bind = op.get_bind()
     insp = sa.inspect(bind)
-    if insp.has_table("ponto_dias_convocados"):
-        op.drop_table("ponto_dias_convocados")
+    if insp.has_table(_TABLE):
+        op.drop_table(_TABLE)

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -9,9 +9,9 @@ from sqlalchemy.orm import Session, joinedload
 from app.database import get_db
 from app.models import Ticket, TicketMensagem, Atendente
 from app.models.ticket_read import TicketRead
-from app.models.whatsapp_chat_read import WhatsappChatRead
-from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
-from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
+from app.models.whatsapp_chat import WhatsappChat
+from app.models.portal_chat import PortalChat
+from app.services import chat_nao_lidas as chat_nao_lidas_svc
 from app.schemas.notificacoes import NotificacaoResumo, NotificacaoItem, NotificacaoItensResponse
 from app.schemas.atendente_notificacao import NotificacaoPreferenciasRead, NotificacaoPreferenciasUpdate
 from app.core.auth import obter_atendente_atual
@@ -121,28 +121,6 @@ def _last_unread_message_at_subq(atendente_id: int):
     )
 
 
-def _wpp_resposta_pendente_exprs(atendente_id: int):
-    seen_at = (
-        select(WhatsappChatRead.last_seen_at)
-        .where(
-            WhatsappChatRead.chat_id == WhatsappChat.id,
-            WhatsappChatRead.atendente_id == atendente_id,
-        )
-        .limit(1)
-        .scalar_subquery()
-    )
-    inbound_last = (
-        select(func.max(WhatsappMensagem.created_at))
-        .where(
-            WhatsappMensagem.chat_id == WhatsappChat.id,
-            WhatsappMensagem.direcao == "inbound",
-        )
-        .scalar_subquery()
-    )
-    eff_seen = func.coalesce(seen_at, WhatsappChat.atendimento_inicio_at, WhatsappChat.created_at)
-    return inbound_last, eff_seen
-
-
 def _preview_ultima_nao_lida(db: Session, ticket: Ticket, atendente_id: int) -> str | None:
     ls = (
         db.query(TicketRead.last_seen_at)
@@ -185,46 +163,6 @@ def _count_wpp_fila(db: Session, atendente: Atendente) -> int:
     return int(db.execute(stmt).scalar_one())
 
 
-def _count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
-    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
-    stmt = (
-        select(func.count())
-        .select_from(WhatsappChat)
-        .where(
-            WhatsappChat.estado == "em_atendimento",
-            WhatsappChat.atendente_id == atendente.id,
-            inbound_last.isnot(None),
-            eff_seen < inbound_last,
-        )
-    )
-    if atendente.role != "admin":
-        vis = ids_setores_visiveis_atendente(db, atendente)
-        stmt = stmt.where(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
-    return int(db.execute(stmt).scalar_one())
-
-
-def _portal_resposta_pendente_exprs(atendente_id: int):
-    seen_at = (
-        select(PortalChatReadModel.last_seen_at)
-        .where(
-            PortalChatReadModel.chat_id == PortalChat.id,
-            PortalChatReadModel.atendente_id == atendente_id,
-        )
-        .limit(1)
-        .scalar_subquery()
-    )
-    inbound_last = (
-        select(func.max(PortalMensagem.created_at))
-        .where(
-            PortalMensagem.chat_id == PortalChat.id,
-            PortalMensagem.direcao == "inbound",
-        )
-        .scalar_subquery()
-    )
-    eff_seen = func.coalesce(seen_at, PortalChat.atendimento_inicio_at, PortalChat.created_at)
-    return inbound_last, eff_seen
-
-
 def _count_portal_fila(db: Session, atendente: Atendente) -> int:
     stmt = (
         select(func.count())
@@ -235,47 +173,6 @@ def _count_portal_fila(db: Session, atendente: Atendente) -> int:
         vis = ids_setores_visiveis_atendente(db, atendente)
         stmt = stmt.where(or_(PortalChat.setor_id.is_(None), PortalChat.setor_id.in_(vis)))
     return int(db.execute(stmt).scalar_one())
-
-
-def _count_portal_respostas_pendentes(db: Session, atendente: Atendente) -> int:
-    inbound_last, eff_seen = _portal_resposta_pendente_exprs(atendente.id)
-    stmt = (
-        select(func.count())
-        .select_from(PortalChat)
-        .where(
-            PortalChat.estado == "em_atendimento",
-            PortalChat.atendente_id == atendente.id,
-            inbound_last.isnot(None),
-            eff_seen < inbound_last,
-        )
-    )
-    if atendente.role != "admin":
-        vis = ids_setores_visiveis_atendente(db, atendente)
-        stmt = stmt.where(or_(PortalChat.setor_id.is_(None), PortalChat.setor_id.in_(vis)))
-    return int(db.execute(stmt).scalar_one())
-
-
-def _wpp_unread_count_for_chat(db: Session, chat_id: int, atendente_id: int) -> int:
-    c = db.query(WhatsappChat.id, WhatsappChat.created_at, WhatsappChat.atendimento_inicio_at).filter(WhatsappChat.id == chat_id).first()
-    if not c:
-        return 0
-    row = (
-        db.query(WhatsappChatRead.last_seen_at, WhatsappChatRead.last_seen_mensagem_id)
-        .filter(WhatsappChatRead.chat_id == chat_id, WhatsappChatRead.atendente_id == atendente_id)
-        .first()
-    )
-    ls = row[0] if row else None
-    cursor_id = row[1] if row else None
-    q = db.query(func.count(WhatsappMensagem.id)).filter(
-        WhatsappMensagem.chat_id == chat_id,
-        WhatsappMensagem.direcao == "inbound",
-    )
-    if cursor_id is not None:
-        q = q.filter(WhatsappMensagem.id > cursor_id)
-    else:
-        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-        q = q.filter(WhatsappMensagem.created_at > eff)
-    return int(q.scalar() or 0)
 
 
 def build_notificacao_itens(
@@ -332,16 +229,15 @@ def build_notificacao_itens(
                 )
             )
 
-    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
+    ultima_nao_lida_at = chat_nao_lidas_svc.wpp_ultima_nao_lida_at_subq(atendente.id)
     stmt_wpp = (
         select(WhatsappChat)
         .where(
             WhatsappChat.estado == "em_atendimento",
             WhatsappChat.atendente_id == atendente.id,
-            inbound_last.isnot(None),
-            eff_seen < inbound_last,
+            chat_nao_lidas_svc.exists_wpp_inbound_nao_lido(atendente.id),
         )
-        .order_by(inbound_last.desc(), WhatsappChat.id.desc())
+        .order_by(ultima_nao_lida_at.desc(), WhatsappChat.id.desc())
         .limit(limit)
     )
     if atendente.role != "admin":
@@ -349,7 +245,7 @@ def build_notificacao_itens(
         stmt_wpp = stmt_wpp.where(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
     chats = db.execute(stmt_wpp).scalars().all()
     for c in chats:
-        uc = _wpp_unread_count_for_chat(db, c.id, atendente.id)
+        uc = chat_nao_lidas_svc.contar_nao_lidas_whatsapp_por_id(db, c.id, atendente.id)
         if uc <= 0:
             uc = 1
         nome = (c.cliente_nome or "").strip() or c.wa_id
@@ -428,9 +324,9 @@ def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoRe
     sem = _count_sem_responsavel(db, atendente)
     nao = _count_tickets_com_nao_lidas(db, atendente)
     wpp_fila = _count_wpp_fila(db, atendente)
-    wpp_resp = _count_wpp_respostas_pendentes(db, atendente)
+    wpp_resp = chat_nao_lidas_svc.count_wpp_respostas_pendentes(db, atendente)
     portal_fila = _count_portal_fila(db, atendente)
-    portal_resp = _count_portal_respostas_pendentes(db, atendente)
+    portal_resp = chat_nao_lidas_svc.count_portal_respostas_pendentes(db, atendente)
     chat_interno = chat_interno_svc.contar_total_nao_lidas_atendente(db, atendente)
     he_pend = 0
     if atendente.role == "admin":

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -36,6 +36,8 @@ from app.schemas.ponto import (
     PontoCoberturaResposta,
     PontoCompetenciaRead,
     PontoCompetenciaReabrir,
+    PontoDiaConvocadoCreate,
+    PontoDiaConvocadoRead,
     PontoDigestRead,
     PontoEstadoRead,
     PontoFeriadoCreate,
@@ -62,6 +64,7 @@ from app.schemas.ponto import (
 from app.services import ponto as ponto_svc
 from app.services import ponto_ausencia as ausencia_svc
 from app.services import ponto_cobertura as cob_svc
+from app.services import ponto_convocado as convocado_svc
 from app.services import ponto_competencia as comp_svc
 from app.services import ponto_folha as folha_svc
 from app.services import ponto_hora_extra as he_svc
@@ -809,6 +812,52 @@ def remover_ausencia(
 ):
     ausencia_svc.remover_admin(db, admin, ausencia_id)
     return Response(status_code=204)
+
+
+@router.post("/convocados/conceder", response_model=PontoDiaConvocadoRead, status_code=201)
+def conceder_dia_convocado(
+    data: PontoDiaConvocadoCreate,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return convocado_svc.criar_admin(
+        db,
+        admin,
+        atendente_id=data.atendente_id,
+        data_ref=data.data_ref,
+        inicio=data.inicio,
+        fim=data.fim,
+        motivo=data.motivo,
+        tolerancia_minutos=data.tolerancia_minutos,
+    )
+
+
+@router.get("/convocados", response_model=list[PontoDiaConvocadoRead])
+def listar_dias_convocados(
+    atendente_id: int | None = Query(None),
+    desde: date | None = Query(None),
+    ate: date | None = Query(None),
+    estado: str | None = Query("ativa"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return convocado_svc.listar_admin(
+        db,
+        admin,
+        atendente_id=atendente_id,
+        desde=desde,
+        ate=ate,
+        estado=estado,
+    )
+
+
+@router.delete("/convocados/{convocado_id}", response_model=PontoDiaConvocadoRead)
+def cancelar_dia_convocado(
+    convocado_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return convocado_svc.cancelar_admin(db, admin, convocado_id)
 
 
 @router.get("/hora-extra/me/status", response_model=PontoHoraExtraMeStatus)

--- a/backend/app/api/portal_chats.py
+++ b/backend/app/api/portal_chats.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Upload
 from fastapi.responses import FileResponse
 from datetime import datetime
 
-from sqlalchemy import func, or_
+from sqlalchemy import or_
 from sqlalchemy.orm import Session, joinedload
 
 from app.config import settings
@@ -16,7 +16,7 @@ from app.core.auth import obter_atendente_atual
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
+from app.models.portal_chat import PortalChat, PortalMensagem
 from app.models.setor import Setor
 from app.schemas.portal_chat import (
     PortalChatDemandaCreate,
@@ -27,6 +27,7 @@ from app.schemas.portal_chat import (
     PortalChatRead,
     PortalTransferirChatBody,
 )
+from app.services.chat_nao_lidas import contar_nao_lidas_portal
 from app.services.portal_auto_messages import try_auto_msg_assumido
 from app.services.portal_chat import (
     assumir_portal_chat,
@@ -73,39 +74,12 @@ def _ultima_mensagem_preview(db: Session, chat_id: int) -> str | None:
     return _preview_corpo(corpo)
 
 
-def _nao_lidas_portal(
-    db: Session, c: PortalChat, atendente_id: int
-) -> tuple[int, datetime | None, int | None]:
-    row = (
-        db.query(PortalChatReadModel.last_seen_at, PortalChatReadModel.last_seen_mensagem_id)
-        .filter(
-            PortalChatReadModel.chat_id == c.id,
-            PortalChatReadModel.atendente_id == atendente_id,
-        )
-        .first()
-    )
-    ls = row[0] if row else None
-    cursor_id = row[1] if row else None
-    q = db.query(func.count(PortalMensagem.id)).filter(
-        PortalMensagem.chat_id == c.id,
-        PortalMensagem.direcao == "inbound",
-    )
-    if cursor_id is not None:
-        q = q.filter(PortalMensagem.id > cursor_id)
-    else:
-        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-        if eff is None:
-            return 0, ls, cursor_id
-        q = q.filter(PortalMensagem.created_at > eff)
-    return int(q.scalar() or 0), ls, cursor_id
-
-
 def _chat_read(db: Session, c: PortalChat, *, atendente_id: int | None = None) -> PortalChatRead:
     nao_lidas = 0
     last_seen: datetime | None = None
     last_seen_msg: int | None = None
     if atendente_id is not None:
-        nao_lidas, last_seen, last_seen_msg = _nao_lidas_portal(db, c, atendente_id)
+        nao_lidas, last_seen, last_seen_msg = contar_nao_lidas_portal(db, c, atendente_id)
     return PortalChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -448,6 +422,7 @@ def enviar_mensagem(
 ):
     c = _get_chat(db, chat_id)
     msg = registrar_mensagem_atendente(db, c, atendente, body.corpo)
+    marcar_visto_portal_chat(db, chat_id, atendente.id)
     db.commit()
     db.refresh(msg)
     msg = (
@@ -458,6 +433,9 @@ def enviar_mensagem(
     )
     assert msg is not None
     emit_portal_chat_mensagem_from_models(db, c, msg, exclude_atendente_id=atendente.id)
+    from app.services.realtime_emit import emit_notificacao_contagem
+
+    emit_notificacao_contagem(db, [atendente.id])
     return _mensagem_read(msg)
 
 
@@ -513,6 +491,7 @@ async def enviar_mensagem_midia(
         midia_nome_arquivo=nome_guardado,
         caption=caption,
     )
+    marcar_visto_portal_chat(db, chat_id, atendente.id)
     db.commit()
     db.refresh(msg)
     msg = (
@@ -523,6 +502,9 @@ async def enviar_mensagem_midia(
     )
     assert msg is not None
     emit_portal_chat_mensagem_from_models(db, c, msg, exclude_atendente_id=atendente.id)
+    from app.services.realtime_emit import emit_notificacao_contagem
+
+    emit_notificacao_contagem(db, [atendente.id])
     return _mensagem_read(msg)
 
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -17,7 +17,6 @@ from app.models.setor import Setor
 from app.models.rede import Rede
 from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
 from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem, WhatsappSettings
-from app.models.whatsapp_chat_read import WhatsappChatRead as WhatsappChatReadModel
 from app.schemas.lista_paginada import ListaPaginada
 from app.schemas.whatsapp_chat import (
     WhatsappAbrirTicketBody,
@@ -62,6 +61,7 @@ from app.services.whatsapp_auto_messages import (
 from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+from app.services.chat_nao_lidas import contar_nao_lidas_whatsapp, marcar_leitura_whatsapp
 from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
@@ -437,9 +437,25 @@ def _enviar_texto_whatsapp(
         status_entrega=status_inicial_outbound_whatsapp(wa_message_id=sent_wa_id) if evento_sistema is None else None,
     )
     db.add(m)
+    if (
+        atendente is not None
+        and evento_sistema is None
+        and chat.atendente_id is not None
+        and chat.atendente_id == atendente.id
+    ):
+        marcar_leitura_whatsapp(db, chat.id, atendente.id)
     db.commit()
     db.refresh(m)
     emit_chat_mensagem_from_models(db, chat, m, exclude_atendente_id=atendente.id if atendente else None)
+    if (
+        atendente is not None
+        and evento_sistema is None
+        and chat.atendente_id is not None
+        and chat.atendente_id == atendente.id
+    ):
+        from app.services.realtime_emit import emit_notificacao_contagem
+
+        emit_notificacao_contagem(db, [atendente.id])
     return m
 
 
@@ -633,34 +649,6 @@ def _criar_funcionario_rede(
     return f
 
 
-def _nao_lidas_whatsapp(
-    db: Session, c: WhatsappChat, atendente_id: int
-) -> tuple[int, datetime | None, int | None]:
-    """Inbound após o cursor de leitura (#951)."""
-    row = (
-        db.query(WhatsappChatReadModel.last_seen_at, WhatsappChatReadModel.last_seen_mensagem_id)
-        .filter(
-            WhatsappChatReadModel.chat_id == c.id,
-            WhatsappChatReadModel.atendente_id == atendente_id,
-        )
-        .first()
-    )
-    ls = row[0] if row else None
-    cursor_id = row[1] if row else None
-    q = db.query(func.count(WhatsappMensagem.id)).filter(
-        WhatsappMensagem.chat_id == c.id,
-        WhatsappMensagem.direcao == "inbound",
-    )
-    if cursor_id is not None:
-        q = q.filter(WhatsappMensagem.id > cursor_id)
-    else:
-        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-        if eff is None:
-            return 0, ls, cursor_id
-        q = q.filter(WhatsappMensagem.created_at > eff)
-    return int(q.scalar() or 0), ls, cursor_id
-
-
 def _chat_read(
     db: Session,
     c: WhatsappChat,
@@ -677,7 +665,7 @@ def _chat_read(
     last_seen: datetime | None = None
     last_seen_msg: int | None = None
     if atendente_id is not None:
-        nao_lidas, last_seen, last_seen_msg = _nao_lidas_whatsapp(db, c, atendente_id)
+        nao_lidas, last_seen, last_seen_msg = contar_nao_lidas_whatsapp(db, c, atendente_id)
     return WhatsappChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -2185,6 +2173,8 @@ async def enviar_mensagem_midia(
     )
     db.add(m)
     _sair_pausa_inatividade_por_atividade(c)
+    if c.atendente_id is not None and c.atendente_id == atendente.id:
+        marcar_leitura_whatsapp(db, c.id, atendente.id)
     db.commit()
     m2 = (
         db.query(WhatsappMensagem)
@@ -2194,6 +2184,9 @@ async def enviar_mensagem_midia(
     )
     assert m2 is not None
     emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    from app.services.realtime_emit import emit_notificacao_contagem
+
+    emit_notificacao_contagem(db, [atendente.id])
     return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
 
 
@@ -2257,26 +2250,7 @@ def marcar_chat_visto(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
 
     now = datetime.now(timezone.utc)
-    max_msg_id = (
-        db.query(func.max(WhatsappMensagem.id)).filter(WhatsappMensagem.chat_id == chat_id).scalar()
-    )
-    row = (
-        db.query(WhatsappChatReadModel)
-        .filter(WhatsappChatReadModel.chat_id == chat_id, WhatsappChatReadModel.atendente_id == atendente.id)
-        .first()
-    )
-    if row:
-        row.last_seen_at = now
-        row.last_seen_mensagem_id = max_msg_id
-    else:
-        db.add(
-            WhatsappChatReadModel(
-                chat_id=chat_id,
-                atendente_id=atendente.id,
-                last_seen_at=now,
-                last_seen_mensagem_id=max_msg_id,
-            )
-        )
+    marcar_leitura_whatsapp(db, chat_id, atendente.id, now=now)
     # ✓✓ azul no WhatsApp do cliente: só o responsável, em atendimento
     if (
         c.estado == "em_atendimento"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -116,8 +116,11 @@ class Settings(BaseSettings):
     SAAS_CONTROL_PLANE_INGEST_URL: str | None = None
     SAAS_INSTANCE_INGEST_TOKEN: str | None = None
     SAAS_INSTANCE_SLUG: str | None = None
-    # Só no control-plane: URL pública que as instâncias devem usar (escrita no client.env).
+    # Só no control-plane: URL pública (documentação / instâncias remotas).
     SAAS_INGEST_PUBLIC_URL: str | None = None
+    # URL gravada no client.env para pull/push server-to-server na mesma VPS (evita Cloudflare no worker).
+    # Vazio = usa SAAS_INGEST_PUBLIC_URL / api.{domínio}.
+    SAAS_INGEST_LOOPBACK_URL: str = "http://127.0.0.1:8001/v1/saas/ingest/solicitacoes"
     # Instância cliente: intervalo do pull autenticado da triagem SaaS (#856).
     SAAS_TRIAGEM_PULL_INTERVAL_SECONDS: int = 60
     # Control-plane: token longo para o MCP do Cursor (não JWT). Vazio = só login saas_ops.

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
 from app.models.ponto_hora_extra import PontoHoraExtra
 from app.models.ponto_ausencia import PontoAusencia
+from app.models.ponto_dia_convocado import PontoDiaConvocado
 from app.models.ponto_cobertura import PontoCobertura
 from app.models.ponto_competencia import PontoCompetencia, PontoEspelhoCiencia
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
@@ -106,6 +107,7 @@ __all__ = [
     "PontoJustificativa",
     "PontoHoraExtra",
     "PontoAusencia",
+    "PontoDiaConvocado",
     "PontoCobertura",
     "PontoCompetencia",
     "PontoEspelhoCiencia",

--- a/backend/app/models/ponto_dia_convocado.py
+++ b/backend/app/models/ponto_dia_convocado.py
@@ -1,0 +1,30 @@
+"""Dia convocado — trabalho excepcional fora da grade (#985)."""
+
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoDiaConvocado(Base):
+    __tablename__ = "ponto_dias_convocados"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    data_ref = Column(Date, nullable=False, index=True)
+    inicio = Column(String(5), nullable=False)
+    fim = Column(String(5), nullable=False)
+    tolerancia_minutos = Column(Integer, nullable=True)
+    motivo = Column(String(1000), nullable=False)
+    # ativa | cancelada
+    estado = Column(String(20), nullable=False, default="ativa", server_default="ativa")
+    criado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    cancelado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    cancelado_em = Column(DateTime(timezone=True), nullable=True)
+
+    atendente = relationship("Atendente", foreign_keys=[atendente_id])
+    criado_por = relationship("Atendente", foreign_keys=[criado_por_id])
+    cancelado_por = relationship("Atendente", foreign_keys=[cancelado_por_id])

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -147,6 +147,7 @@ class PontoCalendarioDia(BaseModel):
     atrasado: bool = False
     feriado: bool = False
     ausencia_tipo: str | None = None  # ferias | folga_programada
+    dia_convocado: bool = False
     pausa_abaixo_minimo: bool = False
     # #842 — meta de jornada × realizado (cores do calendário)
     segundos_trabalhados: int = 0
@@ -350,6 +351,33 @@ class PontoAusenciaRead(BaseModel):
     decidido_em: datetime | None = None
     decisao_motivo: str | None = None
     created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PontoDiaConvocadoCreate(BaseModel):
+    atendente_id: int = Field(..., ge=1)
+    data_ref: date
+    inicio: str = Field(..., min_length=5, max_length=5)
+    fim: str = Field(..., min_length=5, max_length=5)
+    motivo: str = Field(..., min_length=3, max_length=1000)
+    tolerancia_minutos: int | None = Field(default=None, ge=0, le=240)
+
+
+class PontoDiaConvocadoRead(BaseModel):
+    id: int
+    atendente_id: int
+    atendente_nome: str | None = None
+    data_ref: date
+    inicio: str
+    fim: str
+    tolerancia_minutos: int | None = None
+    motivo: str
+    estado: str
+    criado_por_id: int | None = None
+    created_at: datetime | None = None
+    cancelado_por_id: int | None = None
+    cancelado_em: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/chat_nao_lidas.py
+++ b/backend/app/services/chat_nao_lidas.py
@@ -1,0 +1,284 @@
+"""Contagem de inbound não lido e cursor de leitura por atendente (#951 / #S202608-0010)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import and_, exists, func, or_, select
+from sqlalchemy.orm import Session
+
+from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.models.atendente import Atendente
+from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+from app.models.whatsapp_chat_read import WhatsappChatRead as WhatsappChatReadModel
+
+
+# --- WhatsApp: expressões SQL reutilizáveis ---
+
+
+def wpp_seen_msg_id_subq(atendente_id: int):
+    return (
+        select(WhatsappChatReadModel.last_seen_mensagem_id)
+        .where(
+            WhatsappChatReadModel.chat_id == WhatsappChat.id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def wpp_seen_at_subq(atendente_id: int):
+    return (
+        select(WhatsappChatReadModel.last_seen_at)
+        .where(
+            WhatsappChatReadModel.chat_id == WhatsappChat.id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def wpp_eff_seen_ts(atendente_id: int):
+    return func.coalesce(
+        wpp_seen_at_subq(atendente_id),
+        WhatsappChat.atendimento_inicio_at,
+        WhatsappChat.created_at,
+    )
+
+
+def _wpp_inbound_contavel_filters():
+    return (
+        WhatsappMensagem.direcao == "inbound",
+        or_(WhatsappMensagem.evento_sistema.is_(None), WhatsappMensagem.evento_sistema == ""),
+        WhatsappMensagem.apagada_em.is_(None),
+    )
+
+
+def _wpp_inbound_apos_cursor_clause(atendente_id: int):
+    seen_msg_id = wpp_seen_msg_id_subq(atendente_id)
+    eff_ts = wpp_eff_seen_ts(atendente_id)
+    return or_(
+        and_(seen_msg_id.isnot(None), WhatsappMensagem.id > seen_msg_id),
+        and_(seen_msg_id.is_(None), WhatsappMensagem.created_at > eff_ts),
+    )
+
+
+def exists_wpp_inbound_nao_lido(atendente_id: int):
+    return exists(
+        select(WhatsappMensagem.id).where(
+            WhatsappMensagem.chat_id == WhatsappChat.id,
+            *_wpp_inbound_contavel_filters(),
+            _wpp_inbound_apos_cursor_clause(atendente_id),
+        )
+    )
+
+
+def wpp_ultima_nao_lida_at_subq(atendente_id: int):
+    return (
+        select(func.max(WhatsappMensagem.created_at))
+        .where(
+            WhatsappMensagem.chat_id == WhatsappChat.id,
+            *_wpp_inbound_contavel_filters(),
+            _wpp_inbound_apos_cursor_clause(atendente_id),
+        )
+        .scalar_subquery()
+    )
+
+
+def _ler_cursor_whatsapp(
+    db: Session, chat_id: int, atendente_id: int
+) -> tuple[datetime | None, int | None]:
+    row = (
+        db.query(WhatsappChatReadModel.last_seen_at, WhatsappChatReadModel.last_seen_mensagem_id)
+        .filter(
+            WhatsappChatReadModel.chat_id == chat_id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    if not row:
+        return None, None
+    return row[0], row[1]
+
+
+def contar_nao_lidas_whatsapp(
+    db: Session, c: WhatsappChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    """Inbound contável após o cursor de leitura do atendente."""
+    ls, cursor_id = _ler_cursor_whatsapp(db, c.id, atendente_id)
+    q = db.query(func.count(WhatsappMensagem.id)).filter(
+        WhatsappMensagem.chat_id == c.id,
+        *_wpp_inbound_contavel_filters(),
+    )
+    if cursor_id is not None:
+        q = q.filter(WhatsappMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(WhatsappMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def contar_nao_lidas_whatsapp_por_id(db: Session, chat_id: int, atendente_id: int) -> int:
+    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        return 0
+    n, _, _ = contar_nao_lidas_whatsapp(db, c, atendente_id)
+    return n
+
+
+def marcar_leitura_whatsapp(
+    db: Session,
+    chat_id: int,
+    atendente_id: int,
+    *,
+    now: datetime | None = None,
+) -> None:
+    ts = now or datetime.now(timezone.utc)
+    max_msg_id = (
+        db.query(func.max(WhatsappMensagem.id)).filter(WhatsappMensagem.chat_id == chat_id).scalar()
+    )
+    row = (
+        db.query(WhatsappChatReadModel)
+        .filter(
+            WhatsappChatReadModel.chat_id == chat_id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    if row:
+        row.last_seen_at = ts
+        row.last_seen_mensagem_id = max_msg_id
+    else:
+        db.add(
+            WhatsappChatReadModel(
+                chat_id=chat_id,
+                atendente_id=atendente_id,
+                last_seen_at=ts,
+                last_seen_mensagem_id=max_msg_id,
+            )
+        )
+
+
+def count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.estado == "em_atendimento",
+            WhatsappChat.atendente_id == atendente.id,
+            exists_wpp_inbound_nao_lido(atendente.id),
+        )
+    )
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
+    return int(db.execute(stmt).scalar_one())
+
+
+# --- Portal ---
+
+
+def portal_seen_msg_id_subq(atendente_id: int):
+    return (
+        select(PortalChatReadModel.last_seen_mensagem_id)
+        .where(
+            PortalChatReadModel.chat_id == PortalChat.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def portal_seen_at_subq(atendente_id: int):
+    return (
+        select(PortalChatReadModel.last_seen_at)
+        .where(
+            PortalChatReadModel.chat_id == PortalChat.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def portal_eff_seen_ts(atendente_id: int):
+    return func.coalesce(
+        portal_seen_at_subq(atendente_id),
+        PortalChat.atendimento_inicio_at,
+        PortalChat.created_at,
+    )
+
+
+def _portal_inbound_contavel_filters():
+    return (
+        PortalMensagem.direcao == "inbound",
+        or_(PortalMensagem.evento_sistema.is_(None), PortalMensagem.evento_sistema == ""),
+    )
+
+
+def _portal_inbound_apos_cursor_clause(atendente_id: int):
+    seen_msg_id = portal_seen_msg_id_subq(atendente_id)
+    eff_ts = portal_eff_seen_ts(atendente_id)
+    return or_(
+        and_(seen_msg_id.isnot(None), PortalMensagem.id > seen_msg_id),
+        and_(seen_msg_id.is_(None), PortalMensagem.created_at > eff_ts),
+    )
+
+
+def exists_portal_inbound_nao_lido(atendente_id: int):
+    return exists(
+        select(PortalMensagem.id).where(
+            PortalMensagem.chat_id == PortalChat.id,
+            *_portal_inbound_contavel_filters(),
+            _portal_inbound_apos_cursor_clause(atendente_id),
+        )
+    )
+
+
+def contar_nao_lidas_portal(
+    db: Session, c: PortalChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    row = (
+        db.query(PortalChatReadModel.last_seen_at, PortalChatReadModel.last_seen_mensagem_id)
+        .filter(
+            PortalChatReadModel.chat_id == c.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(PortalMensagem.id)).filter(
+        PortalMensagem.chat_id == c.id,
+        *_portal_inbound_contavel_filters(),
+    )
+    if cursor_id is not None:
+        q = q.filter(PortalMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(PortalMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def count_portal_respostas_pendentes(db: Session, atendente: Atendente) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(PortalChat)
+        .where(
+            PortalChat.estado == "em_atendimento",
+            PortalChat.atendente_id == atendente.id,
+            exists_portal_inbound_nao_lido(atendente.id),
+        )
+    )
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(or_(PortalChat.setor_id.is_(None), PortalChat.setor_id.in_(vis)))
+    return int(db.execute(stmt).scalar_one())

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -411,14 +411,21 @@ def _primeira_entrada_do_dia(batidas_dia: list[PontoBatida]) -> PontoBatida | No
     return min(entradas, key=lambda b: (_as_utc(b.registrado_em), b.id))
 
 
-def _atrasado_entrada(atendente: Atendente, entrada: PontoBatida | None) -> bool:
+def _atrasado_entrada(
+    atendente: Atendente,
+    entrada: PontoBatida | None,
+    *,
+    conv: "PontoDiaConvocado | None" = None,
+) -> bool:
     """True se a 1ª entrada passou inicio + tolerância (dentro da tol = não atraso)."""
+    from app.services import ponto_convocado as conv_svc
+
     if entrada is None:
         return False
-    if not escala_svc.escala_configurada(atendente):
+    if not conv and not escala_svc.escala_configurada(atendente):
         return False
     local = _as_utc(entrada.registrado_em).astimezone(PONTO_TZ)
-    limite = escala_svc.limite_atraso_em(atendente, local.date())
+    limite = conv_svc.limite_atraso_em(atendente, local.date(), conv)
     if limite is None:
         return False
     return local > limite
@@ -552,17 +559,22 @@ def calendario(
     usa = escala_svc.escala_configurada(atendente)
     from app.services import ponto_ausencia as ausencia_svc
     from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
 
     ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
+    convocados = conv_svc.mapa_convocados(db, atendente.id, desde=desde, ate=ate)
     pausa_min = int(getattr(settings, "pausa_minima_minutos", None) or 0)
     papeis = cob_svc.mapa_papeis_periodo(db, atendente.id, desde=desde, ate=ate)
     dias_out: list[PontoCalendarioDia] = []
     for d in dias_mes:
         feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d)
         ausencia_tipo = ausencias.get(d)
+        conv = convocados.get(d)
         esp_escala = escala_svc.eh_dia_de_trabalho(atendente, d) if usa else False
         papel = papeis.get(d)
-        if papel == "solicitante":
+        if conv:
+            esp = True
+        elif papel == "solicitante":
             esp = False
         elif papel == "cobertor":
             esp = True
@@ -571,12 +583,14 @@ def calendario(
         bats = por_dia.get(d, [])
         te = any(b.tipo == "entrada" for b in bats)
         ts = any(b.tipo == "saida" for b in bats)
-        atrasado = _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats))
+        atrasado = _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats), conv=conv)
         intervalos = _intervalos_de_batidas(bats)
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
         pausas = _segundos_pausas_do_dia(bats)
         esperado_visual = bool(esp and not feriado and not ausencia_tipo)
-        if (usa or papel == "cobertor") and esperado_visual:
+        if conv and esperado_visual:
+            esperados = conv_svc.segundos_esperados_convocado(conv) or meta_default
+        elif (usa or papel == "cobertor") and esperado_visual:
             esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
             esperados = meta_default
@@ -585,7 +599,8 @@ def calendario(
         else:
             esperados = 0
         # Sem jornada esperada: dia com batidas compara à meta; dia vazio fica neutro
-        esperado_para_cor = esperado_visual if (usa or papel) else bool(te or ts)
+        usa_para_cor = usa or papel == "cobertor" or conv is not None
+        esperado_para_cor = esperado_visual if usa_para_cor else bool(te or ts)
         dias_out.append(
             PontoCalendarioDia(
                 data=d,
@@ -593,7 +608,7 @@ def calendario(
                 tem_entrada=te,
                 tem_saida=ts,
                 status=_status_dia(  # type: ignore[arg-type]
-                    usa_escala=usa or papel == "cobertor",
+                    usa_escala=usa_para_cor,
                     esperado=esp,
                     tem_entrada=te,
                     tem_saida=ts,
@@ -604,6 +619,7 @@ def calendario(
                 atrasado=atrasado,
                 feriado=feriado,
                 ausencia_tipo=ausencia_tipo,
+                dia_convocado=conv is not None,
                 pausa_abaixo_minimo=_pausa_abaixo_minimo(
                     tem_entrada=te, segundos_pausa=pausas, pausa_minima_minutos=pausa_min
                 ),
@@ -633,7 +649,7 @@ def calendario(
 
 def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     from app.services import ponto_ausencia as ausencia_svc
-    from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
     from app.services.presenca import PRESENCA_TTL_SEC
 
     hoje = datetime.now(PONTO_TZ).date()
@@ -654,7 +670,8 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
     for a in atendentes:
         usa = escala_svc.escala_configurada(a)
         ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, a.id, hoje)
-        esperado = cob_svc.eh_dia_esperado_efetivo(db, a, hoje) if not feriado_hoje else False
+        conv = conv_svc.convocado_ativo_no_dia(db, a.id, hoje)
+        esperado = conv_svc.eh_dia_esperado_efetivo(db, a, hoje) if not feriado_hoje else False
         entrada = _entrada_da_jornada_aberta(db, a.id)
         inicio, fim = _bounds_periodo(hoje, hoje)
         bats = (
@@ -668,9 +685,9 @@ def visao_hoje(db: Session, admin: Atendente) -> PontoHojeRead:
         )
         te = any(b.tipo == "entrada" for b in bats)
         ts = any(b.tipo == "saida" for b in bats)
-        atrasado = _atrasado_entrada(a, _primeira_entrada_do_dia(bats))
+        atrasado = _atrasado_entrada(a, _primeira_entrada_do_dia(bats), conv=conv)
         st = _status_dia(
-            usa_escala=usa or esperado,
+            usa_escala=usa or esperado or conv is not None,
             esperado=esperado,
             tem_entrada=te,
             tem_saida=ts,
@@ -743,7 +760,7 @@ def banco_horas(
     ate: date,
 ) -> PontoBancoHorasRead:
     from app.services import ponto_ausencia as ausencia_svc
-    from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
 
     if ate < desde:
         raise HTTPException(status_code=400, detail="Período inválido (até < desde).")
@@ -751,6 +768,7 @@ def banco_horas(
     settings = ponto_settings_svc.get_or_create_settings(db, atendente.tenant_id)
     meta_default = int(getattr(settings, "jornada_diaria_minutos", None) or 480) * 60
     ausencias = ausencia_svc.mapa_ausencias_aprovadas(db, atendente.id, desde=desde, ate=ate)
+    convocados = conv_svc.mapa_convocados(db, atendente.id, desde=desde, ate=ate)
     dias_escala = 0
     dias_feriado = 0
     esperado = 0
@@ -760,9 +778,10 @@ def banco_horas(
         if feriado or d in ausencias:
             if feriado:
                 dias_feriado += 1
-        elif cob_svc.eh_dia_esperado_efetivo(db, atendente, d):
+        elif conv_svc.eh_dia_esperado_efetivo(db, atendente, d):
             dias_escala += 1
-            seg = escala_svc.segundos_esperados_dia(atendente, d)
+            conv = convocados.get(d)
+            seg = conv_svc.segundos_esperados_efetivo(db, atendente, d, conv)
             esperado += seg if seg > 0 else meta_default
         d += timedelta(days=1)
 
@@ -806,14 +825,16 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
     from app.services import ponto_cobertura as cob_svc
+    from app.services import ponto_convocado as conv_svc
 
     ausencia_tipo = ausencia_svc.tipo_ausencia_aprovada_no_dia(db, atendente.id, hoje)
+    conv = conv_svc.convocado_ativo_no_dia(db, atendente.id, hoje)
     jornada_ativa = escala_svc.escala_configurada(atendente) or (
         cob_svc.papel_cobertura_aprovada(db, atendente.id, hoje) is not None
-    )
+    ) or conv is not None
     esperado = None
     if not feriado and not ausencia_tipo:
-        esperado = cob_svc.eh_dia_esperado_efetivo(db, atendente, hoje)
+        esperado = conv_svc.eh_dia_esperado_efetivo(db, atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
     inicio, fim = _bounds_periodo(hoje, hoje)
@@ -849,19 +870,23 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     # Modo nenhum: sem avisos de falta/atraso/lembretes de tolerância (#959 / #968)
     if jornada_ativa:
         if esperado is True and not tem_entrada_hoje and entrada is None:
-            liberacao = escala_svc.liberacao_entrada_em(atendente, hoje)
+            liberacao = conv_svc.liberacao_entrada_em(atendente, hoje, conv)
             if liberacao is not None and agora_local >= liberacao:
                 sem_entrada = True
                 lembrete_entrada = True
-                limite = escala_svc.limite_atraso_em(atendente, hoje)
+                limite = conv_svc.limite_atraso_em(atendente, hoje, conv)
                 if limite is not None and agora_local <= limite:
                     msgs.append("Janela de entrada — registre o ponto agora.")
+                elif conv:
+                    msgs.append(
+                        "Hoje é dia convocado pela empresa e ainda não há entrada registrada."
+                    )
                 else:
                     msgs.append(
                         "Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada."
                     )
 
-        if _atrasado_entrada(atendente, primeira):
+        if _atrasado_entrada(atendente, primeira, conv=conv):
             msgs.append("Entrada registrada após o horário previsto (fora da tolerância).")
 
     if online and entrada is None:
@@ -879,8 +904,8 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
                 f"Jornada aberta há cerca de {horas_aberta:.0f} h — lembre-se de registrar a saída."
             )
         elif jornada_ativa:
-            inicio_saida = escala_svc.liberacao_saida_lembrete_em(atendente, hoje)
-            saida_prev = escala_svc.saida_prevista_em(atendente, hoje)
+            inicio_saida = conv_svc.liberacao_saida_lembrete_em(atendente, hoje, conv)
+            saida_prev = conv_svc.saida_prevista_em(atendente, hoje, conv)
             if inicio_saida is not None and agora_local >= inicio_saida:
                 lembrete_saida = True
                 if saida_prev is not None and agora_local >= saida_prev:
@@ -913,15 +938,20 @@ def _contar_atrasos_periodo(
     desde: date,
     ate: date,
 ) -> int:
-    if not escala_svc.escala_configurada(atendente):
-        return 0
+    from app.services import ponto_convocado as conv_svc
+
+    usa = escala_svc.escala_configurada(atendente)
     n = 0
     d = desde
     while d <= ate:
         if ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d):
             d += timedelta(days=1)
             continue
-        if not escala_svc.eh_dia_de_trabalho(atendente, d):
+        conv = conv_svc.convocado_ativo_no_dia(db, atendente.id, d)
+        if not conv and not usa:
+            d += timedelta(days=1)
+            continue
+        if not conv and not escala_svc.eh_dia_de_trabalho(atendente, d):
             d += timedelta(days=1)
             continue
         ini, fim = _bounds_periodo(d, d)
@@ -934,7 +964,7 @@ def _contar_atrasos_periodo(
             )
             .all()
         )
-        if _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats)):
+        if _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats), conv=conv):
             n += 1
         d += timedelta(days=1)
     return n

--- a/backend/app/services/ponto_convocado.py
+++ b/backend/app/services/ponto_convocado.py
@@ -1,0 +1,320 @@
+"""Dia convocado — trabalho fora da grade (#985)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.core.business_calendar import parse_hhmm
+from app.models.atendente import Atendente
+from app.models.ponto_dia_convocado import PontoDiaConvocado
+from app.schemas.ponto import PontoDiaConvocadoRead
+from app.services import escala as escala_svc
+from app.services.escala import PONTO_TZ
+
+
+def _to_read(row: PontoDiaConvocado) -> PontoDiaConvocadoRead:
+    return PontoDiaConvocadoRead(
+        id=row.id,
+        atendente_id=row.atendente_id,
+        atendente_nome=row.atendente.nome if row.atendente else None,
+        data_ref=row.data_ref,
+        inicio=row.inicio,
+        fim=row.fim,
+        tolerancia_minutos=row.tolerancia_minutos,
+        motivo=row.motivo,
+        estado=row.estado,
+        criado_por_id=row.criado_por_id,
+        created_at=row.created_at,
+        cancelado_por_id=row.cancelado_por_id,
+        cancelado_em=row.cancelado_em,
+    )
+
+
+def _validar_horario(inicio: str, fim: str) -> tuple[str, str]:
+    ini = parse_hhmm(inicio)
+    fim_p = parse_hhmm(fim)
+    if not ini or not fim_p:
+        raise HTTPException(status_code=400, detail="Horários inválidos (use HH:MM).")
+    if (ini[0], ini[1]) >= (fim_p[0], fim_p[1]):
+        raise HTTPException(status_code=400, detail="O início deve ser anterior ao fim (sem cruzar meia-noite).")
+    return f"{ini[0]:02d}:{ini[1]:02d}", f"{fim_p[0]:02d}:{fim_p[1]:02d}"
+
+
+def janela_horario(row: PontoDiaConvocado) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    ini = parse_hhmm(row.inicio)
+    fim = parse_hhmm(row.fim)
+    if ini and fim and (fim[0], fim[1]) > (ini[0], ini[1]):
+        return ini, fim
+    return None
+
+
+def tolerancia_efetiva(atendente: Atendente, row: PontoDiaConvocado) -> int:
+    if row.tolerancia_minutos is not None:
+        return max(0, int(row.tolerancia_minutos))
+    return int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+
+
+def segundos_esperados_convocado(row: PontoDiaConvocado) -> int:
+    janela = janela_horario(row)
+    if not janela:
+        return 0
+    pe, ps = janela
+    ini = pe[0] * 3600 + pe[1] * 60
+    fim = ps[0] * 3600 + ps[1] * 60
+    return max(0, fim - ini)
+
+
+def limite_atraso_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    if conv:
+        janela = janela_horario(conv)
+        if not janela:
+            return None
+        pe, _ = janela
+        tol = tolerancia_efetiva(atendente, conv)
+        return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) + timedelta(
+            minutes=tol
+        )
+    return escala_svc.limite_atraso_em(atendente, dia)
+
+
+def liberacao_entrada_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    if conv:
+        janela = janela_horario(conv)
+        if not janela:
+            return None
+        pe, _ = janela
+        tol = tolerancia_efetiva(atendente, conv)
+        return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) - timedelta(
+            minutes=tol
+        )
+    return escala_svc.liberacao_entrada_em(atendente, dia)
+
+
+def saida_prevista_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    if conv:
+        janela = janela_horario(conv)
+        if not janela:
+            return None
+        _, ps = janela
+        return datetime.combine(dia, time(hour=ps[0], minute=ps[1]), tzinfo=PONTO_TZ)
+    return escala_svc.saida_prevista_em(atendente, dia)
+
+
+def liberacao_saida_lembrete_em(
+    atendente: Atendente, dia: date, conv: PontoDiaConvocado | None
+) -> datetime | None:
+    saida = saida_prevista_em(atendente, dia, conv)
+    if saida is None:
+        return None
+    if conv:
+        tol = tolerancia_efetiva(atendente, conv)
+        return saida - timedelta(minutes=tol)
+    return escala_svc.liberacao_saida_lembrete_em(atendente, dia)
+
+
+def convocado_ativo_no_dia(db: Session, atendente_id: int, dia: date) -> PontoDiaConvocado | None:
+    return (
+        db.query(PontoDiaConvocado)
+        .filter(
+            PontoDiaConvocado.atendente_id == atendente_id,
+            PontoDiaConvocado.data_ref == dia,
+            PontoDiaConvocado.estado == "ativa",
+        )
+        .first()
+    )
+
+
+def mapa_convocados(
+    db: Session, atendente_id: int, *, desde: date, ate: date
+) -> dict[date, PontoDiaConvocado]:
+    rows = (
+        db.query(PontoDiaConvocado)
+        .filter(
+            PontoDiaConvocado.atendente_id == atendente_id,
+            PontoDiaConvocado.estado == "ativa",
+            PontoDiaConvocado.data_ref >= desde,
+            PontoDiaConvocado.data_ref <= ate,
+        )
+        .all()
+    )
+    return {r.data_ref: r for r in rows}
+
+
+def eh_dia_esperado_efetivo(db: Session, atendente: Atendente, dia: date) -> bool:
+    """Dia esperado incluindo convocação (#985) e cobertura (#970)."""
+    if convocado_ativo_no_dia(db, atendente.id, dia):
+        return True
+    from app.services import ponto_cobertura as cob_svc
+
+    return cob_svc.eh_dia_esperado_efetivo(db, atendente, dia)
+
+
+def segundos_esperados_efetivo(
+    db: Session, atendente: Atendente, dia: date, conv: PontoDiaConvocado | None = None
+) -> int:
+    row = conv or convocado_ativo_no_dia(db, atendente.id, dia)
+    if row:
+        seg = segundos_esperados_convocado(row)
+        if seg > 0:
+            return seg
+    return escala_svc.segundos_esperados_dia(atendente, dia)
+
+
+def _atendente_tenant(db: Session, tenant_id: int, atendente_id: int) -> Atendente:
+    a = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == tenant_id,
+            Atendente.role != "saas_ops",
+            Atendente.ativo.is_(True),
+        )
+        .first()
+    )
+    if not a:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    return a
+
+
+def _checar_conflitos(
+    db: Session,
+    *,
+    tenant_id: int,
+    atendente_id: int,
+    data_ref: date,
+) -> None:
+    from app.services import ponto_ausencia as ausencia_svc
+
+    if ausencia_svc.tipo_ausencia_aprovada_no_dia(db, atendente_id, data_ref):
+        raise HTTPException(
+            status_code=400,
+            detail="Já há férias ou folga programada nesta data.",
+        )
+    existente = convocado_ativo_no_dia(db, atendente_id, data_ref)
+    if existente:
+        raise HTTPException(status_code=400, detail="Já existe convocação ativa nesta data.")
+
+
+def criar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int,
+    data_ref: date,
+    inicio: str,
+    fim: str,
+    motivo: str,
+    tolerancia_minutos: int | None = None,
+) -> PontoDiaConvocadoRead:
+    if data_ref < date.today():
+        raise HTTPException(status_code=400, detail="A data deve ser hoje ou futura.")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(status_code=400, detail="Informe o motivo (mínimo 3 caracteres).")
+    ini_s, fim_s = _validar_horario(inicio, fim)
+    alvo = _atendente_tenant(db, admin.tenant_id, atendente_id)
+    _checar_conflitos(db, tenant_id=admin.tenant_id, atendente_id=alvo.id, data_ref=data_ref)
+    if tolerancia_minutos is not None and tolerancia_minutos < 0:
+        raise HTTPException(status_code=400, detail="Tolerância inválida.")
+    row = PontoDiaConvocado(
+        tenant_id=admin.tenant_id,
+        atendente_id=alvo.id,
+        data_ref=data_ref,
+        inicio=ini_s,
+        fim=fim_s,
+        tolerancia_minutos=tolerancia_minutos,
+        motivo=motivo_limpo[:1000],
+        estado="ativa",
+        criado_por_id=admin.id,
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_dia_convocado",
+        row.id,
+        "create",
+        admin.id,
+        payload={
+            "atendente_id": alvo.id,
+            "data_ref": str(data_ref),
+            "inicio": ini_s,
+            "fim": fim_s,
+            "motivo": motivo_limpo,
+        },
+    )
+    db.commit()
+    return _to_read(
+        db.query(PontoDiaConvocado)
+        .options(joinedload(PontoDiaConvocado.atendente))
+        .filter(PontoDiaConvocado.id == row.id)
+        .first()  # type: ignore[arg-type]
+    )
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None = None,
+    desde: date | None = None,
+    ate: date | None = None,
+    estado: str | None = "ativa",
+) -> list[PontoDiaConvocadoRead]:
+    q = (
+        db.query(PontoDiaConvocado)
+        .options(joinedload(PontoDiaConvocado.atendente))
+        .filter(PontoDiaConvocado.tenant_id == admin.tenant_id)
+    )
+    if atendente_id is not None:
+        q = q.filter(PontoDiaConvocado.atendente_id == atendente_id)
+    if desde is not None:
+        q = q.filter(PontoDiaConvocado.data_ref >= desde)
+    if ate is not None:
+        q = q.filter(PontoDiaConvocado.data_ref <= ate)
+    if estado:
+        q = q.filter(PontoDiaConvocado.estado == estado)
+    rows = q.order_by(PontoDiaConvocado.data_ref.asc(), PontoDiaConvocado.id.asc()).limit(200).all()
+    return [_to_read(r) for r in rows]
+
+
+def cancelar_admin(db: Session, admin: Atendente, convocado_id: int) -> PontoDiaConvocadoRead:
+    row = (
+        db.query(PontoDiaConvocado)
+        .options(joinedload(PontoDiaConvocado.atendente))
+        .filter(
+            PontoDiaConvocado.id == convocado_id,
+            PontoDiaConvocado.tenant_id == admin.tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Convocação não encontrada")
+    if row.estado != "ativa":
+        raise HTTPException(status_code=400, detail="Esta convocação já foi cancelada.")
+    if row.data_ref < date.today():
+        raise HTTPException(status_code=400, detail="Só é possível cancelar convocações de hoje em diante.")
+    row.estado = "cancelada"
+    row.cancelado_por_id = admin.id
+    row.cancelado_em = datetime.now(timezone.utc)
+    registrar_audit(
+        db,
+        "ponto_dia_convocado",
+        row.id,
+        "cancelar",
+        admin.id,
+        payload={"atendente_id": row.atendente_id, "data_ref": str(row.data_ref)},
+    )
+    db.commit()
+    db.refresh(row)
+    return _to_read(row)

--- a/backend/app/services/saas_provisionamento.py
+++ b/backend/app/services/saas_provisionamento.py
@@ -161,9 +161,9 @@ def montar_comandos_ops(row: ClienteSaaS) -> str | None:
     port = row.api_port
     port_txt = str(port) if port is not None else "<api_port>"
     slug = row.slug
-    from app.services.saas_solicitacao_ingest import ingest_url_publica
+    from app.services.saas_solicitacao_ingest import ingest_url_para_client_env
 
-    ingest_url = ingest_url_publica()
+    ingest_url = ingest_url_para_client_env()
     return (
         f"# Na raiz do repositório no host de deploy\n"
         f"./deploy/scripts/provision-client.sh --slug {slug} --base-domain {base} --api-port {port_txt}\n"

--- a/backend/app/services/saas_solicitacao_ingest.py
+++ b/backend/app/services/saas_solicitacao_ingest.py
@@ -55,6 +55,14 @@ def ingest_url_publica() -> str:
     return f"https://api.{base}/v1/saas/ingest/solicitacoes"
 
 
+def ingest_url_para_client_env() -> str:
+    """URL escrita no client.env da instância (worker server-to-server)."""
+    loopback = (settings.SAAS_INGEST_LOOPBACK_URL or "").strip()
+    if loopback:
+        return loopback.rstrip("/")
+    return ingest_url_publica()
+
+
 def instance_slug_local() -> str:
     slug = (settings.SAAS_INSTANCE_SLUG or "").strip().lower()
     if slug:
@@ -504,7 +512,7 @@ def escrever_ingest_no_client_env(row: ClienteSaaS, *, token: str | None = None)
         return
     text = env_path.read_text(encoding="utf-8")
     text = _set_env_line(text, "SAAS_INSTANCE_SLUG", row.slug)
-    text = _set_env_line(text, "SAAS_CONTROL_PLANE_INGEST_URL", ingest_url_publica())
+    text = _set_env_line(text, "SAAS_CONTROL_PLANE_INGEST_URL", ingest_url_para_client_env())
     if token:
         text = _set_env_line(text, "SAAS_INSTANCE_INGEST_TOKEN", token)
     env_path.write_text(text, encoding="utf-8")

--- a/backend/tests/test_alembic_134_idempotent.py
+++ b/backend/tests/test_alembic_134_idempotent.py
@@ -1,0 +1,154 @@
+"""Idempotência da migration 134 — ponto_dias_convocados (#985)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import event
+from sqlalchemy.pool import StaticPool
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1] / "alembic" / "versions" / "134_ponto_dia_convocado_985.py"
+)
+
+_OPTIONAL_COLUMNS = frozenset(
+    {
+        "tolerancia_minutos",
+        "estado",
+        "criado_por_id",
+        "created_at",
+        "cancelado_por_id",
+        "cancelado_em",
+    }
+)
+
+_EXPECTED_INDEXES = frozenset(
+    {
+        "ix_ponto_dias_convocados_tenant_id",
+        "ix_ponto_dias_convocados_atendente_id",
+        "ix_ponto_dias_convocados_data_ref",
+        "ix_ponto_dias_convocados_atendente_data",
+    }
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_134", _MIGRATION_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sqlite_engine():
+    engine = sa.create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _pragma_fk(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
+
+
+def _bootstrap_parents(conn) -> None:
+    conn.execute(sa.text("CREATE TABLE tenants (id INTEGER PRIMARY KEY)"))
+    conn.execute(sa.text("CREATE TABLE atendentes (id INTEGER PRIMARY KEY)"))
+    conn.execute(sa.text("INSERT INTO tenants (id) VALUES (1)"))
+    conn.execute(sa.text("INSERT INTO atendentes (id) VALUES (1)"))
+
+
+def _run_upgrade(migration, engine) -> None:
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            migration.upgrade()
+
+
+def _create_partial_convocados_table(conn) -> None:
+    """Núcleo obrigatório + FKs como INTEGER (DDL manual típico); faltam opcionais simples."""
+    conn.execute(
+        sa.text(
+            """
+            CREATE TABLE ponto_dias_convocados (
+                id INTEGER PRIMARY KEY,
+                tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+                atendente_id INTEGER NOT NULL REFERENCES atendentes(id),
+                data_ref DATE NOT NULL,
+                inicio VARCHAR(5) NOT NULL,
+                fim VARCHAR(5) NOT NULL,
+                motivo VARCHAR(1000) NOT NULL,
+                criado_por_id INTEGER,
+                cancelado_por_id INTEGER
+            )
+            """
+        )
+    )
+
+
+def _create_full_convocados_table_without_indexes(conn) -> None:
+    conn.execute(
+        sa.text(
+            """
+            CREATE TABLE ponto_dias_convocados (
+                id INTEGER PRIMARY KEY,
+                tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+                atendente_id INTEGER NOT NULL REFERENCES atendentes(id),
+                data_ref DATE NOT NULL,
+                inicio VARCHAR(5) NOT NULL,
+                fim VARCHAR(5) NOT NULL,
+                tolerancia_minutos INTEGER,
+                motivo VARCHAR(1000) NOT NULL,
+                estado VARCHAR(20) NOT NULL DEFAULT 'ativa',
+                criado_por_id INTEGER REFERENCES atendentes(id),
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                cancelado_por_id INTEGER REFERENCES atendentes(id),
+                cancelado_em DATETIME
+            )
+            """
+        )
+    )
+
+
+def _assert_schema_complete(engine) -> None:
+    insp = sa.inspect(engine)
+    assert insp.has_table("ponto_dias_convocados")
+    cols = {c["name"] for c in insp.get_columns("ponto_dias_convocados")}
+    assert _OPTIONAL_COLUMNS.issubset(cols)
+    idxs = {i["name"] for i in insp.get_indexes("ponto_dias_convocados")}
+    assert _EXPECTED_INDEXES.issubset(idxs)
+
+
+def test_134_upgrade_idempotente_tabela_parcial():
+    """DDL manual com núcleo + FKs como INTEGER; upgrade duas vezes completa opcionais simples."""
+    migration = _load_migration()
+    engine = _sqlite_engine()
+    with engine.begin() as conn:
+        _bootstrap_parents(conn)
+        _create_partial_convocados_table(conn)
+
+    _run_upgrade(migration, engine)
+    _run_upgrade(migration, engine)
+    _assert_schema_complete(engine)
+
+
+def test_134_upgrade_idempotente_tabela_completa_sem_indices():
+    """Tabela completa criada manualmente sem índices: upgrade duas vezes cria índices."""
+    migration = _load_migration()
+    engine = _sqlite_engine()
+    with engine.begin() as conn:
+        _bootstrap_parents(conn)
+        _create_full_convocados_table_without_indexes(conn)
+
+    _run_upgrade(migration, engine)
+    _run_upgrade(migration, engine)
+    _assert_schema_complete(engine)

--- a/backend/tests/test_ponto_dia_convocado_985.py
+++ b/backend/tests/test_ponto_dia_convocado_985.py
@@ -1,0 +1,180 @@
+"""Dia convocado — trabalho fora da grade (#985)."""
+
+from datetime import date, datetime, timedelta, timezone
+
+from app.services.escala import PONTO_TZ
+
+
+def _folga_total(client, headers, atendente_id: int):
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={"modo_jornada": "nenhum", "usa_escala": False},
+    )
+
+
+def test_convocado_folga_gera_falta_e_esperado(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    amanha = date.today() + timedelta(days=1)
+    r = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": amanha.isoformat(),
+            "inicio": "09:00",
+            "fim": "13:00",
+            "motivo": "Inventário no posto",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["estado"] == "ativa"
+    assert body["inicio"] == "09:00"
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={amanha.year}&mes={amanha.month}",
+        headers=user,
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == amanha.isoformat())
+    assert dia["esperado"] is True
+    assert dia["dia_convocado"] is True
+    assert dia["status"] == "falta"
+    assert dia["segundos_esperados"] == 4 * 3600
+
+
+def test_convocado_atraso_usa_janela_propria(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    alvo = date.today() + timedelta(days=2)
+    assert (
+        client.post(
+            "/v1/ponto/convocados/conceder",
+            headers=admin,
+            json={
+                "atendente_id": a1.id,
+                "data_ref": alvo.isoformat(),
+                "inicio": "08:00",
+                "fim": "12:00",
+                "motivo": "Plantão",
+                "tolerancia_minutos": 0,
+            },
+        ).status_code
+        == 201
+    )
+    entrada = datetime(alvo.year, alvo.month, alvo.day, 8, 30, tzinfo=PONTO_TZ)
+    bat = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": entrada.astimezone(timezone.utc).isoformat(),
+            "motivo": "teste convocado atraso",
+        },
+    )
+    assert bat.status_code == 201, bat.text
+    cal = client.get(
+        f"/v1/ponto/me/calendario?ano={alvo.year}&mes={alvo.month}",
+        headers=user,
+    )
+    dia = next(d for d in cal.json()["dias"] if d["data"] == alvo.isoformat())
+    assert dia["atrasado"] is True
+
+
+def test_convocado_cancelar_futuro(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    futuro = date.today() + timedelta(days=5)
+    criado = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": futuro.isoformat(),
+            "inicio": "10:00",
+            "fim": "14:00",
+            "motivo": "Evento",
+        },
+    )
+    assert criado.status_code == 201
+    cid = criado.json()["id"]
+    cancel = client.delete(f"/v1/ponto/convocados/{cid}", headers=admin)
+    assert cancel.status_code == 200
+    assert cancel.json()["estado"] == "cancelada"
+    lista = client.get("/v1/ponto/convocados?estado=ativa", headers=admin)
+    assert all(x["id"] != cid for x in lista.json())
+
+
+def test_convocado_cancelar_reverte_calendario(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert _folga_total(client, admin, a1.id).status_code == 200
+    futuro = date.today() + timedelta(days=4)
+    criado = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": futuro.isoformat(),
+            "inicio": "09:00",
+            "fim": "13:00",
+            "motivo": "Inventário",
+        },
+    )
+    assert criado.status_code == 201
+    cid = criado.json()["id"]
+    cal1 = client.get(
+        f"/v1/ponto/me/calendario?ano={futuro.year}&mes={futuro.month}",
+        headers=user,
+    )
+    dia1 = next(d for d in cal1.json()["dias"] if d["data"] == futuro.isoformat())
+    assert dia1["esperado"] is True
+    assert client.delete(f"/v1/ponto/convocados/{cid}", headers=admin).status_code == 200
+    cal2 = client.get(
+        f"/v1/ponto/me/calendario?ano={futuro.year}&mes={futuro.month}",
+        headers=user,
+    )
+    dia2 = next(d for d in cal2.json()["dias"] if d["data"] == futuro.isoformat())
+    assert dia2["esperado"] is False
+    assert dia2["dia_convocado"] is False
+    assert dia2["status"] in ("folga", "livre")
+
+
+def test_convocado_conflita_com_ausencia(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    dia = date.today() + timedelta(days=3)
+    assert (
+        client.post(
+            "/v1/ponto/ausencias/conceder",
+            headers=admin,
+            json={
+                "atendente_id": a1.id,
+                "tipo": "folga_programada",
+                "desde": dia.isoformat(),
+                "ate": dia.isoformat(),
+                "motivo": "Folga",
+            },
+        ).status_code
+        == 201
+    )
+    r = client.post(
+        "/v1/ponto/convocados/conceder",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "data_ref": dia.isoformat(),
+            "inicio": "08:00",
+            "fim": "12:00",
+            "motivo": "Conflito",
+        },
+    )
+    assert r.status_code == 400

--- a/backend/tests/test_ponto_lote_d_969_974.py
+++ b/backend/tests/test_ponto_lote_d_969_974.py
@@ -1,8 +1,6 @@
 """Lote D: solicitação HE (#969) + teto mensal (#974)."""
 
-from datetime import date, datetime, timedelta
-
-from app.services.escala import PONTO_TZ
+from datetime import date
 
 
 def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
@@ -177,8 +175,7 @@ def test_me_status_campos_mensais(client, seed_base, auth_headers):
         headers=admin,
         json={"he_teto_mensal_minutos": 120},
     ).status_code == 200
-    fim = (datetime.now(PONTO_TZ) + timedelta(hours=2)).strftime("%H:%M")
-    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    assert _patch_jornada_semanal(client, admin, a1.id, fim="18:00").status_code == 200
     st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
     assert st.status_code == 200
     body = st.json()

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -976,3 +976,17 @@ def test_versao_alvo_rotulo_so_apos_release(client, seed_base, auth_headers, mon
         json={"versao_alvo": "2026.09.01"},
     )
     assert inexistente.status_code == 404
+
+
+def test_ingest_url_para_client_env_prefere_loopback(monkeypatch):
+    from app.config import settings
+    from app.services.saas_solicitacao_ingest import ingest_url_para_client_env, ingest_url_publica
+
+    monkeypatch.setattr(
+        settings,
+        "SAAS_INGEST_LOOPBACK_URL",
+        "http://127.0.0.1:8001/v1/saas/ingest/solicitacoes",
+    )
+    assert ingest_url_para_client_env() == "http://127.0.0.1:8001/v1/saas/ingest/solicitacoes"
+    monkeypatch.setattr(settings, "SAAS_INGEST_LOOPBACK_URL", "")
+    assert ingest_url_para_client_env() == ingest_url_publica()

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -100,6 +100,107 @@ def test_meus_e_visto_contam_nao_lidas(client, seed_base, auth_headers):
     assert row2["nao_lidas_count"] == 0
 
 
+def test_enviar_ao_cliente_zera_nao_lidas(client, seed_base, auth_headers, monkeypatch, db_session):
+    """#S202608-0010: resposta outbound pelo responsável zera nao_lidas_count."""
+    seq = {"n": 0}
+
+    def fake_send(*_a, **_k):
+        seq["n"] += 1
+        return True, None, f"wa-reply-nl-{seq['n']}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "nl-reply",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "nl-reply"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666556", msg_id="nl-r1", text="oi"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    assert client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"]).status_code == 200
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666556", msg_id="nl-r2", text="preciso de ajuda"),
+        headers=h,
+    )
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row = next(c for c in meus if c["id"] == cid)
+    assert row["nao_lidas_count"] >= 1
+
+    r_send = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Claro, como posso ajudar?"},
+        headers=auth_headers["a1"],
+    )
+    assert r_send.status_code == 201
+
+    meus2 = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row2 = next(c for c in meus2 if c["id"] == cid)
+    assert row2["nao_lidas_count"] == 0
+
+    from app.api.notificacoes import build_notificacao_resumo
+
+    resumo = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo.wpp_respostas_count == 0
+
+
+def test_wpp_respostas_resumo_alinhado_com_meus(client, seed_base, auth_headers, db_session):
+    """#S202608-0010: sino (resumo/itens) e lista meus usam a mesma regra de não lidas."""
+    from app.api.notificacoes import build_notificacao_itens, build_notificacao_resumo
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "nl-align"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "nl-align"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666777", msg_id="nl-align-1", text="oi"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    assert client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"]).status_code == 200
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666777", msg_id="nl-align-2", text="nova"),
+        headers=h,
+    )
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row = next(c for c in meus if c["id"] == cid)
+    assert row["nao_lidas_count"] >= 1
+
+    resumo = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo.wpp_respostas_count >= 1
+
+    itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
+    wpp_itens = [i for i in itens if i.tipo == "wpp_chats_com_resposta" and i.chat_id == cid]
+    assert len(wpp_itens) >= 1
+    assert wpp_itens[0].count >= 1
+
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    meus2 = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row2 = next(c for c in meus2 if c["id"] == cid)
+    assert row2["nao_lidas_count"] == 0
+    resumo2 = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo2.wpp_respostas_count == 0
+
+
 def test_listar_encerrados_filtra_e_respeita_rbac(client, seed_base, auth_headers):
     client.patch(
         "/v1/settings/whatsapp",

--- a/deploy/admin-center/README.md
+++ b/deploy/admin-center/README.md
@@ -48,7 +48,7 @@ Painel DuplexSoft continua em `/opt/dx-connect/frontend/dist` (API `api-duplexso
 
 1. Migrar tabelas SaaS + mídia `solicitacao_media` + `protocol_sequences` (`kind=S`) + contas `saas_ops` para o Postgres do `admin-center`
 2. Criar licença `clientes_saas` slug `duplexsoft` e token de ingest
-3. Na DuplexSoft (`backend/.env`): `SAAS_CONTROL_PLANE=false`, `SAAS_INSTANCE_SLUG=duplexsoft`, `SAAS_CONTROL_PLANE_INGEST_URL` + `SAAS_INSTANCE_INGEST_TOKEN`
+3. Na DuplexSoft (`backend/.env`): `SAAS_CONTROL_PLANE=false`, `SAAS_INSTANCE_SLUG=duplexsoft`, `SAAS_CONTROL_PLANE_INGEST_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes` + `SAAS_INSTANCE_INGEST_TOKEN`
 4. Desativar contas `saas_ops` na BD DuplexSoft (ficam só na comercial)
 5. Health esperado: `api.deskrudder.com.br` → `saas_control_plane: true`; `api-duplexsoft…` → `false`
 

--- a/deploy/admin-center/client.env.example
+++ b/deploy/admin-center/client.env.example
@@ -46,6 +46,8 @@ SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
 # Clientes novos começam em 8002; 8001 é desta API comercial
 SAAS_PROVISION_API_PORT_START=8002
 SAAS_INGEST_PUBLIC_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+# Gravada no client.env das instâncias na mesma VPS (worker server-to-server). Vazio = usa URL pública.
+SAAS_INGEST_LOOPBACK_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes
 SAAS_NOTIFY_EMAIL=comercial@deskrudder.com.br
 SAAS_TRIAL_DAYS=14
 SAAS_RENEWAL_ALERT_DAYS_BEFORE=14

--- a/deploy/clients/_template/client.env.example
+++ b/deploy/clients/_template/client.env.example
@@ -52,6 +52,8 @@ SEED_ADMIN_PASSWORD=ALTERE_SENHA_ADMIN_INICIAL
 SAAS_MODULOS=helpdesk
 
 # Fila de sugestões → control-plane DeskRudder (#855 / #856). Preenchido no provisionamento.
+# Na mesma VPS que o admin-center, o control-plane grava loopback (127.0.0.1:8001) para o worker
+# não passar pelo Cloudflare. Instância remota: deixe SAAS_INGEST_LOOPBACK_URL vazio no admin-center.
 SAAS_INSTANCE_SLUG=exemplo
 SAAS_CONTROL_PLANE_INGEST_URL=
 SAAS_INSTANCE_INGEST_TOKEN=

--- a/docs/ALEMBIC_MIGRATIONS.md
+++ b/docs/ALEMBIC_MIGRATIONS.md
@@ -30,3 +30,39 @@ Se `history`/`heads` já falhar, há inconsistência de `revision`/`down_revisio
 
 Se `alembic heads` listar **mais de uma** revision, `alembic upgrade head` falha no deploy. Crie uma migration de **merge** (sem DDL) com `down_revision` em tupla apontando para cada head — ver `029_merge_ticket_parent_and_outbox_heads.py`.
 
+## Hotfix manual (DDL antes do deploy)
+
+Em produção, às vezes é necessário aplicar SQL manual **antes** do release (ex.: coluna faltando que quebra login). Regras:
+
+1. **Preferir** `ALTER TABLE … ADD COLUMN IF NOT EXISTS` (Postgres) — alinhado ao que a migration idempotente faria no próximo deploy.
+2. **Não** alterar `alembic_version` à mão, salvo `alembic stamp` planejado com o time.
+3. Migrations idempotentes do repo (`has_table`, `_ensure_columns`, `_ensure_indexes`) **não** recriam colunas obrigatórias ausentes — só completam colunas opcionais e índices quando a tabela já existe.
+
+### Exemplo: `134_ponto_dia_convocado_985` (#985)
+
+Se `ponto_dias_convocados` foi criada manualmente:
+
+| Situação | O que a migration faz |
+|----------|------------------------|
+| Tabela não existe | `CREATE TABLE` + índices |
+| Tabela existe, faltam colunas opcionais (`tolerancia_minutos`, `estado`, `criado_por_id`, `created_at`, `cancelado_*`) | `ADD COLUMN` só das ausentes |
+| Tabela existe, faltam índices | `CREATE INDEX` dos ausentes |
+| Tabela existe **sem** colunas obrigatórias (`tenant_id`, `atendente_id`, `data_ref`, `inicio`, `fim`, `motivo`) | **Não corrige** — o DDL manual deve incluir o núcleo; ajuste o SQL na VPS ou recrie a tabela |
+
+SQL mínimo aceitável para hotfix manual (Postgres):
+
+```sql
+CREATE TABLE IF NOT EXISTS ponto_dias_convocados (
+    id SERIAL PRIMARY KEY,
+    tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+    atendente_id INTEGER NOT NULL REFERENCES atendentes(id) ON DELETE CASCADE,
+    data_ref DATE NOT NULL,
+    inicio VARCHAR(5) NOT NULL,
+    fim VARCHAR(5) NOT NULL,
+    motivo VARCHAR(1000) NOT NULL
+);
+-- Colunas opcionais e índices: o deploy (migration 134) completa se faltarem.
+```
+
+Teste automatizado: `backend/tests/test_alembic_134_idempotent.py`.
+

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -116,9 +116,11 @@ No `client.env` (provisionamento):
 
 ```
 SAAS_INSTANCE_SLUG=<slug da licença>
-SAAS_CONTROL_PLANE_INGEST_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+SAAS_CONTROL_PLANE_INGEST_URL=http://127.0.0.1:8001/v1/saas/ingest/solicitacoes
 SAAS_INSTANCE_INGEST_TOKEN=<gerado no painel SaaS, nunca no browser>
 ```
+
+Na **mesma VPS** que o admin-center, use a URL **loopback** acima no `backend/.env` da instância (o worker `saas-triagem-pull` chama a API sem passar pelo Cloudflare). O provisionamento grava essa URL automaticamente quando `SAAS_INGEST_LOOPBACK_URL` está definido no control-plane (padrão). Instância em **outro servidor**: deixe `SAAS_INGEST_LOOPBACK_URL` vazio no admin-center e use a URL pública `https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes`.
 
 Sem URL/token/slug, o pedido local continua; a cópia simplesmente não é enviada. Falha HTTP não faz rollback — a outbox (`webhook_outbox`, eventos `saas.solicitacao` e `saas.solicitacao.media`) tenta de novo. O JSON vai primeiro; a mídia (prints/anexos) segue em multipart para não meter ficheiros no payload JSON.
 
@@ -139,7 +141,8 @@ No control-plane (`SAAS_CONTROL_PLANE=true`), a abertura grava directo na tabela
 - `POST /v1/saas/me/mcp-token` — gera o token Cursor desta conta (plaintext uma vez). `GET` estado; `DELETE` revoga.
 - `GET/POST /v1/saas/usuarios` e `PATCH /v1/saas/usuarios/{id}` — equipa `saas_ops` (nome, e-mail, activo). `POST …/senha-temporaria` devolve senha uma vez. Não são atendentes da instância do cliente.
 - `POST /v1/saas/clientes/{id}/gerar-token-ingest` — devolve o plaintext **uma vez** e escreve no `client.env` se a pasta do cliente já existir.
-- `SAAS_INGEST_PUBLIC_URL` (opcional) — URL escrita no env das instâncias; por omissão `https://api.{SAAS_PROVISION_BASE_DOMAIN}/v1/saas/ingest/solicitacoes`.
+- `SAAS_INGEST_PUBLIC_URL` (opcional) — URL pública documentada; usada no `client.env` só se `SAAS_INGEST_LOOPBACK_URL` estiver vazio.
+- `SAAS_INGEST_LOOPBACK_URL` (control-plane, padrão `http://127.0.0.1:8001/v1/saas/ingest/solicitacoes`) — gravada no `client.env` das instâncias na mesma VPS.
 
 Handoff Cursor é #857: o Cursor **puxa** a fila (MCP `deskrudder-saas`) contra a **API do control-plane**, não o contrário.
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -807,6 +807,15 @@ export const ponto = {
     }),
   removerAusencia: (id: number) =>
     api<void>(`/ponto/ausencias/${id}`, { method: 'DELETE' }),
+  convocadosAdmin: (params?: { atendente_id?: number; desde?: string; ate?: string; estado?: string }) =>
+    api<Ponto.DiaConvocado[]>(withParams('/ponto/convocados', params)),
+  concederDiaConvocado: (data: Ponto.DiaConvocadoCreate) =>
+    api<Ponto.DiaConvocado>('/ponto/convocados/conceder', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  cancelarDiaConvocado: (id: number) =>
+    api<Ponto.DiaConvocado>(`/ponto/convocados/${id}`, { method: 'DELETE' }),
   horaExtraMeStatus: () => api<Ponto.HoraExtraMeStatus>('/ponto/hora-extra/me/status'),
   minhasHoraExtra: () => api<Ponto.HoraExtra[]>('/ponto/hora-extra/me'),
   solicitarHoraExtra: (data?: Ponto.HoraExtraCreate) =>
@@ -4970,6 +4979,7 @@ export namespace Ponto {
     atrasado?: boolean
     feriado?: boolean
     ausencia_tipo?: string | null
+    dia_convocado?: boolean
     pausa_abaixo_minimo?: boolean
     segundos_trabalhados?: number
     segundos_esperados?: number
@@ -5176,6 +5186,29 @@ export namespace Ponto {
     decidido_em?: string | null
     decisao_motivo?: string | null
     created_at?: string | null
+  }
+  export interface DiaConvocadoCreate {
+    atendente_id: number
+    data_ref: string
+    inicio: string
+    fim: string
+    motivo: string
+    tolerancia_minutos?: number | null
+  }
+  export interface DiaConvocado {
+    id: number
+    atendente_id: number
+    atendente_nome?: string | null
+    data_ref: string
+    inicio: string
+    fim: string
+    tolerancia_minutos?: number | null
+    motivo: string
+    estado: string
+    criado_por_id?: number | null
+    created_at?: string | null
+    cancelado_por_id?: number | null
+    cancelado_em?: string | null
   }
   export interface CoberturaCreate {
     cobertor_id: number

--- a/frontend/src/components/PontoCalendarioMes.tsx
+++ b/frontend/src/components/PontoCalendarioMes.tsx
@@ -223,6 +223,7 @@ export function PontoCalendarioMes({
               : detalhe.ausencia_tipo === 'folga_programada'
                 ? ' · Folga programada'
                 : ''}
+            {detalhe.dia_convocado ? ' · Dia convocado' : ''}
             {detalhe.pausa_abaixo_minimo ? ' · Pausa abaixo do mínimo' : ''}
           </p>
           <p className="mt-2 text-xs text-cyan-700 dark:text-cyan-300">

--- a/frontend/src/components/release/ReleaseNotesView.tsx
+++ b/frontend/src/components/release/ReleaseNotesView.tsx
@@ -7,6 +7,8 @@ import { Button } from '../../components/ui/Button'
 import { VoltarButton } from '../../components/ui/VoltarButton'
 import { BrandLogo } from '../../brand'
 import { PageContainer } from '../../components/ui/PageContainer'
+import { SolicitacoesMelhoriaListaTable } from '../solicitacoes/SolicitacoesMelhoriaListaTable'
+import { SolicitacoesMelhoriaListaSkeleton } from '../solicitacoes/SolicitacoesMelhoriaListaSkeleton'
 
 const CATEGORY_LABEL: Record<string, string> = {
   melhorias: 'Melhorias',
@@ -117,15 +119,9 @@ export type ReleaseNotesViewProps = {
   showProductTags?: boolean
 }
 
-function formatWhen(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
-  } catch {
-    return iso
-  }
-}
+/** Lista compartilhada de versão + histórico (#674 / #920). */
 
-/** Lista partilhada de versão + histórico (#674 / #920). */
+const PREVIEW_MINHAS = 5
 export function ReleaseNotesView({
   backTo,
   backLabel = 'Voltar',
@@ -141,11 +137,13 @@ export function ReleaseNotesView({
 }: ReleaseNotesViewProps) {
   const navigate = useNavigate()
   const [minhas, setMinhas] = useState<SolicitacoesMelhoria.ListaItem[]>([])
+  const [loadingMinhas, setLoadingMinhas] = useState(showSugestoesCta)
   const pastReleases = (notes?.releases ?? []).filter((r) => r.version !== notes?.current?.version)
 
   useEffect(() => {
     if (!showSugestoesCta) return
     let cancelled = false
+    setLoadingMinhas(true)
     void solicitacoesMelhoria
       .minhas()
       .then((rows) => {
@@ -153,6 +151,9 @@ export function ReleaseNotesView({
       })
       .catch(() => {
         if (!cancelled) setMinhas([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingMinhas(false)
       })
     return () => {
       cancelled = true
@@ -201,40 +202,52 @@ export function ReleaseNotesView({
             >
               Enviar sugestão / relatar problema
             </Button>
+            {loadingMinhas ? null : minhas.length > 0 ? (
+              <Link
+                to="/minhas-solicitacoes"
+                className="text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+              >
+                Minhas solicitações ({minhas.length})
+              </Link>
+            ) : null}
           </div>
         ) : null}
       </Card>
 
       {showSugestoesCta ? (
-        <Card title="Minhas solicitações">
-          {minhas.length === 0 ? (
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Ainda não enviou nenhum pedido. Use o botão acima para sugerir uma melhoria ou relatar um problema.
-            </p>
-          ) : (
-            <ul className="divide-y divide-slate-100 dark:divide-slate-800">
-              {minhas.slice(0, 8).map((item) => (
-                <li key={item.id}>
-                  <Link
-                    to={`/minhas-solicitacoes/${item.id}`}
-                    className="flex flex-wrap items-baseline justify-between gap-2 py-3 text-sm hover:text-cyan-700 dark:hover:text-cyan-400"
-                  >
-                    <span className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</span>
-                    <span className="text-xs text-slate-500">
-                      {item.status_rotulo} · {formatWhen(item.created_at)}
-                    </span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          )}
-          {minhas.length > 8 ? (
-            <p className="pt-2 text-sm">
-              <Link to="/minhas-solicitacoes" className="font-medium text-cyan-700 hover:underline dark:text-cyan-400">
+        <Card
+          title="Minhas solicitações"
+          description={
+            loadingMinhas
+              ? 'Carregando…'
+              : minhas.length > 0
+                ? `${Math.min(minhas.length, PREVIEW_MINHAS)} mais recente${minhas.length === 1 ? '' : 's'}`
+                : undefined
+          }
+          titleActions={
+            !loadingMinhas && minhas.length > PREVIEW_MINHAS ? (
+              <Link
+                to="/minhas-solicitacoes"
+                className="text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+              >
                 Ver todas →
               </Link>
+            ) : null
+          }
+          bodyClassName={loadingMinhas || minhas.length > 0 ? 'overflow-x-auto p-0' : 'p-6'}
+        >
+          {loadingMinhas ? (
+            <SolicitacoesMelhoriaListaSkeleton rows={PREVIEW_MINHAS} />
+          ) : minhas.length === 0 ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Você ainda não enviou nenhum pedido. Use o botão acima para sugerir uma melhoria ou relatar um problema.
             </p>
-          ) : null}
+          ) : (
+            <SolicitacoesMelhoriaListaTable
+              items={minhas.slice(0, PREVIEW_MINHAS)}
+              itemPath={(solicitacaoId) => `/minhas-solicitacoes/${solicitacaoId}`}
+            />
+          )}
         </Card>
       ) : null}
 

--- a/frontend/src/components/release/SolicitacaoDescricao.tsx
+++ b/frontend/src/components/release/SolicitacaoDescricao.tsx
@@ -29,15 +29,15 @@ export function SolicitacaoDescricao({
   descricao: string
   anexos?: Anexo[] | SolicitacoesMelhoria.Anexo[]
 }) {
-  const ficheiros = anexos.filter((a) => a.papel !== 'inline')
+  const arquivosAnexo = anexos.filter((a) => a.papel !== 'inline')
   return (
     <div className="space-y-4">
       <KbMarkdownPreview markdown={descricao} emptyLabel="Sem descrição." />
-      {ficheiros.length > 0 ? (
+      {arquivosAnexo.length > 0 ? (
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Anexos</p>
           <ul className="space-y-3">
-            {ficheiros.map((a) => {
+            {arquivosAnexo.map((a) => {
               const href = solicitacoesMelhoria.mediaUrl(a.url)
               if (isImage(a.content_type)) {
                 return (

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaBadges.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaBadges.tsx
@@ -1,0 +1,29 @@
+import {
+  classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
+  rotuloStatusSolicitacao,
+  rotuloTipoSolicitacao,
+} from '../../lib/saasSolicitacoes'
+
+type Props = {
+  tipo: string
+  status: string
+  statusRotulo?: string
+}
+
+export function SolicitacoesMelhoriaBadges({ tipo, status, statusRotulo }: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span
+        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(tipo)}`}
+      >
+        {rotuloTipoSolicitacao(tipo)}
+      </span>
+      <span
+        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(status)}`}
+      >
+        {statusRotulo || rotuloStatusSolicitacao(status)}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaSkeleton.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaSkeleton.tsx
@@ -1,0 +1,23 @@
+type Props = {
+  rows?: number
+}
+
+/** Placeholder da tabela enquanto carrega Minhas solicitações no Sobre. */
+export function SolicitacoesMelhoriaListaSkeleton({ rows = 4 }: Props) {
+  return (
+    <div className="divide-y divide-slate-100 dark:divide-slate-800" aria-busy="true" aria-label="Carregando solicitações">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex flex-wrap items-center gap-4 px-4 py-4 sm:px-6">
+          <div className="h-5 w-20 animate-pulse rounded-full bg-slate-100 dark:bg-slate-800" />
+          <div className="h-4 w-24 animate-pulse rounded bg-slate-100 font-mono dark:bg-slate-800" />
+          <div className="min-w-[12rem] flex-1 space-y-2">
+            <div className="h-4 w-full max-w-md animate-pulse rounded bg-slate-100 dark:bg-slate-800" />
+            <div className="h-3 w-32 animate-pulse rounded bg-slate-100 dark:bg-slate-800" />
+          </div>
+          <div className="h-5 w-28 animate-pulse rounded-full bg-slate-100 dark:bg-slate-800" />
+          <div className="h-4 w-24 animate-pulse rounded bg-slate-100 dark:bg-slate-800" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaTable.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaListaTable.tsx
@@ -1,0 +1,89 @@
+import { useNavigate } from 'react-router-dom'
+import type { SolicitacoesMelhoria } from '../../api/client'
+import {
+  classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
+  rotuloStatusSolicitacao,
+  rotuloTipoSolicitacao,
+} from '../../lib/saasSolicitacoes'
+
+function formatWhen(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  } catch {
+    return iso
+  }
+}
+
+type Props = {
+  items: SolicitacoesMelhoria.ListaItem[]
+  /** Rota do detalhe, ex.: `/minhas-solicitacoes/${id}` */
+  itemPath: (id: number) => string
+}
+
+/** Tabela de solicitações do cliente — mesma linguagem visual do painel admin SaaS. */
+export function SolicitacoesMelhoriaListaTable({ items, itemPath }: Props) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[640px] text-left text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Tipo</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Protocolo</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Título</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Status</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Quando</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          {items.map((item) => (
+            <tr
+              key={item.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => navigate(itemPath(item.id))}
+              onKeyDown={(ev) => {
+                if (ev.key === 'Enter' || ev.key === ' ') {
+                  ev.preventDefault()
+                  navigate(itemPath(item.id))
+                }
+              }}
+              className={`cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 ${
+                item.tipo === 'problema'
+                  ? 'border-l-2 border-l-rose-400/80'
+                  : 'border-l-2 border-l-sky-400/60'
+              }`}
+            >
+              <td className="px-4 py-3 sm:px-6">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(item.tipo)}`}
+                >
+                  {rotuloTipoSolicitacao(item.tipo)}
+                </span>
+              </td>
+              <td className="px-4 py-3 font-mono text-sm text-cyan-800 dark:text-cyan-300 sm:px-6">
+                {item.protocolo || '—'}
+              </td>
+              <td className="px-4 py-3 sm:px-6">
+                <p className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</p>
+                {item.versao_alvo_rotulo ? (
+                  <p className="mt-0.5 text-xs text-emerald-700 dark:text-emerald-300">{item.versao_alvo_rotulo}</p>
+                ) : null}
+              </td>
+              <td className="px-4 py-3 sm:px-6">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.status)}`}
+                >
+                  {item.status_rotulo || rotuloStatusSolicitacao(item.status)}
+                </span>
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-slate-500 sm:px-6">{formatWhen(item.created_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/solicitacoes/SolicitacoesMelhoriaTimeline.tsx
+++ b/frontend/src/components/solicitacoes/SolicitacoesMelhoriaTimeline.tsx
@@ -1,0 +1,83 @@
+import type { SolicitacoesMelhoria } from '../../api/client'
+import { classesBadgeStatusSolicitacao } from '../../lib/saasSolicitacoes'
+
+function fmt(dt: string): string {
+  try {
+    return new Date(dt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  } catch {
+    return dt
+  }
+}
+
+type TimelineEntry =
+  | { kind: 'historico'; id: number; created_at: string; data: SolicitacoesMelhoria.Historico }
+  | { kind: 'comentario'; id: number; created_at: string; data: SolicitacoesMelhoria.Comentario }
+
+function montarTimeline(
+  historico: SolicitacoesMelhoria.Historico[],
+  comentarios: SolicitacoesMelhoria.Comentario[],
+): TimelineEntry[] {
+  const items: TimelineEntry[] = [
+    ...historico.map((h) => ({ kind: 'historico' as const, id: h.id, created_at: h.created_at, data: h })),
+    ...comentarios.map((c) => ({ kind: 'comentario' as const, id: c.id, created_at: c.created_at, data: c })),
+  ]
+  return items.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+}
+
+type Props = {
+  historico: SolicitacoesMelhoria.Historico[]
+  comentarios: SolicitacoesMelhoria.Comentario[]
+}
+
+/** Linha do tempo vertical — status + comentários em ordem cronológica. */
+export function SolicitacoesMelhoriaTimeline({ historico, comentarios }: Props) {
+  const items = montarTimeline(historico, comentarios)
+
+  if (items.length === 0) {
+    return <p className="text-sm text-slate-500">Ainda não há atualizações neste pedido.</p>
+  }
+
+  return (
+    <ol className="relative border-l-2 border-slate-200 pl-6 dark:border-slate-700">
+      {items.map((item) => {
+        const isComentario = item.kind === 'comentario'
+        const dotClass = isComentario
+          ? 'bg-cyan-500 ring-cyan-100 dark:ring-cyan-950/60'
+          : 'bg-slate-400 ring-slate-100 dark:bg-slate-500 dark:ring-slate-900/80'
+
+        return (
+          <li key={`${item.kind}-${item.id}`} className="relative pb-6 last:pb-0">
+            <span
+              className={`absolute -left-[calc(0.75rem+1px)] top-1.5 size-3 rounded-full ring-4 ${dotClass}`}
+              aria-hidden
+            />
+            {item.kind === 'historico' ? (
+              <div className="rounded-lg border border-slate-100 bg-slate-50/80 p-3 text-sm dark:border-slate-800 dark:bg-slate-800/40">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.data.status_novo)}`}
+                  >
+                    {item.data.status_novo_rotulo}
+                  </span>
+                  <span className="text-xs text-slate-400">{fmt(item.created_at)}</span>
+                </div>
+                {item.data.mensagem_publica ? (
+                  <p className="mt-2 whitespace-pre-wrap text-slate-600 dark:text-slate-300">
+                    {item.data.mensagem_publica}
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-cyan-100 bg-white p-3 text-sm shadow-sm dark:border-cyan-900/40 dark:bg-slate-900/60">
+                <p className="text-xs font-medium text-slate-500">
+                  {item.data.autor_nome || 'Equipe'} · {fmt(item.created_at)}
+                </p>
+                <p className="mt-1 whitespace-pre-wrap text-slate-700 dark:text-slate-200">{item.data.corpo}</p>
+              </div>
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,25 +1,40 @@
-import { type HTMLAttributes } from 'react'
+import { type HTMLAttributes, type ReactNode } from 'react'
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   title?: string
   description?: string
+  /** Ações à direita do título (ex.: link). */
+  titleActions?: ReactNode
+  /** Classes do corpo (ex.: `p-0` para tabela edge-to-edge). */
+  bodyClassName?: string
 }
 
-export function Card({ title, description, className = '', children, ...props }: CardProps) {
+export function Card({
+  title,
+  description,
+  titleActions,
+  bodyClassName = 'p-6',
+  className = '',
+  children,
+  ...props
+}: CardProps) {
   return (
     <div
       className={`rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900/95 dark:shadow-none dark:ring-1 dark:ring-white/5 ${className}`}
       {...props}
     >
-      {title && (
-        <div className="border-b border-slate-200 px-6 py-4 dark:border-slate-800">
-          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
-          {description ? (
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
-          ) : null}
+      {title ? (
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 px-6 py-4 dark:border-slate-800">
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
+            {description ? (
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+            ) : null}
+          </div>
+          {titleActions ? <div className="shrink-0">{titleActions}</div> : null}
         </div>
-      )}
-      <div className="p-6">{children}</div>
+      ) : null}
+      <div className={bodyClassName}>{children}</div>
     </div>
   )
 }

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -48,7 +48,7 @@ export function PageContainer({
 
 type PageHeaderProps = {
   title: string
-  subtitle?: string
+  subtitle?: ReactNode
   actions?: ReactNode
 }
 
@@ -58,7 +58,11 @@ export function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
     <div className="flex flex-wrap items-start justify-between gap-4">
       <div className="min-w-0">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">{title}</h1>
-        {subtitle ? <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{subtitle}</p> : null}
+        {subtitle ? (
+          <div className={`mt-2 ${typeof subtitle === 'string' ? 'text-sm text-slate-600 dark:text-slate-400' : ''}`}>
+            {subtitle}
+          </div>
+        ) : null}
       </div>
       {actions ? <div className="shrink-0">{actions}</div> : null}
     </div>

--- a/frontend/src/lib/chatUnreadDivider.ts
+++ b/frontend/src/lib/chatUnreadDivider.ts
@@ -1,0 +1,47 @@
+/** Primeira inbound não lida para o divisor visual (#951 / #S202608-0010). */
+export type ChatUnreadCursor = {
+  nao_lidas_count?: number
+  last_seen_mensagem_id?: number | null
+  last_seen_at?: string | null
+  atendimento_inicio_at?: string | null
+  created_at?: string | null
+}
+
+export type MensagemUnreadCursor = {
+  id: number
+  direcao: string
+  evento_sistema?: string | null
+  apagada?: boolean
+  created_at?: string | null
+}
+
+export function primeiraInboundNaoLidaMsgId(
+  msgs: MensagemUnreadCursor[],
+  chat: ChatUnreadCursor,
+): number | null {
+  if ((chat.nao_lidas_count ?? 0) <= 0) return null
+
+  const cursorId = chat.last_seen_mensagem_id
+  if (cursorId != null) {
+    const primeira = msgs.find(
+      (m) =>
+        m.direcao === 'inbound' &&
+        !m.evento_sistema &&
+        !m.apagada &&
+        m.id > cursorId,
+    )
+    return primeira?.id ?? null
+  }
+
+  const eff = chat.last_seen_at || chat.atendimento_inicio_at || chat.created_at || null
+  const effMs = eff ? new Date(eff).getTime() : 0
+  const primeira = msgs.find(
+    (m) =>
+      m.direcao === 'inbound' &&
+      !m.evento_sistema &&
+      !m.apagada &&
+      m.created_at &&
+      new Date(m.created_at).getTime() > effMs,
+  )
+  return primeira?.id ?? null
+}

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -51,6 +51,37 @@ export const SAAS_SOLICITACAO_FASES = [
 
 export type SaasSolicitacaoFase = (typeof SAAS_SOLICITACAO_FASES)[number]['value']
 
+/** Espelha FASES_STATUS do backend (solicitacao_melhoria_copy.py). */
+const FASE_STATUS: Record<SaasSolicitacaoFase, readonly string[]> = {
+  aguardando: ['aberta', 'em_analise', 'planejada'],
+  desenvolvimento: ['em_desenvolvimento'],
+  finalizadas: ['concluida', 'nao_sera_desenvolvida'],
+}
+
+export function statusNaFase(status: string, fase: SaasSolicitacaoFase): boolean {
+  return FASE_STATUS[fase]?.includes(status) ?? false
+}
+
+export function classesCardMensagemStatus(status: string): string {
+  const base = 'rounded-lg border-l-4 p-3 text-sm'
+  if (status === 'concluida') {
+    return `${base} border-emerald-500 bg-emerald-50 text-emerald-900 dark:border-emerald-500 dark:bg-emerald-950/40 dark:text-emerald-100`
+  }
+  if (status === 'nao_sera_desenvolvida') {
+    return `${base} border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-500 dark:bg-rose-950/40 dark:text-rose-100`
+  }
+  if (status === 'em_desenvolvimento') {
+    return `${base} border-cyan-500 bg-cyan-50 text-cyan-900 dark:border-cyan-500 dark:bg-cyan-950/40 dark:text-cyan-100`
+  }
+  if (status === 'planejada') {
+    return `${base} border-violet-500 bg-violet-50 text-violet-900 dark:border-violet-500 dark:bg-violet-950/40 dark:text-violet-100`
+  }
+  if (status === 'em_analise') {
+    return `${base} border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-500 dark:bg-sky-950/40 dark:text-sky-100`
+  }
+  return `${base} border-slate-400 bg-slate-50 text-slate-700 dark:border-slate-600 dark:bg-slate-800/60 dark:text-slate-200`
+}
+
 const BADGE: Record<string, string> = {
   aberta:
     'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70',

--- a/frontend/src/pages/MinhasSolicitacoes.tsx
+++ b/frontend/src/pages/MinhasSolicitacoes.tsx
@@ -1,37 +1,111 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { solicitacoesMelhoria, type SolicitacoesMelhoria } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { VoltarButton } from '../components/ui/VoltarButton'
-import { TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { INPUT_FIELD_CLASS, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { PageLoading } from '../components/ui/PageLoading'
 import { useToast } from '../components/ui/Toast'
 import { SolicitacaoDescricao } from '../components/release/SolicitacaoDescricao'
+import { SolicitacoesMelhoriaBadges } from '../components/solicitacoes/SolicitacoesMelhoriaBadges'
+import { SolicitacoesMelhoriaListaTable } from '../components/solicitacoes/SolicitacoesMelhoriaListaTable'
+import { SolicitacoesMelhoriaTimeline } from '../components/solicitacoes/SolicitacoesMelhoriaTimeline'
 import { useAuth } from '../contexts/AuthContext'
+import {
+  classesCardMensagemStatus,
+  SAAS_SOLICITACAO_FASES,
+  SAAS_SOLICITACAO_STATUS,
+  statusNaFase,
+  type SaasSolicitacaoFase,
+} from '../lib/saasSolicitacoes'
 
 const STATUS_FINAIS = new Set(['concluida', 'nao_sera_desenvolvida'])
 
-function fmt(dt: string): string {
-  try {
-    return new Date(dt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
-  } catch {
-    return dt
-  }
+function FiltroChip({
+  active,
+  onClick,
+  children,
+  count,
+  tone,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+  count?: number
+  tone?: 'sky' | 'rose' | 'default'
+}) {
+  const toneActive =
+    tone === 'sky'
+      ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-400 dark:bg-sky-950/50 dark:text-sky-100'
+      : tone === 'rose'
+        ? 'border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-400 dark:bg-rose-950/50 dark:text-rose-100'
+        : 'border-cyan-500 bg-cyan-50 text-cyan-950 dark:border-cyan-400 dark:bg-cyan-950/40 dark:text-cyan-50'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? toneActive
+          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800/60'
+      }`}
+    >
+      {children}
+      {count != null ? (
+        <span className={`tabular-nums text-xs ${active ? 'opacity-80' : 'text-slate-400 dark:text-slate-500'}`}>
+          {count}
+        </span>
+      ) : null}
+    </button>
+  )
 }
 
-/** Lista + detalhe das solicitações do utilizador (#803). */
+function contarPorFase(items: SolicitacoesMelhoria.ListaItem[], fase: SaasSolicitacaoFase): number {
+  return items.filter((item) => statusNaFase(item.status, fase)).length
+}
+
+/** Lista + detalhe das solicitações do usuário (#803). */
 export function MinhasSolicitacoesPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
   const { user } = useAuth()
   const [lista, setLista] = useState<SolicitacoesMelhoria.ListaItem[]>([])
   const [detalhe, setDetalhe] = useState<SolicitacoesMelhoria.Detalhe | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadingDetalhe, setLoadingDetalhe] = useState(false)
   const [resposta, setResposta] = useState('')
   const [enviando, setEnviando] = useState(false)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+
+  const tipoFiltro = searchParams.get('tipo') || ''
+  const faseFiltro = (searchParams.get('fase') || '') as SaasSolicitacaoFase | ''
+  const statusFiltro = searchParams.get('status') || ''
+
+  function patchFiltros(next: Record<string, string | null>) {
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev)
+        for (const [k, v] of Object.entries(next)) {
+          if (v == null || v === '') p.delete(k)
+          else p.set(k, v)
+        }
+        return p
+      },
+      { replace: true },
+    )
+  }
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim().toLowerCase()), 300)
+    return () => clearTimeout(t)
+  }, [busca])
 
   const carregarLista = useCallback(() => {
     return solicitacoesMelhoria
@@ -54,19 +128,47 @@ export function MinhasSolicitacoesPage() {
   useEffect(() => {
     if (!id) {
       setDetalhe(null)
+      setLoadingDetalhe(false)
       return
     }
     let cancel = false
+    setLoadingDetalhe(true)
     void solicitacoesMelhoria
       .get(Number(id))
       .then((d) => {
         if (!cancel) setDetalhe(d)
       })
       .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Falha ao abrir solicitação')))
+      .finally(() => {
+        if (!cancel) setLoadingDetalhe(false)
+      })
     return () => {
       cancel = true
     }
   }, [id, toast])
+
+  const resumo = useMemo(
+    () => ({
+      total: lista.length,
+      sugestoes: lista.filter((i) => i.tipo === 'sugestao').length,
+      problemas: lista.filter((i) => i.tipo === 'problema').length,
+      aguardando: contarPorFase(lista, 'aguardando'),
+      desenvolvimento: contarPorFase(lista, 'desenvolvimento'),
+      finalizadas: contarPorFase(lista, 'finalizadas'),
+    }),
+    [lista],
+  )
+
+  const listaFiltrada = useMemo(() => {
+    return lista.filter((item) => {
+      if (tipoFiltro && item.tipo !== tipoFiltro) return false
+      if (statusFiltro && item.status !== statusFiltro) return false
+      if (faseFiltro && !statusNaFase(item.status, faseFiltro)) return false
+      if (!debouncedBusca) return true
+      const hay = `${item.titulo} ${item.protocolo || ''}`.toLowerCase()
+      return hay.includes(debouncedBusca)
+    })
+  }, [lista, tipoFiltro, faseFiltro, statusFiltro, debouncedBusca])
 
   async function enviarResposta() {
     if (!detalhe || !resposta.trim()) return
@@ -91,27 +193,48 @@ export function MinhasSolicitacoesPage() {
     !STATUS_FINAIS.has(detalhe.status) &&
     detalhe.autor_atendente_id === user?.id
 
-  if (id && detalhe) {
+  if (id) {
+    if (loadingDetalhe && !detalhe) {
+      return (
+        <PageContainer>
+          <PageLoading label="Abrindo solicitação…" />
+        </PageContainer>
+      )
+    }
+
+    if (!detalhe) {
+      return (
+        <PageContainer>
+          <VoltarButton onClick={() => navigate('/minhas-solicitacoes')} label="Voltar à lista" />
+          <p className="text-sm text-slate-500">Não foi possível carregar este pedido.</p>
+        </PageContainer>
+      )
+    }
+
     return (
       <PageContainer>
-          <PageHeader
+        <PageHeader
           title={`${detalhe.protocolo || 'Pedido'} · ${detalhe.titulo}`}
-          subtitle={`${detalhe.tipo === 'problema' ? 'Problema' : 'Sugestão'} · ${detalhe.status_rotulo}`}
+          subtitle={
+            <SolicitacoesMelhoriaBadges
+              tipo={detalhe.tipo}
+              status={detalhe.status}
+              statusRotulo={detalhe.status_rotulo}
+            />
+          }
         />
         <VoltarButton onClick={() => navigate('/minhas-solicitacoes')} label="Voltar à lista" />
 
         <Card className="space-y-3 p-5">
           <SolicitacaoDescricao descricao={detalhe.descricao} anexos={detalhe.anexos} />
-          <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600 dark:bg-slate-800/60 dark:text-slate-300">
-            {detalhe.mensagem_status}
-          </p>
+          <p className={classesCardMensagemStatus(detalhe.status)}>{detalhe.mensagem_status}</p>
           {detalhe.versao_alvo_rotulo ? (
             <p className="rounded-lg bg-emerald-50 p-3 text-sm font-medium text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100">
               {detalhe.versao_alvo_rotulo}
             </p>
           ) : null}
           {detalhe.status === 'nao_sera_desenvolvida' && detalhe.motivo_nao_desenvolvimento ? (
-            <p className="text-sm text-slate-600 dark:text-slate-300">
+            <p className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-100">
               <span className="font-medium">Motivo: </span>
               {detalhe.motivo_nao_desenvolvimento}
             </p>
@@ -120,23 +243,7 @@ export function MinhasSolicitacoesPage() {
 
         <section className="space-y-3">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Acompanhamento</h2>
-          <div className="space-y-2">
-            {detalhe.historico.map((h) => (
-              <Card key={`h-${h.id}`} className="p-3 text-sm">
-                <p className="font-medium text-slate-800 dark:text-slate-100">{h.status_novo_rotulo}</p>
-                {h.mensagem_publica ? (
-                  <p className="mt-1 whitespace-pre-wrap text-slate-600 dark:text-slate-300">{h.mensagem_publica}</p>
-                ) : null}
-                <p className="mt-1 text-xs text-slate-400">{fmt(h.created_at)}</p>
-              </Card>
-            ))}
-            {detalhe.comentarios.map((c) => (
-              <Card key={`c-${c.id}`} className="p-3 text-sm">
-                <p className="text-xs font-medium text-slate-500">{c.autor_nome || 'Equipe'} · {fmt(c.created_at)}</p>
-                <p className="mt-1 whitespace-pre-wrap text-slate-700 dark:text-slate-200">{c.corpo}</p>
-              </Card>
-            ))}
-          </div>
+          <SolicitacoesMelhoriaTimeline historico={detalhe.historico} comentarios={detalhe.comentarios} />
         </section>
 
         {podeResponder ? (
@@ -177,10 +284,10 @@ export function MinhasSolicitacoesPage() {
         </Link>
       </div>
       {loading ? (
-        <p className="text-sm text-slate-500">A carregar…</p>
+        <PageLoading label="Carregando solicitações…" />
       ) : lista.length === 0 ? (
         <Card className="p-8 text-center text-sm text-slate-500">
-          Ainda não tem pedidos.{' '}
+          Você ainda não enviou nenhum pedido.{' '}
           <Link to="/sobre/nova-solicitacao" className="text-cyan-700 underline dark:text-cyan-400">
             Enviar sugestão
           </Link>
@@ -191,26 +298,127 @@ export function MinhasSolicitacoesPage() {
           .
         </Card>
       ) : (
-        <div className="space-y-2">
-          {lista.map((item) => (
-            <Link key={item.id} to={`/minhas-solicitacoes/${item.id}`} className="block">
-              <Card className="p-4 transition hover:ring-1 hover:ring-cyan-400/50">
-                <div className="flex flex-wrap items-baseline justify-between gap-2">
-                  <h3 className="font-semibold text-slate-900 dark:text-slate-50">
-                    <span className="font-mono text-xs font-medium text-cyan-700 dark:text-cyan-400">
-                      {item.protocolo || 'Pendente'}
-                    </span>{' '}
-                    {item.titulo}
-                  </h3>
-                  <span className="text-xs font-medium text-slate-500">{item.status_rotulo}</span>
-                </div>
-                <p className="mt-1 text-xs text-slate-400">
-                  {item.tipo === 'problema' ? 'Problema' : 'Sugestão'} · {fmt(item.created_at)}
-                  {item.versao_alvo_rotulo ? ` · ${item.versao_alvo_rotulo}` : ''}
+        <div className="space-y-4">
+          <Card>
+            <div className="space-y-4">
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Tipo
                 </p>
-              </Card>
-            </Link>
-          ))}
+                <div className="flex flex-wrap gap-2">
+                  <FiltroChip active={!tipoFiltro} count={resumo.total} onClick={() => patchFiltros({ tipo: null })}>
+                    Todos
+                  </FiltroChip>
+                  <FiltroChip
+                    active={tipoFiltro === 'sugestao'}
+                    count={resumo.sugestoes}
+                    tone="sky"
+                    onClick={() => patchFiltros({ tipo: tipoFiltro === 'sugestao' ? null : 'sugestao' })}
+                  >
+                    Sugestões
+                  </FiltroChip>
+                  <FiltroChip
+                    active={tipoFiltro === 'problema'}
+                    count={resumo.problemas}
+                    tone="rose"
+                    onClick={() => patchFiltros({ tipo: tipoFiltro === 'problema' ? null : 'problema' })}
+                  >
+                    Problemas
+                  </FiltroChip>
+                </div>
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Fase
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <FiltroChip active={!faseFiltro} onClick={() => patchFiltros({ fase: null })}>
+                    Todas
+                  </FiltroChip>
+                  {SAAS_SOLICITACAO_FASES.map((f) => (
+                    <FiltroChip
+                      key={f.value}
+                      active={faseFiltro === f.value}
+                      count={
+                        f.value === 'aguardando'
+                          ? resumo.aguardando
+                          : f.value === 'desenvolvimento'
+                            ? resumo.desenvolvimento
+                            : resumo.finalizadas
+                      }
+                      onClick={() => patchFiltros({ fase: faseFiltro === f.value ? null : f.value })}
+                    >
+                      {f.label}
+                    </FiltroChip>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Status
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <FiltroChip active={!statusFiltro} onClick={() => patchFiltros({ status: null })}>
+                    Todos
+                  </FiltroChip>
+                  {SAAS_SOLICITACAO_STATUS.map((s) => (
+                    <FiltroChip
+                      key={s.value}
+                      active={statusFiltro === s.value}
+                      count={lista.filter((i) => i.status === s.value).length}
+                      onClick={() => patchFiltros({ status: statusFiltro === s.value ? null : s.value })}
+                    >
+                      {s.label}
+                    </FiltroChip>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="busca-solicitacoes" className="mb-2 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Buscar
+                </label>
+                <input
+                  id="busca-solicitacoes"
+                  type="search"
+                  value={busca}
+                  onChange={(e) => setBusca(e.target.value)}
+                  placeholder="Título ou protocolo…"
+                  className={INPUT_FIELD_CLASS}
+                />
+              </div>
+            </div>
+          </Card>
+
+          {listaFiltrada.length === 0 ? (
+            <Card className="p-6 text-center text-sm text-slate-500">
+              Nenhum pedido corresponde aos filtros atuais.{' '}
+              <button
+                type="button"
+                className="text-cyan-700 underline dark:text-cyan-400"
+                onClick={() => {
+                  setBusca('')
+                  patchFiltros({ tipo: null, fase: null, status: null })
+                }}
+              >
+                Limpar filtros
+              </button>
+            </Card>
+          ) : (
+            <Card bodyClassName="overflow-x-auto p-0">
+              <p className="border-b border-slate-100 px-6 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                {listaFiltrada.length === lista.length
+                  ? `${lista.length} pedido${lista.length === 1 ? '' : 's'}`
+                  : `${listaFiltrada.length} de ${lista.length} pedidos`}
+              </p>
+              <SolicitacoesMelhoriaListaTable
+                items={listaFiltrada}
+                itemPath={(solicitacaoId) => `/minhas-solicitacoes/${solicitacaoId}`}
+              />
+            </Card>
+          )}
         </div>
       )}
     </PageContainer>

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -7,6 +7,7 @@ import { PontoAjudaModal } from '../components/PontoAjudaModal'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
 import { PontoBatidaMapaModal } from '../components/PontoBatidaMapaModal'
 import { PontoMetricCard } from '../components/PontoMetricCard'
+import { PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
@@ -62,12 +63,14 @@ function toDatetimeLocalValue(d = new Date()): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
+
 export function PontoEquipe() {
   const toast = useToast()
   const { user } = useAuth()
   const { subscribe } = useEventStream()
   const [items, setItems] = useState<Ponto.BatidaAdmin[]>([])
   const [total, setTotal] = useState(0)
+  const [histPage, setHistPage] = useState(1)
   const [hoje, setHoje] = useState<Ponto.HojeLista | null>(null)
   const [equipe, setEquipe] = useState<Atendentes.Atendente[]>([])
   const [atendenteId, setAtendenteId] = useState('')
@@ -106,6 +109,14 @@ export function PontoEquipe() {
   const [ausAte, setAusAte] = useState(hojeIso)
   const [ausMotivo, setAusMotivo] = useState('')
   const [concedendoAus, setConcedendoAus] = useState(false)
+  const [convAtendente, setConvAtendente] = useState('')
+  const [convData, setConvData] = useState(hojeIso)
+  const [convInicio, setConvInicio] = useState('08:00')
+  const [convFim, setConvFim] = useState('12:00')
+  const [convTolerancia, setConvTolerancia] = useState('')
+  const [convMotivo, setConvMotivo] = useState('')
+  const [convocados, setConvocados] = useState<Ponto.DiaConvocado[]>([])
+  const [concedendoConv, setConcedendoConv] = useState(false)
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
   const [heDuracaoMin, setHeDuracaoMin] = useState('60')
@@ -131,12 +142,13 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, hes, aus, cobs, setupSt, comp, cins] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes, aus, cobs, convs, setupSt, comp, cins] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
             ate,
-            limit: 100,
+            offset: (histPage - 1) * PAGE_SIZE_PADRAO,
+            limit: PAGE_SIZE_PADRAO,
           }),
           ponto.hoje(),
           ponto.justificativasAdmin('pendente'),
@@ -146,12 +158,16 @@ export function PontoEquipe() {
           ponto.horaExtraAdmin('pendente'),
           ponto.ausenciasAdmin('pendente'),
           ponto.coberturasAdmin('pendente'),
+          ponto.convocadosAdmin({ estado: 'ativa' }),
           ponto.setupStatus(),
           ponto.competencia(compAno, compMes),
           ponto.cienciasAdmin(compAno, compMes),
         ])
         setItems(hist.items)
         setTotal(hist.total)
+        if (hist.items.length === 0 && histPage > 1 && hist.total > 0) {
+          setHistPage(histPage - 1)
+        }
         setHoje(dia)
         setJustifs(js)
         setDigest(dig)
@@ -160,6 +176,7 @@ export function PontoEquipe() {
         setHesPendentes(hes)
         setAusPendentes(aus)
         setCobPendentes(cobs)
+        setConvocados(convs)
         setSetup(setupSt)
         setCompetencia(comp)
         setCiencias(cins)
@@ -182,7 +199,7 @@ export function PontoEquipe() {
         setLoading(false)
       }
     },
-    [ate, atendenteId, compAno, compMes, desde, toast],
+    [ate, atendenteId, compAno, compMes, desde, histPage, toast],
   )
 
   useEffect(() => {
@@ -425,6 +442,45 @@ export function PontoEquipe() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar a ausência.'))
     } finally {
       setConcedendoAus(false)
+    }
+  }
+
+  async function concederConv() {
+    if (!convAtendente) {
+      toast.showWarning('Selecione o colaborador.')
+      return
+    }
+    if (!convMotivo.trim() || convMotivo.trim().length < 3) {
+      toast.showWarning('Informe o motivo (mínimo 3 caracteres).')
+      return
+    }
+    setConcedendoConv(true)
+    try {
+      await ponto.concederDiaConvocado({
+        atendente_id: Number(convAtendente),
+        data_ref: convData,
+        inicio: convInicio,
+        fim: convFim,
+        motivo: convMotivo.trim(),
+        tolerancia_minutos: convTolerancia.trim() ? Number(convTolerancia) : null,
+      })
+      toast.showSuccess('Dia convocado agendado.')
+      setConvMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível agendar o dia convocado.'))
+    } finally {
+      setConcedendoConv(false)
+    }
+  }
+
+  async function cancelarConv(id: number) {
+    try {
+      await ponto.cancelarDiaConvocado(id)
+      toast.showSuccess('Convocação cancelada.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cancelar a convocação.'))
     }
   }
 
@@ -978,6 +1034,68 @@ export function PontoEquipe() {
           )}
         </Card>
 
+        <Card title="Dia convocado (fora da grade)">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Marque um dia de folga na escala como trabalho esperado, com janela própria de entrada e saída.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Colaborador"
+              value={convAtendente}
+              onChange={(v) => setConvAtendente(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Input label="Data" type="date" value={convData} onChange={(e) => setConvData(e.target.value)} />
+            <Input
+              label="Início"
+              type="time"
+              value={convInicio}
+              onChange={(e) => setConvInicio(e.target.value)}
+            />
+            <Input label="Fim" type="time" value={convFim} onChange={(e) => setConvFim(e.target.value)} />
+            <Input
+              label="Tolerância (min, opcional)"
+              type="number"
+              min={0}
+              max={240}
+              value={convTolerancia}
+              onChange={(e) => setConvTolerancia(e.target.value)}
+            />
+            <Input label="Motivo" value={convMotivo} onChange={(e) => setConvMotivo(e.target.value)} />
+            <Button type="button" disabled={concedendoConv} onClick={() => void concederConv()}>
+              Agendar
+            </Button>
+          </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Convocações ativas</p>
+          {convocados.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhuma convocação ativa.</p>
+          ) : (
+            <ul className="space-y-3">
+              {convocados.map((c) => (
+                <li
+                  key={c.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">{c.atendente_nome ?? c.atendente_id}</p>
+                    <p className="text-slate-600 dark:text-slate-300">
+                      {c.data_ref} · {c.inicio} → {c.fim}
+                      {c.tolerancia_minutos != null ? ` · tol. ${c.tolerancia_minutos} min` : ''}
+                    </p>
+                    <p className="text-slate-500">{c.motivo}</p>
+                  </div>
+                  <Button type="button" variant="ghost" onClick={() => void cancelarConv(c.id)}>
+                    Cancelar
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
         <Card title="Hora extra (WhatsApp após jornada)">
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
             Conceda HE com antecedência ou libere pedidos após o fim da jornada. Modos: resto do dia, até um horário ou
@@ -1188,15 +1306,41 @@ export function PontoEquipe() {
             <Select
               label="Atendente"
               value={atendenteId}
-              onChange={(v) => setAtendenteId(String(v))}
+              onChange={(v) => {
+                setAtendenteId(String(v))
+                setHistPage(1)
+              }}
               options={[
                 { value: '', label: 'Todos' },
                 ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
               ]}
             />
-            <Input label="De" type="date" value={desde} onChange={(e) => setDesde(e.target.value)} />
-            <Input label="Até" type="date" value={ate} onChange={(e) => setAte(e.target.value)} />
-            <Button type="button" variant="secondary" onClick={() => void carregar()}>
+            <Input
+              label="De"
+              type="date"
+              value={desde}
+              onChange={(e) => {
+                setDesde(e.target.value)
+                setHistPage(1)
+              }}
+            />
+            <Input
+              label="Até"
+              type="date"
+              value={ate}
+              onChange={(e) => {
+                setAte(e.target.value)
+                setHistPage(1)
+              }}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                setHistPage(1)
+                void carregar()
+              }}
+            >
               Filtrar
             </Button>
             <Button type="button" variant="secondary" onClick={() => void exportarCsv()}>
@@ -1216,7 +1360,9 @@ export function PontoEquipe() {
             </Button>
           </div>
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
-            {total} batida{total === 1 ? '' : 's'} no filtro
+            {total === 0
+              ? '0 batidas no filtro'
+              : `${(histPage - 1) * PAGE_SIZE_PADRAO + 1}–${Math.min(histPage * PAGE_SIZE_PADRAO, total)} de ${total} batida${total === 1 ? '' : 's'} no filtro`}
             {banco ? (
               <>
                 {' '}
@@ -1289,6 +1435,31 @@ export function PontoEquipe() {
               </tbody>
             </table>
           </div>
+          {total > PAGE_SIZE_PADRAO ? (
+            <div className="mt-4 flex flex-wrap items-center justify-end gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={histPage <= 1}
+                onClick={() => setHistPage((p) => p - 1)}
+                className="px-2 py-1 text-xs"
+              >
+                Anterior
+              </Button>
+              <span className="tabular-nums">
+                {histPage} / {Math.ceil(total / PAGE_SIZE_PADRAO)}
+              </span>
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={histPage >= Math.ceil(total / PAGE_SIZE_PADRAO)}
+                onClick={() => setHistPage((p) => p + 1)}
+                className="px-2 py-1 text-xs"
+              >
+                Próxima
+              </Button>
+            </div>
+          ) : null}
         </Card>
 
         {atendenteId ? (
@@ -1301,6 +1472,7 @@ export function PontoEquipe() {
                 setDiaCal(iso)
                 setDesde(iso)
                 setAte(iso)
+                setHistPage(1)
               }}
               onMesAnterior={() => {
                 if (calMes <= 1) {

--- a/frontend/src/pages/SolicitacaoMelhoriaNova.tsx
+++ b/frontend/src/pages/SolicitacaoMelhoriaNova.tsx
@@ -8,7 +8,6 @@ import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
 import { PageContainer } from '../components/ui/PageContainer'
 import { VoltarButton } from '../components/ui/VoltarButton'
-import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 
 const ACCEPT_ANEXO = 'image/png,image/jpeg,image/webp,image/gif,application/pdf,video/mp4,video/webm,video/quicktime'
@@ -67,9 +66,9 @@ export function SolicitacaoMelhoriaNovaPage() {
       .catch(() => undefined)
   }, [])
 
-  async function enviarFicheiro(file: File, papel: 'inline' | 'anexo') {
+  async function enviarArquivo(file: File, papel: 'inline' | 'anexo') {
     if (anexos.length >= MAX_ANEXOS) {
-      toast.showError('Pode anexar no máximo 20 ficheiros neste pedido.')
+      toast.showError('Você pode anexar no máximo 20 arquivos neste pedido.')
       return
     }
     setUploading(true)
@@ -82,13 +81,26 @@ export function SolicitacaoMelhoriaNovaPage() {
         setModo('editar')
         toast.showSuccess('Imagem colada no texto.')
       } else {
-        toast.showSuccess('Ficheiro anexado.')
+        toast.showSuccess('Arquivo anexado.')
       }
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar o ficheiro.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar o arquivo.'))
     } finally {
       setUploading(false)
       if (anexoInputRef.current) anexoInputRef.current.value = ''
+    }
+  }
+
+  function removerAnexo(anexo: SolicitacoesMelhoria.Anexo) {
+    setAnexos((cur) => cur.filter((a) => a.id !== anexo.id))
+    if (anexo.papel === 'inline' && anexo.url) {
+      const escaped = anexo.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      setDescricao((d) =>
+        d
+          .replace(new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)\\s*`, 'g'), '')
+          .replace(new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)`, 'g'), '')
+          .trim(),
+      )
     }
   }
 
@@ -100,7 +112,7 @@ export function SolicitacaoMelhoriaNovaPage() {
         const file = item.getAsFile()
         if (file) {
           e.preventDefault()
-          void enviarFicheiro(file, 'inline')
+          void enviarArquivo(file, 'inline')
         }
         return
       }
@@ -137,8 +149,8 @@ export function SolicitacaoMelhoriaNovaPage() {
       })
       toast.showSuccess(
         row.protocolo
-          ? `Pedido ${row.protocolo} enviado. Pode acompanhar em Minhas solicitações.`
-          : 'Pedido enviado. Pode acompanhar em Minhas solicitações.',
+          ? `Pedido ${row.protocolo} enviado. Você pode acompanhar em Minhas solicitações.`
+          : 'Pedido enviado. Você pode acompanhar em Minhas solicitações.',
       )
       navigate(`/minhas-solicitacoes/${row.id}`)
     } catch (err) {
@@ -151,6 +163,7 @@ export function SolicitacaoMelhoriaNovaPage() {
   }
 
   const anexosLista = anexos.filter((a) => a.papel !== 'inline')
+  const anexosInline = anexos.filter((a) => a.papel === 'inline')
 
   return (
     <PageContainer className="flex h-full min-h-0 w-full flex-col" spacing="none">
@@ -164,16 +177,41 @@ export function SolicitacaoMelhoriaNovaPage() {
       <div className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900/95 dark:shadow-none dark:ring-1 dark:ring-white/5">
         <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-hidden p-5 sm:p-6">
           <div className="grid shrink-0 items-start gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,3fr)]">
-            <Select
-              label="Tipo"
-              className="[&>button]:box-border [&>button]:h-10 [&>button]:rounded-lg [&>button]:py-0"
-              value={tipo}
-              onChange={(v) => setTipo(String(v) as SolicitacoesMelhoria.Tipo)}
-              options={[
-                { value: 'sugestao', label: 'Sugestão de melhoria' },
-                { value: 'problema', label: 'Relatar problema' },
-              ]}
-            />
+            <div>
+              <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Tipo</p>
+              <div className="flex flex-wrap gap-2">
+                {(
+                  [
+                    { value: 'sugestao' as const, label: 'Sugestão', tone: 'sky' as const },
+                    { value: 'problema' as const, label: 'Problema', tone: 'rose' as const },
+                  ] as const
+                ).map((opt) => {
+                  const ativo = tipo === opt.value
+                  const toneClass =
+                    opt.tone === 'sky'
+                      ? ativo
+                        ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-400 dark:bg-sky-950/50 dark:text-sky-100'
+                        : ''
+                      : ativo
+                        ? 'border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-400 dark:bg-rose-950/50 dark:text-rose-100'
+                        : ''
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setTipo(opt.value)}
+                      className={`inline-flex items-center rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                        ativo
+                          ? toneClass
+                          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300 dark:hover:border-slate-600'
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
             <Input
               label="Título"
               className="box-border h-10"
@@ -250,7 +288,7 @@ export function SolicitacaoMelhoriaNovaPage() {
                   value={descricao}
                   onChange={(e) => setDescricao(e.target.value)}
                   onPaste={onPaste}
-                  placeholder="Explique o contexto, o que esperava e o impacto. Cole prints (Ctrl+V) à medida que descreve os passos."
+                  placeholder="Explique o contexto, o que esperava e o impacto. Cole prints (Ctrl+V) enquanto descreve os passos."
                   maxLength={20000}
                 />
               ) : (
@@ -261,12 +299,39 @@ export function SolicitacaoMelhoriaNovaPage() {
             </div>
           </div>
 
-          {anexosLista.length > 0 ? (
-            <ul className="shrink-0 space-y-1 text-sm text-slate-600 dark:text-slate-300">
-              {anexosLista.map((a) => (
-                <li key={a.id}>Anexo: {a.nome_original}</li>
-              ))}
-            </ul>
+          {anexos.length > 0 ? (
+            <div className="shrink-0 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Arquivos neste pedido</p>
+              <ul className="flex flex-wrap gap-2">
+                {anexos.map((a) => (
+                  <li
+                    key={a.id}
+                    className="inline-flex max-w-full items-center gap-1 rounded-lg border border-slate-200 bg-slate-50 pl-3 pr-1 py-1 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200"
+                  >
+                    <span className="truncate">
+                      {a.papel === 'inline' ? 'Imagem no texto: ' : ''}
+                      {a.nome_original}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removerAnexo(a)}
+                      className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+                      aria-label={`Remover ${a.nome_original}`}
+                      title="Remover"
+                    >
+                      <svg className="size-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+                        <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+                      </svg>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {anexosInline.length > 0 && anexosLista.length > 0 ? (
+                <p className="text-xs text-slate-500">
+                  Remover uma imagem colada no texto também limpa a marcação na descrição.
+                </p>
+              ) : null}
+            </div>
           ) : null}
 
           {erro ? <p className="shrink-0 text-sm text-rose-600 dark:text-rose-400">{erro}</p> : null}
@@ -289,7 +354,7 @@ export function SolicitacaoMelhoriaNovaPage() {
               className="hidden"
               onChange={(e) => {
                 const f = e.target.files?.[0]
-                if (f) void enviarFicheiro(f, 'anexo')
+                if (f) void enviarArquivo(f, 'anexo')
               }}
             />
           </div>

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -165,11 +165,13 @@ export function ChatListaAtendendo() {
     const u2 = subscribe('chat.mensagem', refresh)
     const u3 = subscribe('portal.chat.fila', refresh)
     const u4 = subscribe('portal.chat.mensagem', refresh)
+    const u5 = subscribe('notificacao.contagem', refresh)
     return () => {
       u1()
       u2()
       u3()
       u4()
+      u5()
     }
   }, [subscribe, load])
 

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -26,6 +26,7 @@ import {
   rotuloResponsavelChat,
 } from '../../lib/whatsappChatMeta'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
+import { primeiraInboundNaoLidaMsgId } from '../../lib/chatUnreadDivider'
 import { WhatsappDemandaTimelineMarco } from '../whatsapp/WhatsappDemandaTimelineMarco'
 import { ACCEPT_ANEXO, type TipoAnexoPicker } from '../whatsapp/WhatsappBarraAnexos'
 import { WhatsappComposerBar } from '../whatsapp/WhatsappComposerBar'
@@ -97,6 +98,25 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const fimRef = useRef<HTMLDivElement>(null)
   const lastMsgIdRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const [divisorNaoLidasMsgId, setDivisorNaoLidasMsgId] = useState<number | null>(null)
+  const chatRef = useRef<PortalChats.Chat | null>(null)
+  const userIdRef = useRef(user?.id)
+
+  useEffect(() => {
+    chatRef.current = chat
+  }, [chat])
+
+  useEffect(() => {
+    userIdRef.current = user?.id
+  }, [user?.id])
+
+  const ehResponsavelPeloChat = useCallback((c: PortalChats.Chat | null, usuarioId?: number) => {
+    return (
+      c?.estado === 'em_atendimento' &&
+      c.atendente_id != null &&
+      c.atendente_id === usuarioId
+    )
+  }, [])
 
   const carregarDemandasTimeline = useCallback(async () => {
     if (!Number.isFinite(chatId)) return
@@ -109,7 +129,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   }, [chatId])
 
   const carregarMensagens = useCallback(
-    async (opts?: { sinceId?: number; replace?: boolean }) => {
+    async (opts?: { sinceId?: number; replace?: boolean; marcarVisto?: boolean }) => {
       if (!Number.isFinite(chatId)) return
       const sinceId = opts?.sinceId
       const rows = await portalChats.mensagens(chatId, sinceId)
@@ -124,8 +144,10 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
           return merged
         })
       }
-      await portalChats.marcarVisto(chatId).catch(() => undefined)
-      void refetchPendenciasResumo()
+      if (opts?.marcarVisto) {
+        await portalChats.marcarVisto(chatId).catch(() => undefined)
+        void refetchPendenciasResumo()
+      }
     },
     [chatId],
   )
@@ -133,54 +155,85 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const load = useCallback(async () => {
     if (!Number.isFinite(chatId)) return
     setLoading(true)
+    setDivisorNaoLidasMsgId(null)
     try {
       const c = await portalChats.get(chatId)
       setChat(c)
-      await Promise.all([carregarMensagens({ replace: true }), carregarDemandasTimeline()])
+      const rows = await portalChats.mensagens(chatId)
+      setMensagens(rows)
+      lastMsgIdRef.current = rows.at(-1)?.id ?? 0
+      const primeiraId = primeiraInboundNaoLidaMsgId(rows, c)
+      if (primeiraId != null) setDivisorNaoLidasMsgId(primeiraId)
+      await portalChats.marcarVisto(chatId).catch(() => undefined)
+      void refetchPendenciasResumo()
+      await carregarDemandasTimeline()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar o chat.'))
     } finally {
       setLoading(false)
     }
-  }, [carregarDemandasTimeline, carregarMensagens, chatId, toast])
+  }, [carregarDemandasTimeline, chatId, toast])
 
   const pollMensagens = useCallback(async () => {
     if (!Number.isFinite(chatId)) return
+    const responsavel = ehResponsavelPeloChat(chatRef.current, userIdRef.current)
     try {
       const sinceId = lastMsgIdRef.current > 0 ? lastMsgIdRef.current : undefined
-      await carregarMensagens(sinceId != null ? { sinceId } : { replace: true })
+      await carregarMensagens(
+        sinceId != null
+          ? { sinceId, marcarVisto: responsavel }
+          : { replace: true, marcarVisto: responsavel },
+      )
     } catch {
       /* silencioso */
     }
-  }, [carregarMensagens, chatId])
+  }, [carregarMensagens, chatId, ehResponsavelPeloChat])
 
   useEffect(() => {
     setChat(null)
     setMensagens([])
     setDemandasTimeline([])
     setTexto('')
+    setDivisorNaoLidasMsgId(null)
     lastMsgIdRef.current = 0
     void load()
   }, [chatId, load])
 
   useEffect(() => {
+    if (!divisorNaoLidasMsgId || loading) return
+    const t = window.setTimeout(() => {
+      document.getElementById('portal-nao-lidas')?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }, 80)
+    return () => window.clearTimeout(t)
+  }, [divisorNaoLidasMsgId, loading])
+
+  useEffect(() => {
+    if (divisorNaoLidasMsgId) return
     fimRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [mensagens, demandasTimeline])
+  }, [mensagens, demandasTimeline, divisorNaoLidasMsgId])
 
   useEffect(() => {
     const refresh = () => void load()
     const u1 = subscribe('portal.chat.mensagem', (payload) => {
-      if (Number(payload?.chat_id) === chatId) {
-        void pollMensagens()
-        void carregarDemandasTimeline()
+      if (Number(payload?.chat_id) !== chatId) return
+      const msg = payload.mensagem as PortalChats.Mensagem | undefined
+      const c = chatRef.current
+      if (
+        msg?.direcao === 'inbound' &&
+        ehResponsavelPeloChat(c, userIdRef.current)
+      ) {
+        void portalChats.marcarVisto(chatId).catch(() => undefined)
+        void refetchPendenciasResumo()
       }
+      void pollMensagens()
+      void carregarDemandasTimeline()
     })
     const u2 = subscribe('portal.chat.fila', refresh)
     return () => {
       u1()
       u2()
     }
-  }, [subscribe, chatId, load, pollMensagens, carregarDemandasTimeline])
+  }, [subscribe, chatId, load, pollMensagens, carregarDemandasTimeline, ehResponsavelPeloChat])
 
   useEffect(() => {
     const intervalMs = useFallback ? 8_000 : 4_000
@@ -494,6 +547,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
 
               const isInbound = m.direcao === 'inbound'
               const isTransferencia = m.evento_sistema === 'transferencia'
+              const mostrarDivisorNaoLidas = divisorNaoLidasMsgId === m.id
 
               if (isTransferencia) {
                 return (
@@ -509,7 +563,22 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
               }
 
               return (
-                <div key={m.id} className={`flex w-full ${isInbound ? 'justify-start' : 'justify-end'}`}>
+                <div key={m.id} className="w-full space-y-3">
+                  {mostrarDivisorNaoLidas && (
+                    <div
+                      id="portal-nao-lidas"
+                      className="flex w-full items-center gap-3 py-1"
+                      role="separator"
+                      aria-label="Mensagens não lidas"
+                    >
+                      <div className="h-px flex-1 bg-cyan-500/50" />
+                      <span className="shrink-0 rounded-full bg-cyan-600 px-3 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white shadow-sm">
+                        Mensagens não lidas
+                      </span>
+                      <div className="h-px flex-1 bg-cyan-500/50" />
+                    </div>
+                  )}
+                <div className={`flex w-full ${isInbound ? 'justify-start' : 'justify-end'}`}>
                   <div className={`max-w-[85%] space-y-1 ${isInbound ? 'items-start' : 'items-end'}`}>
                     <div
                       className={`rounded-2xl px-3 py-2 text-sm shadow-sm ${
@@ -534,6 +603,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
                       {m.created_at ? ` · ${formatarHora(m.created_at)}` : ''}
                     </p>
                   </div>
+                </div>
                 </div>
               )
             })

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -27,6 +27,7 @@ import {
   saveWhatsappScroll,
   scrollWhatsappToBottom,
 } from '../../lib/whatsappScrollMemory'
+import { primeiraInboundNaoLidaMsgId } from '../../lib/chatUnreadDivider'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
@@ -875,6 +876,10 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
   }, [])
 
+  const atualizarSidebarAposEnvioCliente = useCallback(() => {
+    void carregarSidebar()
+  }, [carregarSidebar])
+
 
 
   // Carregar conversa e mensagens
@@ -955,30 +960,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
     carregar()
       .then(async (data) => {
         if (data && (data.chat.nao_lidas_count ?? 0) > 0) {
-          const cursorId = data.chat.last_seen_mensagem_id
-          let primeira: WhatsappChats.Mensagem | undefined
-          if (cursorId != null) {
-            primeira = data.msgs.find(
-              (m) =>
-                m.direcao === 'inbound' &&
-                !m.evento_sistema &&
-                !m.apagada &&
-                m.id > cursorId,
-            )
-          } else {
-            const eff =
-              data.chat.last_seen_at || data.chat.atendimento_inicio_at || data.chat.created_at || null
-            const effMs = eff ? new Date(eff).getTime() : 0
-            primeira = data.msgs.find(
-              (m) =>
-                m.direcao === 'inbound' &&
-                !m.evento_sistema &&
-                !m.apagada &&
-                m.created_at &&
-                new Date(m.created_at).getTime() > effMs,
-            )
-          }
-          if (primeira) setDivisorNaoLidasMsgId(primeira.id)
+          const primeiraId = primeiraInboundNaoLidaMsgId(data.msgs, data.chat)
+          if (primeiraId != null) setDivisorNaoLidasMsgId(primeiraId)
         }
         await whatsappChats.marcarVisto(id)
         void carregarSidebar()
@@ -1220,6 +1203,9 @@ useEffect(() => {
 
       stickToBottomRef.current = true
       await carregar()
+      if (!modoInterno) {
+        atualizarSidebarAposEnvioCliente()
+      }
 
     } catch (err) {
 
@@ -1292,6 +1278,7 @@ useEffect(() => {
       setMsgRespondida(null)
       stickToBottomRef.current = true
       await carregar()
+      atualizarSidebarAposEnvioCliente()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar áudio.'))
     } finally {
@@ -1326,6 +1313,7 @@ useEffect(() => {
       setLegendaMidia('')
       stickToBottomRef.current = true
       await carregar()
+      atualizarSidebarAposEnvioCliente()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
     } finally {
@@ -1381,6 +1369,7 @@ useEffect(() => {
       setMsgRespondida(null)
       stickToBottomRef.current = true
       await carregar()
+      atualizarSidebarAposEnvioCliente()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar figurinha'))
     } finally {


### PR DESCRIPTION
## Summary

Release do lote acumulado na `main` desde **26.08.017** (produção atual na staging).

### SaaS Control Plane
- Deploy: pedidos do CHANGELOG marcados **concluída** no painel admin com versão CalVer
- Sobre: notas Interno/Infra só no painel admin
- Release notes 26.08.015 sem duplicatas

### DeskRudder — Melhorias
- **Minhas solicitações** + bloco no Sobre (tabela, badges, filtros, timeline, nova solicitação com chips/anexos)
- Provisionamento: ingest URL em loopback por padrão (mesma VPS)
- **Ponto** (lote RH): férias/folga, justificativa com anexo, dia convocado (#985), paginação histórico equipe (#S202608-0011), HE com teto mensal, competência/espelho/ciência, export folha, cobertura de plantão, checklist e ajuda

### DeskRudder — Correções
- Migration 134 idempotente (`ponto_dias_convocados`)
- Chat: barra superior desktop (#996), botões só responsável (#998), contador não lidas alinhado (#S202608-0010)
- Sobre: filtro de notas internas e release notes sem duplicar versões antigas

PRs incluídos: #1005–#1011

## Test plan

- [ ] `alembic upgrade head` em instância de teste (migrations 129–134)
- [ ] Login admin + atendente (DuplexSoft ou ambiente espelho)
- [ ] **Ponto**: dia convocado, paginação equipe, HE, competência, export
- [ ] **Chat**: contador não lidas (sino, lista, conversa, portal); botões encerrar/registrar só responsável
- [ ] **Minhas solicitações**: lista, filtros, detalhe com timeline
- [ ] **Sobre**: release notes sem duplicatas; sem bullets Interno/Infra
- [ ] Smoke pós-deploy: health API + frontend
