### PR TITLE
feat(chat): badge de tickets abertos no chip do contato (#1020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - Contato no chat: detalhe do funcionário da rede com abas **Geral**, **Chats** e **Tickets** — histórico operacional ao clicar no chip do contato (#1012 / #S202608-0012)
 - Hub de chat — aba **Contatos**: linha do contato abre o detalhe cadastral/operacional (#1018)
+- Chat WhatsApp: badge de **tickets abertos** no chip do contato vinculado (#1020)
 
 #### Correções
 
 - Listagens (tema escuro): hover das linhas de tabela deixa de «lavar» o texto — contraste alinhado ao padrão das telas SaaS (#921 / #S202608-0001)
+- Módulo de chat: textos de interface padronizados em português do Brasil («contato», não «contacto») (#1020)
 
 ## [26.08.018] - 2026-08-28
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -502,7 +502,7 @@ function AppRoutes() {
                   placeholder={
                     <ChatHubPlaceholder
                       titulo="Contatos"
-                      subtitulo="Escolha um contacto ou número avulso para iniciar conversa no WhatsApp."
+                      subtitulo="Escolha um contato ou número avulso para iniciar conversa no WhatsApp."
                     />
                   }
                 />

--- a/frontend/src/components/EmpresaChatsPanel.tsx
+++ b/frontend/src/components/EmpresaChatsPanel.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 function formatDuration(chat: WhatsappChats.Chat) {
   if (!chat.atendimento_inicio_at) return '—'
-  if (!chat.encerramento_at) return 'Em curso'
+  if (!chat.encerramento_at) return 'Em andamento'
   const start = new Date(chat.atendimento_inicio_at)
   const end = new Date(chat.encerramento_at)
   const diff = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000))
@@ -232,7 +232,7 @@ export function EmpresaChatsPanel({
                       className="h-9 px-3 text-xs"
                       onClick={() => setRetomarChat(c)}
                     >
-                      Retomar contacto
+                      Retomar contato
                     </Button>
                   )}
                 </div>

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -101,7 +101,7 @@ export function ChatIniciarConversaModal({
         aria-labelledby="iniciar-chat-titulo"
       >
         <h2 id="iniciar-chat-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
-          {titulo || (contato ? `Contactar ${contato.nome}` : 'Novo contacto WhatsApp')}
+          {titulo || (contato ? `Contactar ${contato.nome}` : 'Novo contato WhatsApp')}
         </h2>
         {contato && (
           <p className="mt-1 text-xs text-slate-500">

--- a/frontend/src/components/chat/CopiarWaIdButton.tsx
+++ b/frontend/src/components/chat/CopiarWaIdButton.tsx
@@ -22,7 +22,7 @@ export function CopiarWaIdButton({ waId, className = '', formatado = true }: Pro
       type="button"
       className={`max-w-full truncate font-mono text-xs transition hover:text-cyan-700 dark:hover:text-cyan-300 ${className}`}
       title={copiado ? 'Copiado' : 'Clique para copiar o número'}
-      aria-label={copiado ? 'Número copiado' : 'Copiar número do contacto'}
+      aria-label={copiado ? 'Número copiado' : 'Copiar número do contato'}
       onClick={(e) => {
         e.preventDefault()
         e.stopPropagation()

--- a/frontend/src/components/chat/WhatsappAvatar.tsx
+++ b/frontend/src/components/chat/WhatsappAvatar.tsx
@@ -10,7 +10,7 @@ type Props = {
   onFotoClick?: () => void
 }
 
-/** Avatar do contacto WhatsApp com fallback para inicial (#630). */
+/** Avatar do contato WhatsApp com fallback para inicial (#630). */
 export function WhatsappAvatar({
   nome,
   fotoUrl,
@@ -36,7 +36,7 @@ export function WhatsappAvatar({
           type="button"
           onClick={onFotoClick}
           className="shrink-0 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
-          aria-label="Ver foto do contacto"
+          aria-label="Ver foto do contato"
         >
           {img}
         </button>

--- a/frontend/src/constants/contatoClienteLabels.ts
+++ b/frontend/src/constants/contatoClienteLabels.ts
@@ -5,10 +5,10 @@ export const CONTATO_CLIENTE = {
   vincularCurto: 'Identificar',
   vincularEmpresa: 'Identificar contato',
   bannerNaoVinculado:
-    'Contacto não identificado — ainda não está vinculado a nenhuma empresa da rede.',
+    'Contato não identificado — ainda não está vinculado a nenhuma empresa da rede.',
   modalTitulo: 'Contato do cliente',
   modalSubtitulo:
-    'Vincule um cadastro existente ou cadastre este contacto como colaborador da empresa cliente.',
+    'Vincule um cadastro existente ou cadastre este contato como colaborador da empresa cliente.',
   buscarPlaceholder: 'Buscar contatos da rede…',
   selecioneContato: 'Selecione um contato da rede.',
   selecioneEmpresaContato: 'Selecione a empresa deste contato.',

--- a/frontend/src/hooks/useTicketsAbertosContato.ts
+++ b/frontend/src/hooks/useTicketsAbertosContato.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react'
+import { tickets } from '../api/client'
+
+/** Contagem de tickets abertos do contato (API #1012). */
+export function useTicketsAbertosContato(funcionarioRedeId: number | null | undefined) {
+  const [total, setTotal] = useState<number | null>(null)
+  const [reloadSeq, setReloadSeq] = useState(0)
+
+  const reload = useCallback(() => {
+    setReloadSeq((n) => n + 1)
+  }, [])
+
+  useEffect(() => {
+    if (funcionarioRedeId == null) {
+      setTotal(null)
+      return
+    }
+    let cancelled = false
+    tickets
+      .list({ funcionario_rede_id: funcionarioRedeId, situacao: 'abertos', limit: 1 })
+      .then(({ total: t }) => {
+        if (!cancelled) setTotal(t)
+      })
+      .catch(() => {
+        if (!cancelled) setTotal(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [funcionarioRedeId, reloadSeq])
+
+  return { total, reload }
+}

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -162,7 +162,7 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
     return (
       <ChatHubEmptyState
         title="Nenhum chat na fila"
-        description="Novos contactos aparecem aqui quando pedem atendimento."
+        description="Novos contatos aparecem aqui quando pedem atendimento."
         actions={[
           { type: 'link', to: '/chat/atendendo', label: 'Ver Atendendo' },
           { type: 'link', to: '/chat/contatos', label: 'Contatos' },

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -73,6 +73,7 @@ import { ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappComposerBar } from './WhatsappComposerBar'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
+import { useTicketsAbertosContato } from '../../hooks/useTicketsAbertosContato'
 import {
   marcarWhatsappChatAtivo,
   whatsappConversaLink,
@@ -507,7 +508,7 @@ function WhatsappVideoLightbox({
   )
 }
 
-/** Foto do contacto em overlay (#681). */
+/** Foto do contato em overlay (#681). */
 function WhatsappFotoPerfilLightbox({ src, nome, onClose }: { src: string; nome?: string | null; onClose: () => void }) {
   return (
     <div
@@ -525,7 +526,7 @@ function WhatsappFotoPerfilLightbox({ src, nome, onClose }: { src: string; nome?
       </button>
       <img
         src={src}
-        alt={nome ? `Foto de ${nome}` : 'Foto do contacto'}
+        alt={nome ? `Foto de ${nome}` : 'Foto do contato'}
         className="max-h-[85vh] max-w-full rounded-2xl object-contain shadow-2xl"
         referrerPolicy="no-referrer"
         onClick={(e) => e.stopPropagation()}
@@ -583,6 +584,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   // Estados de Dados
 
   const [chat, setChat] = useState<WhatsappChats.Chat | null>(null)
+  const { total: ticketsAbertosContato, reload: reloadTicketsAbertosContato } =
+    useTicketsAbertosContato(chat?.funcionario_rede_id)
 
   const [msgs, setMsgs] = useState<WhatsappChats.Mensagem[]>([])
 
@@ -1117,6 +1120,27 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
       cancelled = true
     }
   }, [chat?.ticket_ids])
+
+  const prevTicketsContatoTicketIdsKeyRef = useRef<string | null>(null)
+
+  const ticketIdsKey = chat?.ticket_ids?.slice().sort((a, b) => a - b).join(',') ?? ''
+  useEffect(() => {
+    prevTicketsContatoTicketIdsKeyRef.current = null
+  }, [chat?.funcionario_rede_id])
+
+  useEffect(() => {
+    if (!chat?.funcionario_rede_id) {
+      prevTicketsContatoTicketIdsKeyRef.current = null
+      return
+    }
+    if (prevTicketsContatoTicketIdsKeyRef.current === null) {
+      prevTicketsContatoTicketIdsKeyRef.current = ticketIdsKey
+      return
+    }
+    if (prevTicketsContatoTicketIdsKeyRef.current === ticketIdsKey) return
+    prevTicketsContatoTicketIdsKeyRef.current = ticketIdsKey
+    reloadTicketsAbertosContato()
+  }, [chat?.funcionario_rede_id, ticketIdsKey, reloadTicketsAbertosContato])
 
 //transferencia de atendente
 useEffect(() => {
@@ -2028,6 +2052,16 @@ useEffect(() => {
                   {chat.funcionario_nome}
                   {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
                 </Link>
+                {ticketsAbertosContato != null && ticketsAbertosContato > 0 ? (
+                  <Link
+                    to={`/funcionarios-rede/${chat.funcionario_rede_id}?aba=tickets`}
+                    state={{ voltarPara: `${location.pathname}${location.search}` }}
+                    className="inline-flex shrink-0 rounded-full border border-amber-200/80 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200"
+                    title={`${ticketsAbertosContato} ticket(s) aberto(s) deste contato`}
+                  >
+                    {ticketsAbertosContato} aberto{ticketsAbertosContato === 1 ? '' : 's'}
+                  </Link>
+                ) : null}
                 {chat.empresa_nome && chat.empresa_id ? (
                   <Link
                     to={`/empresas/${chat.empresa_id}`}
@@ -2069,7 +2103,7 @@ useEffect(() => {
         {precisaEmpresaContexto && (
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
             <p>
-              Este contacto pertence a mais de uma empresa. Pergunte ao cliente qual empresa deseja
+              Este contato pertence a mais de uma empresa. Pergunte ao cliente qual empresa deseja
               atendimento e vincule quando souber — pode fazer isso a qualquer momento antes de
               encerrar.
             </p>

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -134,7 +134,7 @@ export function WhatsappHistorico() {
 
   const formatDuration = (chat: WhatsappChats.Chat) => {
     if (!chat.atendimento_inicio_at) return '—'
-    if (!chat.encerramento_at) return 'Em curso'
+    if (!chat.encerramento_at) return 'Em andamento'
     const start = new Date(chat.atendimento_inicio_at)
     const end = new Date(chat.encerramento_at)
     const diff = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000))
@@ -356,7 +356,7 @@ export function WhatsappHistorico() {
                           className="h-9 min-w-0 flex-1 px-3 text-xs sm:flex-none"
                           onClick={() => setRetomarChat(c)}
                         >
-                          Retomar contacto
+                          Retomar contato
                         </Button>
                       )}
                     </div>

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -10,6 +10,7 @@ import { CheckboxField } from '../../components/ui/CheckboxField'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
+import { useTicketsAbertosContato } from '../../hooks/useTicketsAbertosContato'
 
 type Modo = 'vincular' | 'cadastrar'
 type TipoCadastro = 'colaborador' | 'supervisor'
@@ -24,6 +25,7 @@ type Props = {
 
 export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }: Props) {
   const toast = useToast()
+  const { total: ticketsAbertosContato } = useTicketsAbertosContato(chat.funcionario_rede_id)
   const [modo, setModo] = useState<Modo>('vincular')
   const [salvando, setSalvando] = useState(false)
 
@@ -329,6 +331,16 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
               >
                 Ver histórico de chats
               </Link>
+              {ticketsAbertosContato != null && ticketsAbertosContato > 0 ? (
+                <Link
+                  to={`/funcionarios-rede/${chat.funcionario_rede_id}?aba=tickets`}
+                  state={{ voltarPara: window.location.pathname + window.location.search }}
+                  className="text-xs font-medium text-amber-800 underline dark:text-amber-200"
+                >
+                  {ticketsAbertosContato} ticket{ticketsAbertosContato === 1 ? '' : 's'} aberto
+                  {ticketsAbertosContato === 1 ? '' : 's'}
+                </Link>
+              ) : null}
               <button
                 type="button"
                 className="text-xs font-medium text-red-600 underline"
@@ -545,7 +557,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                   }}
                 />
                 <p className="text-xs text-slate-500">
-                  Usado para tickets por e-mail; contactos só WhatsApp podem deixar em branco.
+                  Usado para tickets por e-mail; contatos só WhatsApp podem deixar em branco.
                 </p>
                 <p className="text-xs text-slate-500">
                   WhatsApp do contato: <span className="font-mono">{chat.wa_id}</span>


### PR DESCRIPTION
## Summary

- Badge de **tickets abertos** no chip do contato vinculado no chat WhatsApp (header e modal de vínculo), com link para a aba Tickets do cadastro (#1020)
- Hook `useTicketsAbertosContato` usa `GET /tickets?funcionario_rede_id&situacao=abertos&limit=1` e recarrega quando `ticket_ids` do chat mudam
- Sweep pt-BR no módulo de chat («contato», não «contacto»; «Em andamento» em durações)

Closes #1020

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `npm run build` passou localmente
- [ ] Abrir chat com contato vinculado que tenha tickets abertos → badge âmbar com contagem visível no header
- [ ] Clicar no badge → abre `/funcionarios-rede/:id?aba=tickets`
- [ ] Vincular novo ticket no modal do chat → badge atualiza sem recarregar a página
- [ ] Modal «Identificar contato» com vínculo existente → link de tickets abertos quando `total > 0`
- [ ] Textos do módulo chat exibem «contato» (não «contacto»)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

SSE em tempo real na contagem de tickets: fora de escopo v1 (documentado na issue #1020).
