### PR TITLE
feat(chat): polish detalhe do contato — refetch abas e resumo tickets (#1022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Contato no chat: detalhe do funcionário da rede com abas **Geral**, **Chats** e **Tickets** — histórico operacional ao clicar no chip do contato (#1012 / #S202608-0012)
 - Hub de chat — aba **Contatos**: linha do contato abre o detalhe cadastral/operacional (#1018)
 - Chat WhatsApp: badge de **tickets abertos** no chip do contato vinculado (#1020)
+- Detalhe do contato: resumo de tickets abertos na aba **Geral** e listas atualizadas ao focar abas Chats/Tickets (#1022)
 
 #### Correções
 

--- a/frontend/src/components/EmpresaChatsPanel.tsx
+++ b/frontend/src/components/EmpresaChatsPanel.tsx
@@ -19,6 +19,7 @@ type Props = {
   intro?: string
   emptyTitle?: string
   emptyDescription?: string
+  reloadKey?: number
 }
 
 function formatDuration(chat: WhatsappChats.Chat) {
@@ -52,6 +53,7 @@ export function EmpresaChatsPanel({
   intro,
   emptyTitle,
   emptyDescription,
+  reloadKey = 0,
 }: Props) {
   const toast = useToast()
   const [page, setPage] = useState(1)
@@ -101,7 +103,7 @@ export function EmpresaChatsPanel({
     return () => {
       cancelled = true
     }
-  }, [empresaId, funcionarioRedeId, page, debouncedBusca, toast])
+  }, [empresaId, funcionarioRedeId, page, debouncedBusca, toast, reloadKey])
 
   const textoIntro =
     intro ??

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { ApiError, funcionariosRede, tickets, type FuncionariosRede, type Tickets } from '../api/client'
 import { Button } from '../components/ui/Button'
@@ -13,6 +13,7 @@ import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBus
 import { EmpresaChatsPanel } from '../components/EmpresaChatsPanel'
 import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
 import { formatTelefoneBrExibicao } from '../utils/masks'
+import { useTicketsAbertosContato } from '../hooks/useTicketsAbertosContato'
 
 type Aba = 'geral' | 'chats' | 'tickets'
 type SituacaoTickets = 'abertos' | 'fechados' | 'todos'
@@ -107,6 +108,15 @@ export function FuncionarioRedeDetalhe() {
   const [ticketsItems, setTicketsItems] = useState<Tickets.Ticket[]>([])
   const [ticketsTotal, setTicketsTotal] = useState(0)
   const [loadingT, setLoadingT] = useState(false)
+  const [reloadChatsSeq, setReloadChatsSeq] = useState(0)
+  const [reloadTicketsSeq, setReloadTicketsSeq] = useState(0)
+  const skipLocationReloadRef = useRef(true)
+  const abaRef = useRef(aba)
+  abaRef.current = aba
+
+  const { total: ticketsAbertos, reload: reloadTicketsAbertos } = useTicketsAbertosContato(
+    Number.isNaN(funcionarioId) ? null : funcionarioId,
+  )
 
   useEffect(() => {
     const q = searchParams.get('aba')
@@ -116,12 +126,34 @@ export function FuncionarioRedeDetalhe() {
   }, [searchParams])
 
   const mudarAba = (key: Aba) => {
+    if (key !== aba) {
+      if (key === 'chats') setReloadChatsSeq((n) => n + 1)
+      if (key === 'tickets') setReloadTicketsSeq((n) => n + 1)
+    }
+    if (key === 'geral') reloadTicketsAbertos()
     setAba(key)
     const next = new URLSearchParams(searchParams)
     if (key === 'geral') next.delete('aba')
     else next.set('aba', key)
     setSearchParams(next, { replace: true })
   }
+
+  const irParaTicketsAbertos = () => {
+    setSituacaoT('abertos')
+    setPageT(1)
+    mudarAba('tickets')
+  }
+
+  useEffect(() => {
+    if (skipLocationReloadRef.current) {
+      skipLocationReloadRef.current = false
+      return
+    }
+    const current = abaRef.current
+    if (current === 'chats') setReloadChatsSeq((n) => n + 1)
+    else if (current === 'tickets') setReloadTicketsSeq((n) => n + 1)
+    else if (current === 'geral') reloadTicketsAbertos()
+  }, [location.key, reloadTicketsAbertos])
 
   useEffect(() => {
     if (!id || isNaN(funcionarioId)) {
@@ -191,7 +223,7 @@ export function FuncionarioRedeDetalhe() {
     return () => {
       cancelled = true
     }
-  }, [aba, funcionarioId, pageT, debouncedBuscaT, situacaoT])
+  }, [aba, funcionarioId, pageT, debouncedBuscaT, situacaoT, reloadTicketsSeq])
 
   function abrirEdicao() {
     if (!f) return
@@ -345,12 +377,31 @@ export function FuncionarioRedeDetalhe() {
               <DetailRow label="Cadastrado em" value={createdFmt} />
             </dl>
           </section>
+
+          {ticketsAbertos != null && ticketsAbertos > 0 ? (
+            <section className="rounded-2xl border border-amber-200/80 bg-amber-50/80 p-5 shadow-sm sm:p-7 lg:col-span-2 dark:border-amber-900/40 dark:bg-amber-950/20">
+              <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-amber-800 dark:text-amber-300">
+                Atendimento
+              </h2>
+              <p className="text-sm text-amber-950 dark:text-amber-100">
+                {ticketsAbertos} ticket{ticketsAbertos === 1 ? '' : 's'} aberto{ticketsAbertos === 1 ? '' : 's'} deste
+                contato.
+              </p>
+              <button
+                type="button"
+                onClick={irParaTicketsAbertos}
+                className="mt-3 text-sm font-medium text-amber-900 underline decoration-amber-400 underline-offset-2 hover:decoration-amber-600 dark:text-amber-200 dark:decoration-amber-700 dark:hover:decoration-amber-400"
+              >
+                Ver tickets abertos
+              </button>
+            </section>
+          ) : null}
         </div>
       )}
 
       {aba === 'chats' && (
         <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-800/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
-          <EmpresaChatsPanel funcionarioRedeId={f.id} returnPath={returnPath} />
+          <EmpresaChatsPanel funcionarioRedeId={f.id} returnPath={returnPath} reloadKey={reloadChatsSeq} />
         </section>
       )}
 


### PR DESCRIPTION
## Summary

- Detalhe do contato (`FuncionarioRedeDetalhe`): card na aba **Geral** com contagem de tickets abertos e atalho para a aba Tickets (filtro abertos)
- Re-fetch das listas ao focar abas **Chats** e **Tickets**; recarga ao voltar de conversa/ticket via `location.key`
- `EmpresaChatsPanel`: prop `reloadKey` para forçar recarga sem duplicar chamadas na troca manual de aba

Closes #1022

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `npm run build` passou localmente
- [ ] Contato com tickets abertos → aba Geral mostra card «N ticket(s) aberto(s)» e link **Ver tickets abertos**
- [ ] Link abre aba Tickets com filtro **Abertos** ativo
- [ ] Trocar Geral → Chats → Tickets recarrega cada lista (uma chamada por aba)
- [ ] Abrir conversa na aba Chats, voltar → lista atualizada
- [ ] Abrir ticket na aba Tickets, voltar → lista atualizada

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

Fora de escopo v1 (#1022): SSE em tempo real, badge na lista do hub Contatos, sweep pt-BR global (#868).
