### PR TITLE
chore(ci): valida CHANGELOG após merge simulado em PRs → staging

### DIFF
--- a/.cursor/commands/release-staging.md
+++ b/.cursor/commands/release-staging.md
@@ -22,14 +22,24 @@ Se já existir PR aberto `main` → `staging`, **reutilize** (não duplique).
 
 ## Passo 2 — Conflitos?
 
-Se `gh pr create` / GitHub indicar conflito:
+Se `gh pr create` / GitHub indicar conflito **ou** o CI `changelog` falhar com «merge simulado» / `[Unreleased]` vazio:
 
 1. Branch a partir de `origin/staging`: `merge/main-into-staging-YYYYMMDD`
-2. `git merge origin/main` e resolver (código da `main`; `[Unreleased]` = só o que ainda não foi publicado na staging)
-3. Push da branch e **um** PR → `staging`
-4. **Pare** — entregue o URL; **não** mergeie
+2. `git merge origin/main` e resolver (**obrigatório:** manter bullets de `[Unreleased]` da `main` — não aceitar `[Unreleased]` vazio da `staging`)
+3. Validar localmente: `python scripts/check_changelog.py --base origin/staging --head HEAD`
+4. Push da branch e **um** PR → `staging`
+5. **Pare** — entregue o URL; **não** mergeie
 
 Não manter dois PRs de release abertos sem explicar; preferir **um** PR mergeável.
+
+### Checklist CHANGELOG antes do merge release
+
+```bash
+git fetch origin
+python scripts/check_changelog.py --base origin/staging --head origin/main
+```
+
+Deve imprimir `OK` com bullets no merge simulado. Se falhar, **não** mergeie `main → staging` direto — use branch `merge/…` acima.
 
 ## Passo 3 — Criar PR (sem merge)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           python scripts/check_changelog.py \
             --base "origin/${{ github.event.pull_request.base.ref }}" \
             --head "${{ github.event.pull_request.head.sha }}"
+          # PR → staging: o script simula merge base←head e valida [Unreleased] no resultado.
 
   backend:
     needs: changes

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -115,6 +115,7 @@ Após cada deploy, o workflow commita `VERSION`, `CHANGELOG.md`, `manifest.json`
 ## Checklist — PR `main → staging`
 
 - [ ] `[Unreleased]` lista **todas** as entregas do lote (por produto)
+- [ ] `python scripts/check_changelog.py --base origin/staging --head origin/main` → **OK** (merge simulado; evita `[Unreleased]` vazio após conflito de CHANGELOG)
 - [ ] Revisão de redação (sem «deploy», «branch», «commit»)
 - [ ] **Aprovação e merge manuais** no GitHub (agente não executa `gh pr merge`)
 

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -66,6 +66,52 @@ def changed_files(base: str, head: str) -> list[str]:
     return [ln.strip() for ln in out.splitlines() if ln.strip()]
 
 
+def is_staging_base(base: str) -> bool:
+    ref = base.removeprefix("origin/").strip()
+    return ref == "staging"
+
+
+def changelog_after_simulated_merge(base: str, head: str) -> tuple[str | None, str | None]:
+    """Simula merge base←head e devolve CHANGELOG.md resultante (ou erro de conflito)."""
+    import tempfile
+
+    base_sha = _run("git", "rev-parse", base).strip()
+    head_sha = _run("git", "rev-parse", head).strip()
+    wt: Path | None = None
+    try:
+        td = tempfile.mkdtemp(prefix="dx-changelog-merge-")
+        wt = Path(td) / "wt"
+        _run("git", "worktree", "add", str(wt), base_sha)
+        merge = subprocess.run(
+            ["git", "merge", "--no-commit", "--no-ff", head_sha],
+            cwd=wt,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if merge.returncode != 0:
+            return None, (
+                "Merge simulado falhou (conflitos entre base e head). "
+                "Para release staging, abra branch `merge/main-into-staging-…`, resolva CHANGELOG "
+                "mantendo os bullets de [Unreleased] da main e abra PR → staging."
+            )
+        cl = wt / "CHANGELOG.md"
+        return (cl.read_text(encoding="utf-8") if cl.is_file() else ""), None
+    finally:
+        if wt is not None:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(wt)],
+                cwd=ROOT,
+                capture_output=True,
+                check=False,
+            )
+            parent = wt.parent
+            if parent.exists():
+                import shutil
+
+                shutil.rmtree(parent, ignore_errors=True)
+
+
 def requires_changelog(paths: list[str]) -> bool:
     product = False
     for p in paths:
