### PR TITLE
fix(frontend): hover legível no tema escuro nas listagens (#921)

### DIFF
--- a/.cursor/commands/criar-pr.md
+++ b/.cursor/commands/criar-pr.md
@@ -5,7 +5,7 @@ Finalize a feature, abra Pull Request para **`main`**, acompanhe o CI, aprove e 
 > **`main` é branch de testes** neste repo — após CI verde, merge automático é o comportamento padrão do `/criar-pr`.
 > Para **só abrir PR sem merge**, o usuário deve pedir explicitamente: `/criar-pr sem merge`.
 >
-> **Este comando NÃO serve para `staging`.** Release para produção = `/release-staging` (abre PR `main → staging` e **para**; o utilizador mergeia no GitHub). **Nunca** `gh pr merge` com base `staging`.
+> **Este comando NÃO serve para `staging`.** Release para produção = `/release-staging` (abre PR `main → staging` e para até merge humano; depois do Deploy, Passo 5 sync na `main`). **Nunca** `gh pr merge` com base `staging`.
 
 ## Pré-requisitos
 

--- a/.cursor/commands/release-staging.md
+++ b/.cursor/commands/release-staging.md
@@ -1,8 +1,8 @@
 # Release staging
 
-Abre Pull Request **`main` → `staging`** para o utilizador **analisar e aprovar no GitHub**.
+Abre Pull Request **`main` → `staging`** para o usuário **analisar e aprovar no GitHub**. Após merge e deploy, **sincroniza o CHANGELOG na `main`** (higiene pós-release).
 
-> **`staging` = produção.** O agente **NUNCA** faz `gh pr merge` neste fluxo — nem com CI verde, nem “para facilitar”.
+> **`staging` = produção.** O agente **NUNCA** faz `gh pr merge` no PR **`main → staging`** — nem com CI verde, nem “para facilitar”. O PR de sync **`→ main`** (Passo 5) **pode** ser mergeado automaticamente como em `/criar-pr`.
 
 ## Pré-requisitos
 
@@ -39,8 +39,90 @@ gh pr create --base staging --head main --title "release: main → staging" --bo
 
 Corpo do PR: Summary do lote (`[Unreleased]`) + test plan. **Sem** avisos sobre quem aprova/mergeia (isso é óbvio e irrelevante no GitHub).
 
-## Passo 4 — Entrega
+## Passo 4 — Entrega (pré-merge)
 
 No chat: URL do PR (base `staging`). Sem sermão sobre “merge só no GitHub”.
 
-**Não** executar: `gh pr merge`, push para `staging`.
+**Não** executar: `gh pr merge` (base `staging`), push para `staging`.
+
+---
+
+## Passo 5 — Higiene do CHANGELOG na `main` (pós-merge)
+
+**Quando:** o usuário confirmou merge do release **ou** o PR `main → staging` está `MERGED`, e o workflow **Deploy** em `staging` concluiu com sucesso (inclui o commit `chore(release): publica v… [skip ci]`).
+
+**Por quê:** o deploy consome `[Unreleased]` só na `staging`. A `main` continua com bullets já publicados até este passo — isso confunde o próximo lote e o `/release-staging` seguinte.
+
+### 5.1 — Verificar
+
+```bash
+git fetch origin
+gh pr view <número-do-release> --json state,mergedAt
+gh run list --branch staging --workflow deploy.yml --limit 5
+```
+
+Só prossiga com Deploy **verde** no commit de release. Se ainda estiver rodando, monitore (`gh run watch`) e retome depois.
+
+### 5.2 — Branch de sync
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b chore/sync-changelog-YYYYMMDD
+```
+
+### 5.3 — Artefatos de release (fonte: `origin/staging`)
+
+Arquivos que o deploy finaliza na `staging`:
+
+- `CHANGELOG.md` (nova seção CalVer + `[Unreleased]` vazio)
+- `VERSION`
+- `docs/releases/manifest.json`
+- `backend/app/data/release_notes.json`
+- `frontend/public/release-notes.json`
+
+**Se `origin/staging..origin/main` estiver vazio** (nada novo na `main` depois do release):
+
+```bash
+git checkout origin/staging -- CHANGELOG.md VERSION docs/releases/manifest.json \
+  backend/app/data/release_notes.json frontend/public/release-notes.json
+```
+
+**Se houver commits na `main` à frente da `staging`** (ex.: outro PR mergeado depois de abrir o release):
+
+1. Antes do checkout, **anotar** os bullets atuais de `## [Unreleased]` na `main` (só o delta ainda não publicado).
+2. Fazer o `git checkout origin/staging -- …` dos arquivos acima.
+3. **Reinserir** em `## [Unreleased]` os bullets anotados (formato `### DeskRudder` / `### SaaS Control Plane` — ver `docs/RELEASES.md`).
+
+Não duplicar bullets que já entraram na seção versionada do release.
+
+### 5.4 — PR → `main`
+
+```bash
+git add CHANGELOG.md VERSION docs/releases/manifest.json \
+  backend/app/data/release_notes.json frontend/public/release-notes.json
+git commit -m "chore(release): alinha CHANGELOG da main com vXX.XX.XXX publicada"
+git push -u origin HEAD
+gh pr create --base main --title "chore(release): sync CHANGELOG pós vXX.XX.XXX" --body "$(cat <<'EOF'
+## Summary
+
+- Sincroniza `CHANGELOG.md`, `VERSION` e artefatos de release notes com o que o deploy publicou em `staging`.
+- `[Unreleased]` na `main` fica só com o que ainda não foi para produção.
+
+## Test plan
+
+- [ ] `## [Unreleased]` sem bullets já publicados na CalVer do release
+- [ ] Nova seção `## [XX.XX.XXX]` espelha a `staging`
+- [ ] Se havia delta `staging..main`, bullets novos permanecem em `[Unreleased]`
+
+EOF
+)"
+```
+
+Merge automático em `main` **permitido** quando CI verde (mesmo fluxo de `/criar-pr`).
+
+### 5.5 — Entrega final
+
+No chat: versão publicada (`VERSION`), URL do PR de sync (se aberto) e confirmação de que `[Unreleased]` na `main` reflete só o próximo lote.
+
+**Opcional no mesmo turno** (se o usuário pediu): fechar issues do release, atualizar painel SaaS (#S… → Concluída com versão) — ver `/listar-solicitacoes`.

--- a/.cursor/rules/main-pr-batch-delivery.mdc
+++ b/.cursor/rules/main-pr-batch-delivery.mdc
@@ -27,7 +27,7 @@ feature/feat/<lote>  →  PR  →  main  →  (acumular)  →  PR main → stagi
 
 - **`main → staging`**: só quando houver **release** para produção (várias melhorias no `[Unreleased]`), não a cada merge na `main`.
 - **Nunca** commit direto na `main`.
-- **`staging` = produção**: o agente só **abre** o PR (`/release-staging`); **nunca** executa `gh pr merge` — aprovação e merge são **só do utilizador no GitHub**.
+- **`staging` = produção**: o agente **abre** o PR release (`/release-staging`) e **nunca** executa `gh pr merge` com base `staging`; após Deploy, faz sync CHANGELOG na `main` (Passo 5 do mesmo comando)
 
 ## Nomenclatura de branch
 
@@ -52,4 +52,4 @@ feature/feat/<lote>  →  PR  →  main  →  (acumular)  →  PR main → stagi
 ## Referências
 
 - Encerramento de issues: `.cursor/rules/issue-closure-backlog.mdc`, `docs/ISSUE_CLOSURE.md`
-- Deploy: `/release-staging` (PR sem merge pelo agente); ver `docs/RELEASES.md` e rule `staging-release-approval`
+- Deploy: `/release-staging` (release sem merge pelo agente; sync CHANGELOG na `main` após Deploy); ver `docs/RELEASES.md` e rule `staging-release-approval`

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -13,7 +13,7 @@ Sistema interno de helpdesk para redes de postos (tickets, WhatsApp, e-mail, SSE
 - Mudanças **mínimas**: só o necessário para a tarefa; não refatorar código adjacente.
 - **Não commitar** nem sugerir commit/push sem pedido explícito do usuário.
 - Git: branch nova por feature, PR para `main` — ver rule `git-workflow`.
-- **`staging` = produção**: só PR `main → staging` (`/release-staging`); agente **nunca** mergeia — ver `staging-release-approval`.
+- **`staging` = produção**: PR `main → staging` (`/release-staging`); agente **nunca** mergeia release — após Deploy, sync CHANGELOG na `main` (Passo 5); ver `staging-release-approval`
 
 ## Onde está a verdade
 

--- a/.cursor/rules/staging-release-approval.mdc
+++ b/.cursor/rules/staging-release-approval.mdc
@@ -22,8 +22,9 @@ alwaysApply: true
 
 1. Release = **um único PR** `main` → `staging` (abrir com `/release-staging` ou pedido explícito)
 2. Se houver conflito: resolver numa branch `merge/…`, abrir **um** PR para `staging`, **parar** e entregar o URL
-3. O utilizador (Luis) **analisa e aprova/mergeia no GitHub** — o agente **não** corre `gh pr merge` nesse PR
+3. O usuário (Luis) **analisa e aprova/mergeia no GitHub** — o agente **não** corre `gh pr merge` nesse PR
 4. Após merge humano: deploy/CalVer segue o workflow do repo (`docs/RELEASES.md`)
+5. **Pós-deploy:** o mesmo fluxo `/release-staging` inclui **Passo 5** — PR de sync do CHANGELOG e artefatos de release **`→ main`** (permitido merge automático com CI verde). Ver `.cursor/commands/release-staging.md`.
 
 ## Se o utilizador pedir merge em staging
 
@@ -37,3 +38,4 @@ Só Summary + test plan. **Não** incluir frases do tipo “Merge só no GitHub 
 
 - `/criar-pr` → só **`→ main`** (testes); merge automático CI verde **permitido**
 - `/release-staging` → só **abre** PR `main → staging`; **nunca** mergeia
+- Após merge do release + Deploy verde: **Passo 5** do mesmo comando — sync CHANGELOG `staging` → `main` via PR `→ main` (merge automático OK)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Config: `.cursor/hooks.json`
 | `/subir-local` | Subir Docker, migrations, API e frontend em dev |
 | `/testar-ui` | Smoke test no navegador integrado (login, rotas, console) |
 | `/criar-pr` | PR → watch CI → approve → **merge automático em main** (nunca staging) |
-| `/release-staging` | Abre PR `main → staging`; **não mergeia** (aprovação humana) |
+| `/release-staging` | Abre PR `main → staging` (não mergeia); após deploy, sync CHANGELOG na `main` (Passo 5) |
 | `/listar-solicitacoes` | Fila SaaS pendente no chat (MCP `deskrudder-saas`; cada dev configura o próprio `mcp.json`) |
 
 ## Subagents (Task tool)
@@ -76,7 +76,7 @@ Use subagents para **paralelizar** ou **isolar** trabalho:
 
 O `/criar-pr` monitora Actions, aprova e **mergeia em `main`** quando CI passa (main = branch de testes). Em falha, corrige e re-monitora (skill **babysit**). Opt-out: pedir `/criar-pr sem merge`.
 
-Release para produção: `/release-staging` — **só abre** o PR; merge em `staging` é **sempre** manual no GitHub.
+Release para produção: `/release-staging` — abre PR `main → staging` (merge manual no GitHub); depois do Deploy, **Passo 5** alinha CHANGELOG na `main`.
 
 Para desenvolvimento local: `/subir-local` → `/testar-ui` (navegador integrado).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
+### SaaS Control Plane
+
+#### Correções
+
+- Listagens do painel ops (Leads, Licenças): hover no tema escuro deixa de «lavar» o texto — contraste alinhado ao padrão das demais tabelas (#921 / #S202608-0001)
+
 ### DeskRudder
 
 #### Correções

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
+### DeskRudder
+
+#### Correções
+
+- Listagens (tema escuro): hover das linhas de tabela deixa de «lavar» o texto — contraste alinhado ao padrão das telas SaaS (#921 / #S202608-0001)
+
 ## [26.08.018] - 2026-08-28
 
 ### SaaS Control Plane

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -32,7 +32,8 @@ feature → PR main (+ CHANGELOG com tags Produto/DevOps) → PR main → stagin
 1. **Cada PR para `main`** com mudança visível: bullets em `CHANGELOG.md` → `## [Unreleased]` na **subseção** certa (tag Produto ou DevOps)
 2. **PR `main → staging`**: o `[Unreleased]` descreve **todo o lote** que será publicado
 3. **Merge em `staging`**: **só após análise e aprovação humana no GitHub** (`staging` = produção). Agentes/CI **não** mergeiam este PR automaticamente — usar `/release-staging` para abrir o PR e parar.
