### PR TITLE
feat(chat): abas Chats/Tickets no detalhe do contato (#1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Contato no chat: detalhe do funcionário da rede com abas **Geral**, **Chats** e **Tickets** — histórico operacional ao clicar no chip do contato (#1012 / #S202608-0012)
+
 #### Correções
 
 - Listagens (tema escuro): hover das linhas de tabela deixa de «lavar» o texto — contraste alinhado ao padrão das telas SaaS (#921 / #S202608-0001)

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
-from app.models import FuncionarioRede, FuncionarioRedeEmpresa, Ticket, Empresa
+from app.models import FuncionarioRede, FuncionarioRedeEmpresa, Ticket, Empresa, Rede
 from app.models.atendente import Atendente
 from app.schemas.funcionario_rede import (
     EmpresaOpcaoRead,
@@ -17,13 +17,14 @@ from app.schemas.funcionario_rede import (
 )
 from app.services.funcionario_escopo import (
     escopo_efetivo,
+    funcionario_visivel_no_tenant,
     sincronizar_vinculos_empresas,
     validar_empresa_ids_na_rede,
 )
 from app.services.inbound_ticket_reconcile import reconciliar_tickets_pendentes_por_email
 from app.services.funcionario_rede_resolver import assert_email_unico_por_rede, resolver_remetente_por_email
 from app.schemas.lista_paginada import ListaPaginada
-from app.core.auth import exigir_admin
+from app.core.auth import exigir_admin, obter_atendente_atual
 from app.core.audit import registrar_audit
 from app.core.security import hash_senha
 
@@ -68,6 +69,21 @@ def _para_read(f: FuncionarioRede) -> FuncionarioRedeRead:
         created_at=f.created_at,
         updated_at=f.updated_at,
     )
+
+
+def _para_read_detalhe(db: Session, f: FuncionarioRede) -> FuncionarioRedeRead:
+    base = _para_read(f)
+    rede_nome: str | None = None
+    if f.rede_id is not None:
+        rede = db.query(Rede).filter(Rede.id == f.rede_id).first()
+        if rede:
+            rede_nome = rede.nome
+    empresa_ids = _empresa_ids_leitura(f)
+    empresas_vinculo: list[EmpresaOpcaoRead] = []
+    if empresa_ids:
+        rows = db.query(Empresa).filter(Empresa.id.in_(empresa_ids)).order_by(Empresa.nome).all()
+        empresas_vinculo = [EmpresaOpcaoRead(id=e.id, nome=e.nome) for e in rows]
+    return base.model_copy(update={"rede_nome": rede_nome, "empresas_vinculo": empresas_vinculo})
 
 
 def _escopo_para_tipo(tipo: str, escopo_informado: str | None) -> str:
@@ -251,12 +267,12 @@ def criar(
 def obter(
     funcionario_id: int,
     db: Session = Depends(get_db),
-    _: Atendente = Depends(exigir_admin),
+    atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    f = db.query(FuncionarioRede).filter(FuncionarioRede.id == funcionario_id).first()
+    f = funcionario_visivel_no_tenant(db, atendente, funcionario_id, exigir_ativo=False)
     if not f:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Funcionário não encontrado")
-    return _para_read(f)
+    return _para_read_detalhe(db, f)
 
 
 @router.patch("/{funcionario_id}", response_model=FuncionarioRedeRead)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -10,9 +10,11 @@ from app.database import get_db
 from app.models import Ticket, TicketHistorico, TicketMensagem, Empresa, Setor, StatusTicket, Atendente, Rede
 from app.models.email_inbound_received import EmailInboundReceived
 from app.models.funcionario_rede import FuncionarioRede
+from app.services.funcionario_escopo import funcionario_visivel_no_tenant
 from app.models.ticket_anexo import TicketAnexo
 from app.models.ticket_vinculo import TIPO_DUPLICADO_DE, TicketVinculo
 from app.models.ticket_classificacao import TicketMotivo
+from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket
 from app.schemas.implantacao import TicketChecklistItemPatch, TicketChecklistRead
 from app.schemas.ticket import (
     EmpresaVinculoSugerida,
@@ -493,6 +495,11 @@ def listar(
         None,
         description="Filtrar por responsável (apenas administradores)",
     ),
+    funcionario_rede_id: int | None = Query(
+        None,
+        ge=1,
+        description="Tickets do contato (aberto_por_id ou vínculo via chat WhatsApp)",
+    ),
     situacao: SituacaoTicket = Query(
         SituacaoTicket.abertos,
         description="abertos = fechado_em vazio; fechados = fechado_em preenchido; todos = sem filtro",
@@ -549,6 +556,25 @@ def listar(
         q = q.filter(Ticket.atendente_id.isnot(None))
     elif sem_responsavel:
         q = q.filter(Ticket.atendente_id.is_(None))
+
+    if funcionario_rede_id is not None:
+        if funcionario_visivel_no_tenant(db, atendente, funcionario_rede_id, exigir_ativo=False) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Funcionário não encontrado",
+            )
+        ticket_ids_chat = (
+            db.query(WhatsappChatTicket.ticket_id)
+            .join(WhatsappChat, WhatsappChat.id == WhatsappChatTicket.chat_id)
+            .filter(WhatsappChat.funcionario_rede_id == funcionario_rede_id)
+            .distinct()
+        )
+        q = q.filter(
+            or_(
+                Ticket.aberto_por_id == funcionario_rede_id,
+                Ticket.id.in_(ticket_ids_chat),
+            )
+        )
 
     if situacao == SituacaoTicket.abertos:
         q = q.filter(Ticket.fechado_em.is_(None))

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -44,7 +44,7 @@ from app.schemas.whatsapp_chat import (
     WhatsappRedeCatalogoRead,
     WhatsappEmpresaCatalogoRead,
 )
-from app.services.funcionario_escopo import empresa_ids_vinculados, rede_id_efetiva, sincronizar_vinculos_empresas, validar_empresa_ids_na_rede
+from app.services.funcionario_escopo import empresa_ids_vinculados, funcionario_visivel_no_tenant, rede_id_efetiva, sincronizar_vinculos_empresas, validar_empresa_ids_na_rede
 from app.services.funcionario_rede_resolver import assert_email_unico_por_rede
 from app.core.audit import registrar_audit
 from app.core.auth import exigir_admin, obter_atendente_atual
@@ -863,6 +863,7 @@ def listar_encerrados(
     wa_id: str | None = Query(None, description="Filtro por número ou WhatsApp ID"),
     atendente_id: int | None = Query(None, ge=1, description="Filtro por atendente que encerrou"),
     empresa_id: int | None = Query(None, ge=1, description="Filtrar chats desta empresa (#591)"),
+    funcionario_rede_id: int | None = Query(None, ge=1, description="Filtrar chats deste contato (#1012)"),
     encerramento_inicio: datetime | None = Query(None, description="Filtro por data de encerramento a partir de"),
     encerramento_fim: datetime | None = Query(None, description="Filtro por data de encerramento até"),
     estado: str | None = Query(
@@ -900,6 +901,13 @@ def listar_encerrados(
         if not emp:
             return ListaPaginada(items=[], total=0)
         q = q.filter(WhatsappChat.empresa_id == empresa_id)
+    if funcionario_rede_id is not None:
+        if funcionario_visivel_no_tenant(db, atendente, funcionario_rede_id, exigir_ativo=False) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Funcionário não encontrado",
+            )
+        q = q.filter(WhatsappChat.funcionario_rede_id == funcionario_rede_id)
     ref_data = func.coalesce(
         WhatsappChat.encerramento_at,
         WhatsappChat.atendimento_inicio_at,

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -69,11 +69,18 @@ class FuncionarioRedeUpdate(BaseModel):
         return _telefone_normalizado(v)
 
 
+class EmpresaOpcaoRead(BaseModel):
+    id: int
+    nome: str
+
+
 class FuncionarioRedeRead(FuncionarioRedeBase):
     id: int
     rede_id: int | None = None
+    rede_nome: str | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] = []  # preenchido quando escopo_empresas == selected
+    empresas_vinculo: list[EmpresaOpcaoRead] = []
     portal_habilitado: bool = False
     must_change_password: bool = False
     notificar_email_portal: bool = True
@@ -86,11 +93,6 @@ class FuncionarioRedeRead(FuncionarioRedeBase):
 class FuncionarioRedeComVinculo(FuncionarioRedeRead):
     """Funcionário com texto 'vinculado a' (para exibição na tela da rede)."""
     vinculado_a: str = ""
-
-
-class EmpresaOpcaoRead(BaseModel):
-    id: int
-    nome: str
 
 
 class RemetenteFuncionarioResolveRead(BaseModel):

--- a/backend/app/services/funcionario_escopo.py
+++ b/backend/app/services/funcionario_escopo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
+from app.models.atendente import Atendente
 from app.models.empresa import Empresa
 from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
 
@@ -73,6 +74,44 @@ def funcionario_visivel_na_empresa(db: Session, funcionario: FuncionarioRede, em
     if rede_id is None or int(emp.rede_id) != int(rede_id):
         return False
     return int(empresa_id) in empresa_ids_vinculados(db, funcionario, apenas_ativas=False)
+
+
+def funcionario_visivel_no_tenant(
+    db: Session,
+    atendente: Atendente,
+    funcionario_id: int,
+    *,
+    exigir_ativo: bool = True,
+) -> FuncionarioRede | None:
+    """Funcionário da rede acessível ao atendente (mesmo tenant), ou None."""
+    from app.models.rede import Rede
+
+    func = db.query(FuncionarioRede).filter(FuncionarioRede.id == funcionario_id).first()
+    if not func or (exigir_ativo and not func.ativo):
+        return None
+    rede_id = rede_id_efetiva(db, func)
+    if rede_id is not None:
+        rede = db.query(Rede).filter(Rede.id == rede_id, Rede.tenant_id == atendente.tenant_id).first()
+        if rede:
+            return func
+    if func.empresa_id is not None:
+        emp = (
+            db.query(Empresa)
+            .filter(Empresa.id == func.empresa_id, Empresa.tenant_id == atendente.tenant_id)
+            .first()
+        )
+        if emp:
+            return func
+    vinculo = (
+        db.query(FuncionarioRedeEmpresa)
+        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
+        .filter(
+            FuncionarioRedeEmpresa.funcionario_id == func.id,
+            Empresa.tenant_id == atendente.tenant_id,
+        )
+        .first()
+    )
+    return func if vinculo else None
 
 
 def validar_empresa_ids_na_rede(db: Session, rede_id: int, empresa_ids: list[int]) -> None:

--- a/backend/tests/test_funcionario_rede_contato_1012.py
+++ b/backend/tests/test_funcionario_rede_contato_1012.py
@@ -1,0 +1,204 @@
+"""#1012 — chats e tickets por contato (funcionario_rede_id)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.models import Ticket
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket
+
+
+def _criar_funcionario(db_session, seed_base, *, email="contato@example.com"):
+    f = FuncionarioRede(
+        nome="Contato Teste",
+        email=email,
+        telefone="5511999887766",
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=seed_base["rede"].id,
+        empresa_id=seed_base["empresa"].id,
+    )
+    db_session.add(f)
+    db_session.flush()
+    return f
+
+
+def _protocolo(prefix: str) -> str:
+    return f"{prefix}{datetime.now(timezone.utc).timestamp()}"
+
+
+def test_atendente_obtem_funcionario_rede(client, seed_base, auth_headers, db_session):
+    f = _criar_funcionario(db_session, seed_base)
+    db_session.commit()
+
+    r = client.get(f"/v1/funcionarios-rede/{f.id}", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["telefone"] == "5511999887766"
+    assert body["rede_nome"] == seed_base["rede"].nome
+    assert len(body["empresas_vinculo"]) == 1
+    assert body["empresas_vinculo"][0]["id"] == seed_base["empresa"].id
+
+
+def test_atendente_403_lista_funcionarios_rede_inalterado(client, auth_headers):
+    r = client.get("/v1/funcionarios-rede", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_tickets_por_funcionario_rede_uniao(client, seed_base, auth_headers, db_session):
+    f = _criar_funcionario(db_session, seed_base, email="uniao@example.com")
+    t_portal = Ticket(
+        tenant_id=1,
+        protocolo=_protocolo("TP-"),
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=seed_base["status"].id,
+        assunto="Portal",
+        aberto_por_id=f.id,
+    )
+    t_chat = Ticket(
+        tenant_id=1,
+        protocolo=_protocolo("TC-"),
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=seed_base["status"].id,
+        assunto="Via chat",
+    )
+    db_session.add_all([t_portal, t_chat])
+    db_session.flush()
+    chat = WhatsappChat(
+        protocolo=_protocolo("WC-"),
+        wa_id="5511888776655",
+        estado="encerrado",
+        setor_id=seed_base["setor1"].id,
+        funcionario_rede_id=f.id,
+        empresa_id=seed_base["empresa"].id,
+        atendente_id=seed_base["a1"].id,
+    )
+    db_session.add(chat)
+    db_session.flush()
+    db_session.add(WhatsappChatTicket(chat_id=chat.id, ticket_id=t_chat.id, atendente_id=seed_base["a1"].id))
+    db_session.commit()
+
+    r = client.get(
+        f"/v1/tickets?funcionario_rede_id={f.id}&situacao=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    ids = {item["id"] for item in r.json()["items"]}
+    assert t_portal.id in ids
+    assert t_chat.id in ids
+    assert len(ids) == 2
+
+
+def test_tickets_funcionario_rede_inexistente_404(client, auth_headers):
+    r = client.get("/v1/tickets?funcionario_rede_id=999999&situacao=abertos", headers=auth_headers["a1"])
+    assert r.status_code == 404
+
+
+def test_tickets_funcionario_rede_respeita_escopo_setor(client, seed_base, auth_headers, db_session):
+    f = _criar_funcionario(db_session, seed_base, email="setor@example.com")
+    t_setor1 = Ticket(
+        tenant_id=1,
+        protocolo=_protocolo("TS1-"),
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=seed_base["status"].id,
+        assunto="Setor 1",
+        aberto_por_id=f.id,
+    )
+    t_setor2 = Ticket(
+        tenant_id=1,
+        protocolo=_protocolo("TS2-"),
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor2"].id,
+        status_id=seed_base["status"].id,
+        assunto="Setor 2",
+        aberto_por_id=f.id,
+    )
+    db_session.add_all([t_setor1, t_setor2])
+    db_session.commit()
+
+    r_a1 = client.get(
+        f"/v1/tickets?funcionario_rede_id={f.id}&situacao=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r_a1.status_code == 200
+    ids_a1 = {item["id"] for item in r_a1.json()["items"]}
+    assert t_setor1.id in ids_a1
+    assert t_setor2.id not in ids_a1
+
+    r_a2 = client.get(
+        f"/v1/tickets?funcionario_rede_id={f.id}&situacao=todos",
+        headers=auth_headers["a2"],
+    )
+    assert r_a2.status_code == 200
+    ids_a2 = {item["id"] for item in r_a2.json()["items"]}
+    assert t_setor2.id in ids_a2
+    assert t_setor1.id not in ids_a2
+
+
+def test_chats_encerrados_por_funcionario_rede(client, seed_base, auth_headers, db_session):
+    f = _criar_funcionario(db_session, seed_base, email="chats@example.com")
+    chat = WhatsappChat(
+        protocolo=_protocolo("WA-"),
+        wa_id="5511777666555",
+        estado="em_atendimento",
+        setor_id=seed_base["setor1"].id,
+        funcionario_rede_id=f.id,
+        atendente_id=seed_base["a1"].id,
+        empresa_id=seed_base["empresa"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    r = client.get(
+        f"/v1/whatsapp/chats/encerrados?funcionario_rede_id={f.id}&estado=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    assert r.json()["total"] == 1
+    assert r.json()["items"][0]["id"] == chat.id
+
+
+def test_chats_funcionario_rede_respeita_escopo_setor(client, seed_base, auth_headers, db_session):
+    f = _criar_funcionario(db_session, seed_base, email="chatsetor@example.com")
+    chat_s1 = WhatsappChat(
+        protocolo=_protocolo("CS1-"),
+        wa_id="5511666555444",
+        estado="encerrado",
+        setor_id=seed_base["setor1"].id,
+        funcionario_rede_id=f.id,
+        atendente_id=seed_base["a1"].id,
+        empresa_id=seed_base["empresa"].id,
+    )
+    chat_s2 = WhatsappChat(
+        protocolo=_protocolo("CS2-"),
+        wa_id="5511555444333",
+        estado="encerrado",
+        setor_id=seed_base["setor2"].id,
+        funcionario_rede_id=f.id,
+        atendente_id=seed_base["a2"].id,
+        empresa_id=seed_base["empresa"].id,
+    )
+    db_session.add_all([chat_s1, chat_s2])
+    db_session.commit()
+
+    r_a1 = client.get(
+        f"/v1/whatsapp/chats/encerrados?funcionario_rede_id={f.id}&estado=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r_a1.status_code == 200
+    ids_a1 = {item["id"] for item in r_a1.json()["items"]}
+    assert chat_s1.id in ids_a1
+    assert chat_s2.id not in ids_a1
+
+
+def test_chats_funcionario_rede_inexistente_404(client, auth_headers):
+    r = client.get(
+        "/v1/whatsapp/chats/encerrados?funcionario_rede_id=999999&estado=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 404

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -660,14 +660,7 @@ function AppRoutes() {
           }
         />
         <Route path="atendentes" element={<Navigate to="/configuracoes/equipe/atendentes" replace />} />
-        <Route
-          path="funcionarios-rede/:id"
-          element={
-            <AdminRoute>
-              <FuncionarioRedeDetalhe />
-            </AdminRoute>
-          }
-        />
+        <Route path="funcionarios-rede/:id" element={<FuncionarioRedeDetalhe />} />
         <Route
           path="funcionarios-rede/novo"
           element={

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1699,6 +1699,7 @@ export const tickets = {
     com_responsavel?: boolean;
     meus?: boolean;
     atendente_id?: number;
+    funcionario_rede_id?: number;
     /** Coluna para ordenar (omitir = mais recentes primeiro). */
     ordenar_por?: 'protocolo' | 'rede' | 'empresa' | 'setor' | 'assunto' | 'status' | 'responsavel' | 'fechado_em' | 'fila_desde_at';
     ordem?: 'asc' | 'desc';
@@ -2690,6 +2691,10 @@ export namespace Atendentes {
 
 export namespace FuncionariosRede {
   export type EscopoEmpresas = 'all' | 'selected';
+  export interface EmpresaVinculo {
+    id: number;
+    nome: string;
+  }
   export interface Funcionario {
     id: number;
     nome: string;
@@ -2699,8 +2704,10 @@ export namespace FuncionariosRede {
     escopo_empresas: EscopoEmpresas;
     ativo: boolean;
     rede_id?: number;
+    rede_nome?: string | null;
     empresa_id?: number;
     empresa_ids: number[];
+    empresas_vinculo?: EmpresaVinculo[];
     portal_habilitado?: boolean;
     must_change_password?: boolean;
     notificar_email_portal?: boolean;

--- a/frontend/src/components/EmpresaChatsPanel.tsx
+++ b/frontend/src/components/EmpresaChatsPanel.tsx
@@ -13,7 +13,12 @@ import { marcarWhatsappChatAtivo, whatsappConversaLink } from '../lib/whatsappLi
 import { ChatIniciarConversaModal } from './chat/ChatIniciarConversaModal'
 
 type Props = {
-  empresaId: number
+  empresaId?: number
+  funcionarioRedeId?: number
+  returnPath: string
+  intro?: string
+  emptyTitle?: string
+  emptyDescription?: string
 }
 
 function formatDuration(chat: WhatsappChats.Chat) {
@@ -40,7 +45,14 @@ function formatDateTime(iso?: string | null) {
   })
 }
 
-export function EmpresaChatsPanel({ empresaId }: Props) {
+export function EmpresaChatsPanel({
+  empresaId,
+  funcionarioRedeId,
+  returnPath,
+  intro,
+  emptyTitle,
+  emptyDescription,
+}: Props) {
   const toast = useToast()
   const [page, setPage] = useState(1)
   const [busca, setBusca] = useState('')
@@ -50,8 +62,6 @@ export function EmpresaChatsPanel({ empresaId }: Props) {
   const [loading, setLoading] = useState(false)
   const [retomarChat, setRetomarChat] = useState<WhatsappChats.Chat | null>(null)
 
-  const returnPath = `/empresas/${empresaId}`
-
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
     return () => clearTimeout(t)
@@ -60,14 +70,16 @@ export function EmpresaChatsPanel({ empresaId }: Props) {
   useEffect(() => {
     let cancelled = false
     setLoading(true)
+    const params: Record<string, string | number | undefined> = {
+      estado: 'todos',
+      offset: (page - 1) * PAGE_SIZE_PADRAO,
+      limit: PAGE_SIZE_PADRAO,
+      busca: debouncedBusca || undefined,
+    }
+    if (empresaId != null) params.empresa_id = empresaId
+    if (funcionarioRedeId != null) params.funcionario_rede_id = funcionarioRedeId
     whatsappChats
-      .encerrados({
-        empresa_id: empresaId,
-        estado: 'todos',
-        offset: (page - 1) * PAGE_SIZE_PADRAO,
-        limit: PAGE_SIZE_PADRAO,
-        busca: debouncedBusca || undefined,
-      })
+      .encerrados(params)
       .then(({ items: rows, total: t }) => {
         if (!cancelled) {
           setItems(rows)
@@ -76,7 +88,9 @@ export function EmpresaChatsPanel({ empresaId }: Props) {
       })
       .catch((err) => {
         if (!cancelled) {
-          toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar chats da empresa.'))
+          toast.showError(
+            mensagemFalhaParaToast(err, 'Falha ao carregar chats.'),
+          )
           setItems([])
           setTotal(0)
         }
@@ -87,13 +101,23 @@ export function EmpresaChatsPanel({ empresaId }: Props) {
     return () => {
       cancelled = true
     }
-  }, [empresaId, page, debouncedBusca, toast])
+  }, [empresaId, funcionarioRedeId, page, debouncedBusca, toast])
+
+  const textoIntro =
+    intro ??
+    (funcionarioRedeId != null
+      ? 'Conversas WhatsApp vinculadas a este contato.'
+      : 'Chats e atendimentos WhatsApp vinculados a esta empresa.')
+  const tituloVazio = emptyTitle ?? (funcionarioRedeId != null ? 'Nenhum chat encontrado' : 'Nenhum chat nesta empresa')
+  const descVazio =
+    emptyDescription ??
+    (funcionarioRedeId != null
+      ? 'Quando houver atendimentos com este contato, eles aparecem aqui.'
+      : 'Quando houver atendimentos com esta empresa de contexto, eles aparecem aqui.')
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-500 dark:text-slate-400">
-        Chats e atendimentos WhatsApp vinculados a esta empresa.
-      </p>
+      <p className="text-sm text-slate-500 dark:text-slate-400">{textoIntro}</p>
       <BarraBuscaPaginacao
         busca={busca}
         onBuscaChange={(v) => {
@@ -115,10 +139,8 @@ export function EmpresaChatsPanel({ empresaId }: Props) {
         </div>
       ) : items.length === 0 ? (
         <Card className="flex flex-col items-center justify-center border-dashed border-2 py-14 text-center">
-          <h3 className="font-semibold text-slate-900 dark:text-slate-100">Nenhum chat nesta empresa</h3>
-          <p className="mt-1 text-sm text-slate-500">
-            Quando houver atendimentos com esta empresa de contexto, eles aparecem aqui.
-          </p>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-100">{tituloVazio}</h3>
+          <p className="mt-1 text-sm text-slate-500">{descVazio}</p>
         </Card>
       ) : (
         <div className="grid gap-3">

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -461,7 +461,7 @@ export function EmpresaDetalhe() {
 
       {aba === 'chats' && (
         <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-800/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
-          <EmpresaChatsPanel empresaId={empresa.id} />
+          <EmpresaChatsPanel empresaId={empresa.id} returnPath={`/empresas/${empresa.id}`} />
         </section>
       )}
 

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -1,13 +1,21 @@
-import { useEffect, useState, type ReactNode } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
-import { ApiError, funcionariosRede, redes, empresas, type FuncionariosRede } from '../api/client'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { ApiError, funcionariosRede, tickets, type FuncionariosRede, type Tickets } from '../api/client'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { useAuth } from '../contexts/AuthContext'
 import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { VoltarButton } from '../components/ui/VoltarButton'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
+import { EmpresaChatsPanel } from '../components/EmpresaChatsPanel'
+import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
+import { formatTelefoneBrExibicao } from '../utils/masks'
+
+type Aba = 'geral' | 'chats' | 'tickets'
+type SituacaoTickets = 'abertos' | 'fechados' | 'todos'
 
 const tipoLabel: Record<string, string> = {
   socio: 'Sócio',
@@ -25,19 +33,95 @@ function DetailRow({ label, value }: { label: string; value: string | null | und
   )
 }
 
+const linkEmpresaClass =
+  'font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500'
+
+function renderEmpresaVinculo(em: FuncionariosRede.EmpresaVinculo, admin: boolean) {
+  if (admin) {
+    return (
+      <Link to={`/empresas/${em.id}`} className={linkEmpresaClass}>
+        {em.nome}
+      </Link>
+    )
+  }
+  return <span className="font-medium text-slate-800 dark:text-slate-100">{em.nome}</span>
+}
+
+function buildVinculoExtra(func: FuncionariosRede.Funcionario, admin: boolean): ReactNode {
+  if (func.tipo === 'socio') {
+    return (
+      <p className="text-sm text-slate-700 dark:text-slate-200">
+        Pessoa vinculada como <strong>sócio</strong> da rede (visão e cadastros no contexto da rede).
+      </p>
+    )
+  }
+  const empresas = func.empresas_vinculo ?? []
+  if (func.tipo === 'colaborador' && empresas.length > 0) {
+    return (
+      <p className="text-sm text-slate-700 dark:text-slate-200">
+        Colaborador da empresa {renderEmpresaVinculo(empresas[0], admin)}.
+      </p>
+    )
+  }
+  if (func.tipo === 'supervisor' && empresas.length > 0) {
+    return (
+      <ul className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-slate-700 dark:text-slate-200">
+        {empresas.map((em) => (
+          <li key={em.id}>{renderEmpresaVinculo(em, admin)}</li>
+        ))}
+      </ul>
+    )
+  }
+  return null
+}
+
 export function FuncionarioRedeDetalhe() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const voltarAnterior = useVoltarAnterior('/funcionarios-rede')
+  const location = useLocation()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const voltarPara = (location.state as { voltarPara?: string } | null)?.voltarPara
+  const { isAdmin } = useAuth()
+  const voltarHistorico = useVoltarAnterior(isAdmin ? '/funcionarios-rede' : '/chat/atendendo')
+  const voltar = useCallback(() => {
+    if (voltarPara) {
+      navigate(voltarPara)
+      return
+    }
+    voltarHistorico()
+  }, [navigate, voltarPara, voltarHistorico])
   const toast = useToast()
   const funcionarioId = id ? parseInt(id, 10) : NaN
+  const returnPath = `/funcionarios-rede/${funcionarioId}${searchParams.get('aba') ? `?aba=${searchParams.get('aba')}` : ''}`
 
   const [f, setF] = useState<FuncionariosRede.Funcionario | null>(null)
-  const [redeNome, setRedeNome] = useState('')
-  const [vinculoExtra, setVinculoExtra] = useState<ReactNode>(null)
   const [loading, setLoading] = useState(true)
   const [loadFailure, setLoadFailure] = useState<{ titulo: string; detalhe?: string } | null>(null)
   const [forbidden, setForbidden] = useState(false)
+  const [aba, setAba] = useState<Aba>('geral')
+
+  const [pageT, setPageT] = useState(1)
+  const [buscaT, setBuscaT] = useState('')
+  const [debouncedBuscaT, setDebouncedBuscaT] = useState('')
+  const [situacaoT, setSituacaoT] = useState<SituacaoTickets>('abertos')
+  const [ticketsItems, setTicketsItems] = useState<Tickets.Ticket[]>([])
+  const [ticketsTotal, setTicketsTotal] = useState(0)
+  const [loadingT, setLoadingT] = useState(false)
+
+  useEffect(() => {
+    const q = searchParams.get('aba')
+    if (q === 'chats' || q === 'tickets' || q === 'geral') {
+      setAba(q)
+    }
+  }, [searchParams])
+
+  const mudarAba = (key: Aba) => {
+    setAba(key)
+    const next = new URLSearchParams(searchParams)
+    if (key === 'geral') next.delete('aba')
+    else next.set('aba', key)
+    setSearchParams(next, { replace: true })
+  }
 
   useEffect(() => {
     if (!id || isNaN(funcionarioId)) {
@@ -52,89 +136,11 @@ export function FuncionarioRedeDetalhe() {
     setLoading(true)
     setLoadFailure(null)
     setForbidden(false)
-    setVinculoExtra(null)
 
     funcionariosRede
       .get(funcionarioId)
-      .then(async (func) => {
-        if (cancelled) return
-        setF(func)
-
-        const rid = func.rede_id
-        if (rid != null) {
-          try {
-            const r = await redes.get(rid)
-            if (!cancelled) setRedeNome(r.nome)
-          } catch {
-            if (!cancelled) setRedeNome('—')
-          }
-        } else if (!cancelled) setRedeNome('')
-
-        if (cancelled) return
-
-        if (func.tipo === 'socio') {
-          setVinculoExtra(
-            <p className="text-sm text-slate-700 dark:text-slate-200">
-              Pessoa vinculada como <strong>sócio</strong> da rede (visão e cadastros no contexto da rede).
-            </p>,
-          )
-        } else if (func.tipo === 'colaborador' && func.empresa_id) {
-          try {
-            const em = await empresas.get(func.empresa_id)
-            if (!cancelled) {
-              setVinculoExtra(
-                <p className="text-sm text-slate-700 dark:text-slate-200">
-                  Colaborador da empresa{' '}
-                  <Link
-                    to={`/empresas/${em.id}`}
-                    className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
-                  >
-                    {em.nome}
-                  </Link>
-                  .
-                </p>,
-              )
-            }
-          } catch {
-            if (!cancelled) {
-              setVinculoExtra(
-                <p className="text-sm text-slate-600 dark:text-slate-400">Empresa vinculada (ID {func.empresa_id}) não encontrada.</p>,
-              )
-            }
-          }
-        } else if (func.tipo === 'supervisor' && func.empresa_ids?.length) {
-          try {
-            const lista = await Promise.all(
-              func.empresa_ids.map((eid) =>
-                empresas.get(eid).catch(() => null),
-              ),
-            )
-            if (cancelled) return
-            const ok = lista.filter(Boolean) as Awaited<ReturnType<typeof empresas.get>>[]
-            if (ok.length === 0) {
-              setVinculoExtra(<p className="text-sm text-slate-600 dark:text-slate-400">Não foi possível carregar os nomes das empresas.</p>)
-            } else {
-              setVinculoExtra(
-                <ul className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-slate-700 dark:text-slate-200">
-                  {ok.map((em) => (
-                    <li key={em.id}>
-                      <Link
-                        to={`/empresas/${em.id}`}
-                        className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
-                      >
-                        {em.nome}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>,
-              )
-            }
-          } catch {
-            if (!cancelled) setVinculoExtra(null)
-          }
-        } else {
-          setVinculoExtra(null)
-        }
+      .then((func) => {
+        if (!cancelled) setF(func)
       })
       .catch((err) => {
         if (!cancelled) {
@@ -156,6 +162,37 @@ export function FuncionarioRedeDetalhe() {
     }
   }, [id, funcionarioId])
 
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBuscaT(buscaT.trim()), 400)
+    return () => clearTimeout(t)
+  }, [buscaT])
+
+  useEffect(() => {
+    if (aba !== 'tickets' || !funcionarioId || Number.isNaN(funcionarioId)) return
+    let cancelled = false
+    setLoadingT(true)
+    tickets
+      .list({
+        funcionario_rede_id: funcionarioId,
+        situacao: situacaoT,
+        offset: (pageT - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+        busca: debouncedBuscaT || undefined,
+      })
+      .then(({ items, total }) => {
+        if (!cancelled) {
+          setTicketsItems(items)
+          setTicketsTotal(total)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingT(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [aba, funcionarioId, pageT, debouncedBuscaT, situacaoT])
+
   function abrirEdicao() {
     if (!f) return
     navigate(`/funcionarios-rede/${f.id}/editar`)
@@ -166,7 +203,7 @@ export function FuncionarioRedeDetalhe() {
     try {
       await funcionariosRede.delete(f.id)
       toast.showSuccess('Funcionário excluído.')
-      voltarAnterior()
+      voltar()
     } catch (err) {
       toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir o funcionário.'))
     }
@@ -186,19 +223,17 @@ export function FuncionarioRedeDetalhe() {
     return (
       <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
-          title="Você não tem permissão para acessar este funcionário."
+          title="Você não tem permissão para acessar este contato."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
-          voltarPara="/funcionarios-rede"
-          voltarLabel="Voltar para Funcionários"
+          voltarPara={isAdmin ? '/funcionarios-rede' : '/chat/atendendo'}
+          voltarLabel={isAdmin ? 'Voltar para Funcionários' : 'Voltar para chats'}
         />
       </div>
     )
   }
 
   if (loadFailure) {
-    return (
-      <CarregamentoFalhou titulo={loadFailure.titulo} detalhe={loadFailure.detalhe} onVoltar={voltarAnterior} />
-    )
+    return <CarregamentoFalhou titulo={loadFailure.titulo} detalhe={loadFailure.detalhe} onVoltar={voltar} />
   }
 
   if (!f) {
@@ -210,18 +245,36 @@ export function FuncionarioRedeDetalhe() {
     createdRaw != null && createdRaw !== ''
       ? new Date(createdRaw).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
       : null
+  const telefoneFmt = formatTelefoneBrExibicao(f.telefone) || null
+  const vinculoExtra = buildVinculoExtra(f, isAdmin)
+  const redeNome = f.rede_nome?.trim() || null
+
+  const tabBtn = (key: Aba, label: string) => (
+    <button
+      type="button"
+      onClick={() => mudarAba(key)}
+      aria-current={aba === key ? 'page' : undefined}
+      className={
+        aba === key
+          ? 'border-b-2 border-sky-500 px-3 py-2 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:bg-slate-800/50 dark:text-white'
+          : 'border-b-2 border-transparent px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:bg-white/30 dark:hover:text-slate-200'
+      }
+    >
+      {label}
+    </button>
+  )
 
   return (
     <div className="mx-auto w-full min-w-0 max-w-6xl space-y-8 pb-10">
       <div>
-        <VoltarButton onClick={voltarAnterior} />
+        <VoltarButton onClick={voltar} />
       </div>
 
       <header className="space-y-3">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0 space-y-2">
             <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100 md:text-3xl">{f.nome}</h1>
-            <p className="break-all text-sm text-slate-600 dark:text-slate-400">{f.email}</p>
+            <p className="break-all text-sm text-slate-600 dark:text-slate-400">{f.email || '—'}</p>
             <div className="flex flex-wrap items-center gap-2">
               <span
                 className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
@@ -236,47 +289,117 @@ export function FuncionarioRedeDetalhe() {
             </div>
           </div>
           <div className="flex shrink-0 flex-wrap gap-2">
-            <Button variant="secondary" onClick={voltarAnterior}>
+            <Button variant="secondary" onClick={voltar}>
               Voltar
             </Button>
-            <Button onClick={abrirEdicao}>Editar</Button>
-            <Button variant="danger" onClick={handleExcluir}>
-              Excluir
-            </Button>
+            {isAdmin ? (
+              <>
+                <Button onClick={abrirEdicao}>Editar</Button>
+                <Button variant="danger" onClick={handleExcluir}>
+                  Excluir
+                </Button>
+              </>
+            ) : null}
           </div>
         </div>
       </header>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
-          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Vínculos</h2>
-          <dl>
-            <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5">
-              <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Rede</dt>
-              <dd className="text-sm">
-                {f.rede_id != null && redeNome && redeNome !== '—' ? (
-                  <Link
-                    to={`/redes/${f.rede_id}`}
-                    className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 transition-colors hover:text-slate-950 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
-                  >
-                    {redeNome}
-                  </Link>
-                ) : (
-                  <span className="text-slate-800 dark:text-slate-100">—</span>
-                )}
-              </dd>
-            </div>
-          </dl>
-          {vinculoExtra ? <div className="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">{vinculoExtra}</div> : null}
-        </section>
+      <nav className="-mb-2 flex flex-wrap gap-1 border-b border-slate-200 dark:border-slate-800" aria-label="Abas do contato">
+        {tabBtn('geral', 'Geral')}
+        {tabBtn('chats', 'Chats')}
+        {tabBtn('tickets', 'Tickets')}
+      </nav>
 
-        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
-          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Registro</h2>
-          <dl>
-            <DetailRow label="Cadastrado em" value={createdFmt} />
-          </dl>
+      {aba === 'geral' && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Vínculos</h2>
+            <dl>
+              <DetailRow label="Telefone" value={telefoneFmt} />
+              <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5 dark:border-slate-800">
+                <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Rede</dt>
+                <dd className="text-sm">
+                  {f.rede_id != null && redeNome ? (
+                    isAdmin ? (
+                      <Link
+                        to={`/redes/${f.rede_id}`}
+                        className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 transition-colors hover:text-slate-950 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
+                      >
+                        {redeNome}
+                      </Link>
+                    ) : (
+                      <span className="text-slate-800 dark:text-slate-100">{redeNome}</span>
+                    )
+                  ) : (
+                    <span className="text-slate-800 dark:text-slate-100">—</span>
+                  )}
+                </dd>
+              </div>
+            </dl>
+            {vinculoExtra ? <div className="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">{vinculoExtra}</div> : null}
+          </section>
+
+          <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Registro</h2>
+            <dl>
+              <DetailRow label="Cadastrado em" value={createdFmt} />
+            </dl>
+          </section>
+        </div>
+      )}
+
+      {aba === 'chats' && (
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-800/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+          <EmpresaChatsPanel funcionarioRedeId={f.id} returnPath={returnPath} />
         </section>
-      </div>
+      )}
+
+      {aba === 'tickets' && (
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-800/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+          <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
+            Tickets abertos pelo contato no portal ou vinculados às conversas WhatsApp dele.
+          </p>
+          <div className="mb-4 flex flex-wrap gap-2">
+            {(['abertos', 'fechados', 'todos'] as const).map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => {
+                  setSituacaoT(s)
+                  setPageT(1)
+                }}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  situacaoT === s
+                    ? 'bg-sky-100 text-sky-900 dark:bg-sky-950/50 dark:text-sky-200'
+                    : 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
+                }`}
+              >
+                {s === 'abertos' ? 'Abertos' : s === 'fechados' ? 'Fechados' : 'Todos'}
+              </button>
+            ))}
+          </div>
+          <BarraBuscaPaginacao
+            busca={buscaT}
+            onBuscaChange={(v) => {
+              setBuscaT(v)
+              setPageT(1)
+            }}
+            placeholder="Protocolo ou assunto..."
+            page={pageT}
+            total={ticketsTotal}
+            onPageChange={setPageT}
+            disabled={loadingT}
+          />
+          <div className="mt-4">
+            <TicketsTabelaContexto
+              items={ticketsItems}
+              loading={loadingT}
+              showEmpresaColumn
+              emptyMessage="Nenhum ticket encontrado para este contato."
+            />
+          </div>
+        </section>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -2020,7 +2020,8 @@ useEffect(() => {
             {chat?.funcionario_rede_id && (
               <div className="flex flex-wrap items-center gap-1.5">
                 <Link
-                  to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
+                  to={`/funcionarios-rede/${chat.funcionario_rede_id}?aba=chats`}
+                  state={{ voltarPara: `${location.pathname}${location.search}` }}
                   className="inline-flex max-w-full truncate rounded-full border border-violet-200/80 bg-violet-50 px-2 py-0.5 text-[10px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-300"
                   title={chat.funcionario_email ?? undefined}
                 >

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -323,10 +323,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
             )}
             <div className="mt-2 flex flex-wrap gap-2">
               <Link
-                to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
+                to={`/funcionarios-rede/${chat.funcionario_rede_id}?aba=chats`}
+                state={{ voltarPara: window.location.pathname + window.location.search }}
                 className="text-xs font-medium text-cyan-700 underline dark:text-cyan-300"
               >
-                Abrir cadastro
+                Ver histórico de chats
               </Link>
               <button
                 type="button"


### PR DESCRIPTION
## Summary

- Detalhe do contato (`FuncionarioRedeDetalhe`) com abas **Geral**, **Chats** e **Tickets** — visão operacional ao clicar no chip do contato no WhatsApp (#1012 / #S202608-0012)
- Backend: filtros `funcionario_rede_id` em tickets (união portal + chat) e chats encerrados; `GET /funcionarios-rede/{id}` liberado para atendentes com `rede_nome` e `empresas_vinculo`; 404 quando contato inválido
- Frontend: chip do chat abre `?aba=chats`; painel de chats reutilizado; RBAC (editar/excluir só admin)

Closes #1012

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest tests/test_funcionario_rede_contato_1012.py` — 8 testes (GET atendente, união tickets, 404, escopo setor tickets/chats)
- [x] `npm run build` — OK
- [ ] Smoke manual: chip no chat → aba Chats; aba Tickets com toggle abertos/fechados; telefone na Geral; atendente vê nomes de rede/empresa sem link admin

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Linha clicável na aba **Contatos** do hub — fora de escopo v1 (issue sugerida na #1012)
- [x] Badge "N tickets abertos" no chip — fora de escopo v1
- [x] SSE em tempo real na lista — fora de escopo v1