@@ -137,25 +183,39 @@ def main() -> int:
         print("OK: PR sem arquivos alterados — CHANGELOG não exigido.")
         return 0
 
-    if not requires_changelog(paths):
+    if not requires_changelog(paths) and not is_staging_base(args.base):
         print("OK: alterações só em arquivos isentos — CHANGELOG não exigido.")
         print("Arquivos:", ", ".join(paths[:12]) + ("…" if len(paths) > 12 else ""))
         return 0
 
-    try:
-        text = _run("git", "show", f"{args.head}:{args.changelog.relative_to(ROOT).as_posix()}")
-    except RuntimeError:
-        text = args.changelog.read_text(encoding="utf-8") if args.changelog.is_file() else ""
+    if is_staging_base(args.base):
+        text, merge_err = changelog_after_simulated_merge(args.base, args.head)
+        if merge_err:
+            print(f"::error::{merge_err}", file=sys.stderr)
+            return 1
+        if text is None:
+            print("::error::Não foi possível simular merge para validar CHANGELOG.", file=sys.stderr)
+            return 1
+    else:
+        try:
+            text = _run("git", "show", f"{args.head}:{args.changelog.relative_to(ROOT).as_posix()}")
+        except RuntimeError:
+            text = args.changelog.read_text(encoding="utf-8") if args.changelog.is_file() else ""
 
     bullets = parse_unreleased_bullets(text)
     if not bullets:
+        staging_hint = (
+            "\nPR → staging: confira o CHANGELOG **após merge simulado** — conflitos costumam esvaziar [Unreleased]."
+            if is_staging_base(args.base)
+            else ""
+        )
         print(
             "::error::Este PR altera código de produto, mas CHANGELOG.md não tem bullets em ## [Unreleased].\n"
             "Adicione entregas sob ### DeskRudder e/ou ### SaaS Control Plane, ex.:\n"
             "  ### DeskRudder\n"
             "  #### Melhorias\n"
             "  - Descrição curta da funcionalidade (#123)\n"
-            "Veja docs/RELEASES.md",
+            f"Veja docs/RELEASES.md{staging_hint}",
             file=sys.stderr,
         )
         print("Arquivos de produto no diff:", ", ".join(paths[:20]), file=sys.stderr)
@@ -180,7 +240,8 @@ def main() -> int:
         return 1
 
     parts = [f"{p}={len(by_prod.get(p, []))}" for p in sorted(needed or by_prod.keys())]
-    print(f"OK: CHANGELOG [Unreleased] com {len(bullets)} item(ns) ({', '.join(parts)}).")
+    suffix = " (merge simulado)" if is_staging_base(args.base) else ""
+    print(f"OK: CHANGELOG [Unreleased] com {len(bullets)} item(ns) ({', '.join(parts)}){suffix}.")
     return 0
 
 


### PR DESCRIPTION
## Summary

- `check_changelog.py`: em PRs com base **`staging`**, simula merge `staging←head` e valida `[Unreleased]` no resultado (evita release com CHANGELOG vazio após conflito)
- Checklist em `docs/RELEASES.md` e `/release-staging` com comando local pré-merge

## Test plan

- [ ] `python scripts/check_changelog.py --base origin/staging --head origin/main` falha se `[Unreleased]` vazio no merge simulado
- [ ] PRs → `main` continuam validando CHANGELOG no head
- [ ] CI `changelog` verde neste PR