-4. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json` (cada bullet com `product`), zera `[Unreleased]`
+4. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json` (cada bullet com `product`), zera `[Unreleased]` e commita em `staging` (`chore(release): publica v… [skip ci]`)
+5. **Sync na `main`** (obrigatório, mesmo comando `/release-staging`): após Deploy verde, PR `chore/sync-changelog-…` → `main` copiando artefatos de `origin/staging` e preservando bullets de `[Unreleased]` que existam só na `main` (`origin/staging..origin/main`). Ver Passo 5 em `.cursor/commands/release-staging.md`.
 
 ## Formato do CHANGELOG
 
@@ -116,6 +117,16 @@ Após cada deploy, o workflow commita `VERSION`, `CHANGELOG.md`, `manifest.json`
 - [ ] `[Unreleased]` lista **todas** as entregas do lote (por produto)
 - [ ] Revisão de redação (sem «deploy», «branch», «commit»)
 - [ ] **Aprovação e merge manuais** no GitHub (agente não executa `gh pr merge`)
+
+## Checklist — pós-deploy (sync `main`)
+
+Executado pelo agente no **Passo 5** de `/release-staging` (após merge do release + Deploy verde em `staging`):
+
+- [ ] Workflow Deploy em `staging` concluído (commit `chore(release): publica v…`)
+- [ ] `CHANGELOG.md` na `main` alinhado com `staging` (seção CalVer nova; `[Unreleased]` sem itens já publicados)
+- [ ] `VERSION`, `manifest.json` e JSONs de release notes sincronizados
+- [ ] Se `main` tem commits à frente de `staging`, bullets novos **permanecem** em `[Unreleased]`
+- [ ] PR `chore/sync-changelog-…` → `main` mergeado (CI verde)
 
 ## Desenvolvimento local
 

--- a/frontend/src/components/FuncionariosEmpresaLista.tsx
+++ b/frontend/src/components/FuncionariosEmpresaLista.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+﻿import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import type { FuncionariosRede } from '../api/client'
 import { Button } from './ui/Button'
@@ -52,7 +52,7 @@ export function FuncionariosEmpresaLista({
           {items.map((f) => (
             <tr
               key={f.id}
-              className="transition-colors hover:bg-slate-50/80 dark:hover:bg-white/40"
+              className="transition-colors hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50"
             >
               <td className="px-4 py-3 font-medium text-slate-800 dark:text-slate-100 sm:px-6">
                 {f.nome}

--- a/frontend/src/components/KbConsultaPanel.tsx
+++ b/frontend/src/components/KbConsultaPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+﻿import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { kb, type Kb } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
@@ -280,7 +280,7 @@ export function KbConsultaPanel({ onInserirReferencia, showInserir = false }: Pr
                 <button
                   type="button"
                   onClick={() => abrirArtigo(item.id, item.slug)}
-                  className="flex w-full flex-col gap-0.5 px-4 py-3.5 text-left transition-colors hover:bg-slate-50 dark:hover:bg-white/50"
+                  className="flex w-full flex-col gap-0.5 px-4 py-3.5 text-left transition-colors hover:bg-slate-50 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60"
                 >
                   <span className="font-medium text-slate-900 dark:text-slate-100">{item.titulo}</span>
                   <span className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">

--- a/frontend/src/components/TicketsTabelaContexto.tsx
+++ b/frontend/src/components/TicketsTabelaContexto.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+﻿import { Link } from 'react-router-dom'
 import type { Tickets } from '../api/client'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { marcarTicketAtivo, TICKETS_PATH } from '../lib/ticketAtivo'
@@ -45,7 +45,7 @@ export function TicketsTabelaContexto({
           {items.map((t) => (
             <tr
               key={t.id}
-              className="transition-colors hover:bg-slate-50/80 dark:hover:bg-white/40"
+              className="transition-colors hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50"
             >
               <td
                 className="max-w-[11rem] truncate px-4 py-3 font-mono text-xs text-slate-800 dark:text-slate-100 sm:px-6"

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
@@ -133,7 +133,7 @@ export function Atendentes({ embedded = false }: { embedded?: boolean }) {
                         navigate(`/atendentes/${a.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 sm:px-6">
                       <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/pages/ConfigComercialCustos.tsx
+++ b/frontend/src/pages/ConfigComercialCustos.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+﻿import { useCallback, useEffect, useState } from 'react'
 import {
   ApiError,
   comercialCustosItens,
@@ -537,7 +537,7 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
                     {smItems.map((row) => {
                       const vigente = row.vigencia_fim == null
                       return (
-                        <tr key={row.id} className="transition-colors hover:bg-slate-50/80 dark:hover:bg-white/40">
+                        <tr key={row.id} className="transition-colors hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50">
                           <td className="px-4 py-3.5 font-medium tabular-nums text-slate-800 dark:text-slate-100 sm:px-6">
                             {fmtMoney(row.valor)}
                             {vigente ? (
@@ -629,7 +629,7 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
                 </thead>
                 <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
                   {itens.map((item) => (
-                    <tr key={item.id} className="transition-colors hover:bg-slate-50/80 dark:hover:bg-white/40">
+                    <tr key={item.id} className="transition-colors hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50">
                       <td className="px-4 py-3.5 font-medium text-slate-800 dark:text-slate-100 sm:px-6">{item.nome}</td>
                       <td className="px-4 py-3.5 text-slate-600 dark:text-slate-300 sm:px-6">
                         {TIPO_LABEL[item.tipo] ?? item.tipo}

--- a/frontend/src/pages/ConfigPdvCatalogos.tsx
+++ b/frontend/src/pages/ConfigPdvCatalogos.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+﻿import { useCallback, useEffect, useState } from 'react'
 import { ApiError, pdvRotulos, pdvTiposAcessoRemoto, type PdvCatalogo } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -285,7 +285,7 @@ export function ConfigPdvCatalogos({ embedded = false }: { embedded?: boolean })
                 {items.map((item) => (
                   <tr
                     key={item.id}
-                    className="transition-colors hover:bg-slate-50/80 dark:hover:bg-white/40"
+                    className="transition-colors hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50"
                   >
                     <td className="px-4 py-3.5 font-medium text-slate-800 dark:text-slate-100 sm:px-6">{item.nome}</td>
                     <td className="px-4 py-3.5 text-center tabular-nums text-slate-600 dark:text-slate-400 sm:px-6">

--- a/frontend/src/pages/Empresas.tsx
+++ b/frontend/src/pages/Empresas.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useNavigate } from 'react-router-dom'
@@ -211,7 +211,7 @@ export function Empresas() {
                           navigate(`/empresas/${e.id}`)
                         }
                       }}
-                      className="cursor-pointer transition-colors hover:bg-slate-50/90 focus-within:bg-slate-50/90 dark:hover:bg-white/50 dark:focus-within:bg-slate-800/50"
+                      className="cursor-pointer transition-colors hover:bg-slate-50/90 focus-within:bg-slate-50/90 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50"
                     >
                       <td className="max-w-0 py-3 pl-2 pr-4">
                         <div className="min-w-0 space-y-1">

--- a/frontend/src/pages/FuncionariosRede.tsx
+++ b/frontend/src/pages/FuncionariosRede.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   ApiError,
@@ -184,7 +184,7 @@ export function FuncionariosRede() {
                         navigate(`/funcionarios-rede/${f.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50 dark:focus-visible:bg-slate-800/60"
+                    className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 sm:px-6">
                       <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/pages/KbArtigos.tsx
+++ b/frontend/src/pages/KbArtigos.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+﻿import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError, kb, type Kb } from '../api/client'
 import { Card } from '../components/ui/Card'
@@ -173,7 +173,7 @@ export function KbArtigosPage({ embedded = false }: { embedded?: boolean }) {
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
                 {list.map((item) => (
-                  <tr key={item.id} className="hover:bg-slate-50/80 dark:hover:bg-white/40">
+                  <tr key={item.id} className="hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50">
                     <td className="px-4 py-3 font-medium">
                       {item.titulo}
                       {item.interno_only ? (

--- a/frontend/src/pages/KbCategorias.tsx
+++ b/frontend/src/pages/KbCategorias.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+﻿import { useCallback, useEffect, useState } from 'react'
 import { ApiError, kb, type Kb } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -196,7 +196,7 @@ export function KbCategoriasPage({ embedded = false }: { embedded?: boolean }) {
                 {arvore.map(({ categoria, depth }) => (
                   <tr
                     key={categoria.id}
-                    className={`hover:bg-slate-50/80 dark:hover:bg-white/40 ${dragId === categoria.id ? 'opacity-60' : ''}`}
+                    className={`hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50 ${dragId === categoria.id ? 'opacity-60' : ''}`}
                     onDragOver={(e) => e.preventDefault()}
                     onDrop={() => void soltarEm(categoria.id)}
                   >

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+﻿import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import {
   ApiError,
@@ -1565,7 +1565,7 @@ export function RedeDetalhe() {
                           openViewEmpresa(e)
                         }
                       }}
-                      className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50"
+                      className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60"
                     >
                       <td className="px-4 py-3.5 sm:px-6">
                         <div className="flex flex-wrap items-center gap-2">
@@ -1863,7 +1863,7 @@ export function RedeDetalhe() {
                           verFuncionarioDetalhe(f)
                         }
                       }}
-                      className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50"
+                      className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60"
                     >
                       <td className="px-4 py-3.5 font-medium text-slate-800 sm:px-6 dark:text-slate-100">{f.nome}</td>
                       <td className="max-w-[12rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300" title={f.email ?? undefined}>

--- a/frontend/src/pages/Redes.tsx
+++ b/frontend/src/pages/Redes.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useNavigate } from 'react-router-dom'
@@ -168,7 +168,7 @@ export function Redes() {
                         navigate(`/redes/${r.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50 dark:focus-visible:bg-slate-800/60"
+                    className="cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 sm:px-6">
                       <span className={`font-medium ${r.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>{r.nome}</span>

--- a/frontend/src/pages/RespostasProntas.tsx
+++ b/frontend/src/pages/RespostasProntas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+﻿import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError, respostasProntas, type RespostasProntas } from '../api/client'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
@@ -140,7 +140,7 @@ export function RespostasProntasPage({ embedded = false }: { embedded?: boolean 
                         navigate(`/respostas-prontas/${item.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 font-medium text-slate-800 sm:px-6 dark:text-slate-100">{item.titulo}</td>
                     <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+﻿import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ApiError, atendentes, setores, type Atendentes, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
@@ -434,7 +434,7 @@ export function SetorDetalhe() {
                     .slice()
                     .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
                     .map((a) => (
-                      <tr key={a.id} className="hover:bg-slate-50 dark:hover:bg-white/50">
+                      <tr key={a.id} className="hover:bg-slate-50 focus-within:bg-slate-50 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50">
                         <td className="px-4 py-3.5">
                           <span className={`font-medium ${a.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>
                             {a.nome}

--- a/frontend/src/pages/Setores.tsx
+++ b/frontend/src/pages/Setores.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { ApiError, setores, type Setores } from '../api/client'
@@ -138,7 +138,7 @@ export function Setores({ embedded = false }: { embedded?: boolean }) {
                         navigate(`/setores/${s.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50 focus:outline-none focus-visible:bg-slate-100 dark:focus-visible:bg-slate-800/60"
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 sm:px-6">
                       <span className={`font-medium ${s.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>{s.nome}</span>

--- a/frontend/src/pages/StatusTicket.tsx
+++ b/frontend/src/pages/StatusTicket.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
@@ -129,7 +129,7 @@ export function StatusTicketPage({ embedded = false }: { embedded?: boolean }) {
                         navigate(`/status-ticket/${s.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 sm:px-6">
                       <span className={`font-medium ${s.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>{s.nome}</span>

--- a/frontend/src/pages/TicketNaturezaMotivo.tsx
+++ b/frontend/src/pages/TicketNaturezaMotivo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+﻿import { useCallback, useEffect, useState } from 'react'
 import { ApiError, ticketClassificacao, type TicketClassificacao } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -272,7 +272,7 @@ export function TicketNaturezaMotivoPage({ embedded = false }: { embedded?: bool
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
                 {naturezas.map((item) => (
-                  <tr key={item.id} className="hover:bg-slate-50/80 dark:hover:bg-white/40">
+                  <tr key={item.id} className="hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50">
                     <td className="px-4 py-3.5 font-medium sm:px-6">{item.nome}</td>
                     <td className="px-4 py-3.5 font-mono text-xs text-slate-500 sm:px-6">{item.slug}</td>
                     <td className="px-4 py-3.5 text-center tabular-nums sm:px-6">{item.ordem}</td>
@@ -303,7 +303,7 @@ export function TicketNaturezaMotivoPage({ embedded = false }: { embedded?: bool
             </thead>
             <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
               {motivos.map((item) => (
-                <tr key={item.id} className="hover:bg-slate-50/80 dark:hover:bg-white/40">
+                <tr key={item.id} className="hover:bg-slate-50/80 focus-within:bg-slate-50/80 dark:hover:bg-white/5 dark:focus-within:bg-slate-800/50">
                   <td className="px-4 py-3.5 text-slate-600 sm:px-6">{item.natureza_nome ?? item.natureza_id}</td>
                   <td className="px-4 py-3.5 font-medium sm:px-6">{item.nome}</td>
                   <td className="px-4 py-3.5 font-mono text-xs text-slate-500 sm:px-6">{item.slug}</td>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useId, useCallback } from 'react'
+﻿import { useState, useEffect, useMemo, useId, useCallback } from 'react'
 import { Link, useLocation, useSearchParams } from 'react-router-dom'
 import {
   tickets,
@@ -769,7 +769,7 @@ export function Tickets() {
                     key={t.id}
                     type="button"
                     onClick={() => abrirTicket(t.id)}
-                    className={`w-full px-4 py-4 text-left transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/40 dark:focus-visible:bg-slate-800/60 ${
+                    className={`w-full px-4 py-4 text-left transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60 ${
                       proximoAuto
                         ? 'bg-amber-50/70 ring-1 ring-inset ring-amber-200/70 dark:bg-amber-950/25 dark:ring-amber-800/40'
                         : ''
@@ -985,7 +985,7 @@ export function Tickets() {
                         abrirTicket(t.id)
                       }
                     }}
-                    className={`cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50 dark:focus-visible:bg-slate-800/60 ${
+                    className={`cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60 ${
                       proximoAuto
                         ? 'bg-amber-50/70 ring-1 ring-inset ring-amber-200/70 dark:bg-amber-950/25 dark:ring-amber-800/40'
                         : ''

--- a/frontend/src/pages/TiposNegocio.tsx
+++ b/frontend/src/pages/TiposNegocio.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
@@ -137,7 +137,7 @@ export function TiposNegocio({ embedded = false }: { embedded?: boolean }) {
                         navigate(`/tipos-negocio/${t.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 sm:px-6">
                       <span className={`font-medium ${t.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>{t.nome}</span>

--- a/frontend/src/pages/saas/SaasLeads.tsx
+++ b/frontend/src/pages/saas/SaasLeads.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+﻿import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError, saasLeads, type SaasLeads } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
@@ -156,7 +156,7 @@ export function SaasLeads() {
                         navigate(`/saas/leads/${lead.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50"
+                    className="cursor-pointer transition-colors hover:bg-slate-50 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/5 dark:focus-visible:bg-slate-800/60"
                   >
                     <td className="px-4 py-3.5 sm:px-6">
                       <span className="font-medium text-slate-800 dark:text-slate-100">{lead.nome}</span>

--- a/frontend/src/pages/saas/SaasLicencas.tsx
+++ b/frontend/src/pages/saas/SaasLicencas.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+﻿import { useState, useEffect, useCallback } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { CabecalhoOrdenavel } from '../../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../../hooks/useOrdenacaoLista'
@@ -520,7 +520,7 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
                           navigate(`/saas/licencas/${item.id}`)
                         }
                       }}
-                      className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                      className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
                     >
                       <td className="px-4 py-3.5 sm:px-6">
                         <span className="font-medium text-slate-800 dark:text-slate-100">{item.nome}</span>


### PR DESCRIPTION
## Summary

- Corrige hover das linhas de tabela no **tema escuro**: fundo discreto (`dark:hover:bg-white/5`) em vez de branco a 40–50%, que lavava o texto (#921 / #S202608-0001).
- Alinha `focus-visible` / `focus-within` no mesmo contraste das telas SaaS (21 listagens do escopo da issue).
- Documenta **Passo 5** do `/release-staging`: sync do CHANGELOG na `main` após deploy em produção.

Closes #921

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `npm run build` passou
- [ ] Tema escuro: Empresas — hover na linha mantém texto legível
- [ ] Tema escuro: Redes ou SaasLicencas — mesmo padrão de contraste
- [ ] Tema claro: hover inalterado na prática
- [ ] Tab/foco no teclado: destaque visível sem lavar texto (tema escuro)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

Fora de escopo v1 (já com `/5` ou não listagem): `SaasLayout`, `SaasModulos`, `SolicitacoesMelhoriaListaTable` — sem follow-up necessário.
