### PR TITLE
fix(mobile): alerta sonoro da fila (aberta, 2o plano e fechada)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
+### DeskRudder
+
+#### Correções
+
+- Mobile (navegador e APK): alerta sonoro da fila de espera mais confiável com a app aberta — desbloqueio de áudio no login, banner «Ativar som» se o autoplay bloquear (sem precisar recarregar) e retomada do loop ao voltar ao foco
+- Mobile APK: banner de permissão de notificações também no app nativo; em segundo plano, notificação local com canal de som alto enquanto houver chat aguardando
+- Mobile (app fechada): ao ativar alertas, a inscrição Web Push / UnifiedPush passa a ser feita no mesmo gesto; o servidor reenvia push a cada 2 min enquanto houver fila (`chat.fila.remind`); PWA e APK tratam lembretes da fila com som/vibração reforçados
+
 ## [26.08.019] - 2026-08-31
 
 ### SaaS Control Plane

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -83,6 +83,8 @@ class Settings(BaseSettings):
     WEB_PUSH_VAPID_PRIVATE_KEY: str | None = None
     WEB_PUSH_VAPID_SUBJECT: str = "mailto:ops@deskrudder.com.br"
     WEB_PUSH_WORKER_INTERVAL_SECONDS: int = 5
+    # Reaviso push enquanto houver chats na fila (app fechada). 0 = desliga.
+    WEB_PUSH_FILA_REMIND_MINUTES: int = 2
     # Tentativas HTTP para Evolution API (falhas transitórias).
     EVOLUTION_HTTP_MAX_ATTEMPTS: int = 3
     WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS: int = 60

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -297,10 +297,14 @@ async def lifespan(app: FastAPI):
 
     def web_push_outbox_loop() -> None:
         from app.database import SessionLocal
-        from app.services.web_push_outbox import process_pending_web_push
+        from app.services.web_push_outbox import process_fila_web_push_reminders, process_pending_web_push
 
         interval = max(3, settings.WEB_PUSH_WORKER_INTERVAL_SECONDS)
         while True:
+            try:
+                process_fila_web_push_reminders()
+            except Exception as e:
+                logger.warning("Worker Web Push lembrete fila: %s", e)
             db = SessionLocal()
             try:
                 process_pending_web_push(db, limit=40)

--- a/backend/app/services/web_push_outbox.py
+++ b/backend/app/services/web_push_outbox.py
@@ -25,7 +25,8 @@ STATUS_PENDENTE = "pendente"
 STATUS_ENVIADA = "enviada"
 STATUS_FALHA = "falha"
 
-TIPOS_FILA = frozenset({"chat.fila", "ticket.fila", "portal.chat.fila"})
+TIPOS_FILA = frozenset({"chat.fila", "ticket.fila", "portal.chat.fila", "chat.fila.remind"})
+EVENTO_FILA_REMIND = "chat.fila.remind"
 
 
 def _utcnow() -> datetime:
@@ -83,7 +84,11 @@ def enfileirar_para_atendentes(
             )
             if tem_sub is None:
                 continue
-            if event_type in TIPOS_FILA:
+            if event_type == EVENTO_FILA_REMIND:
+                minutos = max(1, int(settings.WEB_PUSH_FILA_REMIND_MINUTES or 2))
+                bucket = int(now.timestamp() // (minutos * 60))
+                dedup_key = f"{event_type}:{aid}:{bucket}"
+            elif event_type in TIPOS_FILA:
                 dedup_key = f"{event_type}:{entity_id}:{aid}:{int(now.timestamp() // 60)}"
             else:
                 dedup_key = f"{event_type}:{entity_id}:{aid}"
@@ -105,6 +110,111 @@ def enfileirar_para_atendentes(
     except Exception:
         db.rollback()
         logger.exception("Falha ao enfileirar Web Push (%s:%s)", event_type, entity_id)
+    finally:
+        db.close()
+
+
+def _contar_fila_por_atendente(db: Session) -> dict[int, int]:
+    """Agrega chats WhatsApp + Portal em aguardando_atendente por destinatário do push."""
+    from collections import defaultdict
+
+    from app.models.portal_chat import PortalChat
+    from app.models.whatsapp_chat import WhatsappChat
+    from app.services.realtime_emit import ids_atendentes_chat_fila, ids_atendentes_portal_chat_fila
+
+    counts: dict[int, int] = defaultdict(int)
+    wpp = (
+        db.query(WhatsappChat)
+        .filter(WhatsappChat.estado == "aguardando_atendente")
+        .all()
+    )
+    for chat in wpp:
+        for aid in ids_atendentes_chat_fila(db, chat):
+            counts[int(aid)] += 1
+    portal = (
+        db.query(PortalChat)
+        .filter(PortalChat.estado == "aguardando_atendente")
+        .all()
+    )
+    for chat in portal:
+        for aid in ids_atendentes_portal_chat_fila(db, chat):
+            counts[int(aid)] += 1
+    return dict(counts)
+
+
+def process_fila_web_push_reminders() -> int:
+    """
+    Reaviso periódico enquanto houver fila (app fechada / kill).
+    Um push por atendente elegível por janela WEB_PUSH_FILA_REMIND_MINUTES.
+    Retorna quantos pushes foram enfileirados nesta passagem.
+    """
+    if not vapid_configurado():
+        return 0
+    if int(settings.WEB_PUSH_FILA_REMIND_MINUTES or 0) <= 0:
+        return 0
+
+    db = SessionLocal()
+    try:
+        counts = _contar_fila_por_atendente(db)
+        if not counts:
+            return 0
+
+        now = _utcnow()
+        minutos = max(1, int(settings.WEB_PUSH_FILA_REMIND_MINUTES or 2))
+        bucket = int(now.timestamp() // (minutos * 60))
+        enfileirados = 0
+
+        for aid, n in counts.items():
+            if n <= 0:
+                continue
+            prefs = obter_ou_criar_preferencias(db, aid)
+            if not _prefs_permitem(prefs, EVENTO_FILA_REMIND):
+                continue
+            tem_sub = (
+                db.query(PushSubscription.id).filter(PushSubscription.atendente_id == aid).limit(1).first()
+            )
+            if tem_sub is None:
+                continue
+            dedup_key = f"{EVENTO_FILA_REMIND}:{aid}:{bucket}"
+            if _dedup_ja_processado(db, dedup_key):
+                continue
+            corpo = (
+                "Há 1 chat aguardando atendimento"
+                if n == 1
+                else f"Há {n} chats aguardando atendimento"
+            )
+            payload = {
+                "tipo": EVENTO_FILA_REMIND,
+                "id": int(aid),
+                "titulo": "Clientes na fila",
+                "url_path": "/chat/espera",
+                "corpo": corpo,
+            }
+            db.add(
+                PushOutbox(
+                    atendente_id=aid,
+                    event_type=EVENTO_FILA_REMIND,
+                    dedup_key=dedup_key,
+                    payload_json=json.dumps(payload, ensure_ascii=False),
+                    status=STATUS_PENDENTE,
+                    scheduled_at=now,
+                )
+            )
+            enfileirados += 1
+
+        if enfileirados:
+            db.commit()
+            log_event(logger, "web_push_fila_remind_enqueued", atendentes=enfileirados)
+        else:
+            db.rollback()
+        return enfileirados
+    except IntegrityError:
+        db.rollback()
+        return 0
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao enfileirar lembretes Web Push da fila")
+        return 0
     finally:
         db.close()
 

--- a/backend/tests/test_web_push.py
+++ b/backend/tests/test_web_push.py
@@ -208,3 +208,93 @@ def test_worker_envia_e_respeita_410(seed_base, db_session, monkeypatch):
     process_pending_web_push(db_session, limit=10)
     db_session.commit()
     assert db_session.query(PushSubscription).count() == 0
+
+
+def test_fila_remind_enfileira_com_chat_aguardando(seed_base, db_session, monkeypatch):
+    from app.models.whatsapp_chat import WhatsappChat
+    from app.services.web_push_outbox import EVENTO_FILA_REMIND, process_fila_web_push_reminders
+
+    monkeypatch.setattr("app.services.web_push_outbox.vapid_configurado", lambda: True)
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_FILA_REMIND_MINUTES", 2)
+    a1 = seed_base["a1"]
+    prefs = obter_ou_criar_preferencias(db_session, a1.id)
+    prefs.push_habilitado = True
+    prefs.push_fila = True
+    db_session.add(
+        PushSubscription(
+            atendente_id=a1.id,
+            endpoint="https://push.example.com/remind",
+            p256dh="p256dh-key-value",
+            auth="auth-key-value",
+        )
+    )
+    db_session.add(
+        WhatsappChat(
+            protocolo="WCH-REMIND-1",
+            wa_id="5511999990099",
+            cliente_nome="Cliente Reminder",
+            estado="aguardando_atendente",
+            setor_id=seed_base["setor1"].id,
+        )
+    )
+    db_session.commit()
+
+    n = process_fila_web_push_reminders()
+    assert n >= 1
+    db_session.expire_all()
+    rows = (
+        db_session.query(PushOutbox)
+        .filter(PushOutbox.event_type == EVENTO_FILA_REMIND, PushOutbox.atendente_id == a1.id)
+        .all()
+    )
+    assert len(rows) == 1
+    assert "aguardando" in (rows[0].payload_json or "")
+
+    # Dedup na mesma janela
+    assert process_fila_web_push_reminders() == 0
+    assert (
+        db_session.query(PushOutbox)
+        .filter(PushOutbox.event_type == EVENTO_FILA_REMIND, PushOutbox.atendente_id == a1.id)
+        .count()
+        == 1
+    )
+
+
+def test_fila_remind_respeita_mute_e_fila_vazia(seed_base, db_session, monkeypatch):
+    from app.models.whatsapp_chat import WhatsappChat
+    from app.services.web_push_outbox import EVENTO_FILA_REMIND, process_fila_web_push_reminders
+
+    monkeypatch.setattr("app.services.web_push_outbox.vapid_configurado", lambda: True)
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_FILA_REMIND_MINUTES", 2)
+    a1 = seed_base["a1"]
+    prefs = obter_ou_criar_preferencias(db_session, a1.id)
+    prefs.push_habilitado = True
+    prefs.push_fila = False
+    db_session.add(
+        PushSubscription(
+            atendente_id=a1.id,
+            endpoint="https://push.example.com/remind-mute",
+            p256dh="p256dh-key-value",
+            auth="auth-key-value",
+        )
+    )
+    db_session.add(
+        WhatsappChat(
+            protocolo="WCH-REMIND-MUTE",
+            wa_id="5511999990088",
+            cliente_nome="Mute",
+            estado="aguardando_atendente",
+            setor_id=seed_base["setor1"].id,
+        )
+    )
+    db_session.commit()
+    assert process_fila_web_push_reminders() == 0
+    assert db_session.query(PushOutbox).filter(PushOutbox.event_type == EVENTO_FILA_REMIND).count() == 0
+
+    prefs.push_fila = True
+    db_session.commit()
+    # Sem chats aguardando após limpar estado
+    chat = db_session.query(WhatsappChat).filter(WhatsappChat.protocolo == "WCH-REMIND-MUTE").one()
+    chat.estado = "em_atendimento"
+    db_session.commit()
+    assert process_fila_web_push_reminders() == 0

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -128,10 +128,14 @@ O distribuidor embutido usa os servidores de push da Google só como transporte 
 
 | Estado | O que alerta |
 |--------|----------------|
-| **Aberto** (aba/app em foco) | SSE + loop de áudio da fila (`alerta.mp3`); preferência «silenciar» na mesa corta o loop |
-| **2.º plano** (minimizada / outra app / aba oculta; processo ainda vivo) | Notification do SO com `renotify` + re-alerta periódico enquanto a fila > 0; no APK também `App.appStateChange`. Push do servidor continua a chegar em eventos novos |
-| **Fechada / kill** | Só **Web Push** (PWA) ou **UnifiedPush** (APK), com permissão activa |
+| **Aberto** (aba/app em foco) | SSE + loop de áudio da fila (`alerta.mp3`); se o autoplay bloquear, banner «Ativar som»; preferência «silenciar» na mesa corta o loop |
+| **2.º plano** (minimizada / outra app / aba oculta; processo ainda vivo) | Notification do SO com `renotify` + re-alerta periódico; no APK canal nativo `deskrudder_fila` + `App.appStateChange`. Push do servidor continua a chegar em eventos novos |
+| **Fechada / kill** | **Web Push** (PWA) ou **UnifiedPush** (APK) no evento de entrada na fila **e** lembrete periódico (`chat.fila.remind`, padrão a cada 2 min) enquanto a fila > 0 e `push_habilitado` + `push_fila` |
 | **iOS** | PWA no ecrã inicial (#695); sem SSE em background; push limitado pelo Safari |
+
+O banner «Ativar alertas» (permissão de notificação) aparece no **browser e no APK** e, no mesmo gesto, tenta inscrever o endpoint de push (necessário com a app fechada). O gesto de **Entrar** no login já desbloqueia o áudio HTML para a sessão.
+
+Variável `WEB_PUSH_FILA_REMIND_MINUTES` (padrão `2`; `0` desliga o lembrete periódico).
 
 Silenciar na mesa (`ChatFilaSomToggle`) e «Avisar fila de espera» em Notificações ficam alinhados (`push_fila` ↔ mute local).
 

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/DeskRudderPushService.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/DeskRudderPushService.kt
@@ -56,12 +56,20 @@ class DeskRudderPushService : PushService() {
             return
         }
         ensureChannel()
+        ensureFilaChannel()
         val data = UnifiedPushStore.payloadToJson(raw)
         val titulo = data.optString("titulo").ifBlank { "DeskRudder" }
-        val corpo = data.optString("corpo").ifBlank { "Nova actividade no atendimento" }
+        val corpo = data.optString("corpo").ifBlank { "Nova atividade no atendimento" }
         val tipo = data.optString("tipo")
         val id = data.optLong("id", 0L)
-        val tag = "${tipo.ifBlank { "push" }}:$id"
+        val isFila =
+            tipo == "chat.fila" ||
+                tipo == "chat.fila.remind" ||
+                tipo == "portal.chat.fila" ||
+                tipo == "ticket.fila" ||
+                tipo.endsWith(".fila")
+        val channelId = if (isFila) FILA_CHANNEL_ID else CHANNEL_ID
+        val tag = if (isFila) "dx-connect-fila-aguardando" else "${tipo.ifBlank { "push" }}:$id"
 
         val tap = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or
@@ -75,14 +83,14 @@ class DeskRudderPushService : PushService() {
             tap,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+        val notification = NotificationCompat.Builder(this, channelId)
             .setSmallIcon(R.drawable.ic_stat_notify)
             .setContentTitle(titulo)
             .setContentText(corpo)
             .setAutoCancel(true)
             .setContentIntent(pending)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            .setCategory(if (isFila) NotificationCompat.CATEGORY_ALARM else NotificationCompat.CATEGORY_MESSAGE)
             .setOnlyAlertOnce(false)
             .setDefaults(NotificationCompat.DEFAULT_ALL)
             .build()
@@ -99,7 +107,30 @@ class DeskRudderPushService : PushService() {
                 "Alertas de atendimento",
                 NotificationManager.IMPORTANCE_HIGH,
             ).apply {
-                description = "Fila e mensagens nos teus chats e tickets"
+                description = "Fila e mensagens nos seus chats e tickets"
+                enableVibration(true)
+                setSound(
+                    android.media.RingtoneManager.getDefaultUri(
+                        android.media.RingtoneManager.TYPE_NOTIFICATION,
+                    ),
+                    null,
+                )
+                setShowBadge(true)
+            },
+        )
+    }
+
+    private fun ensureFilaChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(FILA_CHANNEL_ID) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                FILA_CHANNEL_ID,
+                "Fila de espera",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "Clientes aguardando atendimento no chat"
                 enableVibration(true)
                 setSound(
                     android.media.RingtoneManager.getDefaultUri(
@@ -114,5 +145,6 @@ class DeskRudderPushService : PushService() {
 
     companion object {
         private const val CHANNEL_ID = "deskrudder_push"
+        private const val FILA_CHANNEL_ID = "deskrudder_fila"
     }
 }

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
@@ -1,8 +1,15 @@
 package br.com.deskrudder.app
 
 import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import com.getcapacitor.JSObject
 import com.getcapacitor.PermissionState
 import com.getcapacitor.Plugin
@@ -62,6 +69,109 @@ class UnifiedPushPlugin : Plugin() {
         }
         UnifiedPushStore.clearEndpoint(context)
         call.resolve()
+    }
+
+    /** Pedido explícito de POST_NOTIFICATIONS (banner / login no APK). */
+    @PluginMethod
+    fun requestNotificationPermission(call: PluginCall) {
+        if (!needsNotificationPermission()) {
+            call.resolve(JSObject().put("granted", true).put("state", "granted"))
+            return
+        }
+        when (getPermissionState("notifications")) {
+            PermissionState.GRANTED -> {
+                call.resolve(JSObject().put("granted", true).put("state", "granted"))
+            }
+            PermissionState.DENIED -> {
+                // Ainda pode mostrar o diálogo se nunca foi pedido de forma permanente
+                requestPermissionForAlias("notifications", call, "onStandaloneNotificationsPermission")
+            }
+            else -> {
+                requestPermissionForAlias("notifications", call, "onStandaloneNotificationsPermission")
+            }
+        }
+    }
+
+    @PermissionCallback
+    fun onStandaloneNotificationsPermission(call: PluginCall) {
+        val granted = getPermissionState("notifications") == PermissionState.GRANTED
+        call.resolve(
+            JSObject()
+                .put("granted", granted)
+                .put("state", if (granted) "granted" else "denied"),
+        )
+    }
+
+    /**
+     * Notificação local da fila (app em 2º plano, processo vivo).
+     * Usa o mesmo canal de som alto do UnifiedPush.
+     */
+    @PluginMethod
+    fun showFilaWaiting(call: PluginCall) {
+        val count = call.getInt("count") ?: 0
+        if (count <= 0) {
+            call.resolve()
+            return
+        }
+        if (Build.VERSION.SDK_INT >= 33 &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            call.resolve()
+            return
+        }
+        ensureFilaChannel()
+        val body =
+            if (count == 1) "Há 1 chat aguardando atendimento"
+            else "Há $count chats aguardando atendimento"
+        val tap = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(UnifiedPushStore.EXTRA_PAYLOAD, """{"tipo":"chat.fila","url_path":"/chat/espera"}""")
+        }
+        val pending = PendingIntent.getActivity(
+            context,
+            FILA_NOTIFY_ID,
+            tap,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(context, FILA_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_stat_notify)
+            .setContentTitle("DeskRudder")
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setContentIntent(pending)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .setOnlyAlertOnce(false)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .build()
+        NotificationManagerCompat.from(context).notify(FILA_NOTIFY_ID, notification)
+        call.resolve()
+    }
+
+    private fun ensureFilaChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(FILA_CHANNEL_ID) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                FILA_CHANNEL_ID,
+                "Fila de espera",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "Clientes aguardando atendimento no chat"
+                enableVibration(true)
+                setSound(
+                    android.media.RingtoneManager.getDefaultUri(
+                        android.media.RingtoneManager.TYPE_NOTIFICATION,
+                    ),
+                    null,
+                )
+                setShowBadge(true)
+            },
+        )
     }
 
     @PluginMethod
@@ -156,6 +266,8 @@ class UnifiedPushPlugin : Plugin() {
     private fun needsNotificationPermission(): Boolean = Build.VERSION.SDK_INT >= 33
 
     companion object {
+        private const val FILA_CHANNEL_ID = "deskrudder_fila"
+        private const val FILA_NOTIFY_ID = 82301
         private var instance: WeakReference<UnifiedPushPlugin>? = null
         @Volatile
         private var pendingRegister: PluginCall? = null

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -75,7 +75,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1606,9 +1605,9 @@
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.5.0.tgz",
-      "integrity": "sha512-rLdzMUM5QV4WITcqoWv04p32i14BXgUH2diqEH6MWQlWaJfiyNrvOyt/+d5vHAfOxOm1klBu637VDEobctlwBA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.5.1.tgz",
+      "integrity": "sha512-LKQFSyLg1QbTN6CGDoFqeRtAlj8C3c9OymP8OuhwlmkbSQwh9i1HQjwUCaNyVem2XkY9rv0v2UOfVlgoxH5pAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1682,7 +1681,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.5.0.tgz",
       "integrity": "sha512-Ca4krtqH1hothjtBIwf2J2TW7IhYq1ujp8QeItTiJohNsqij8ja2DYYH3DU0l8RmxCWaBAFTGA2TgOgOMCSNsQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1711,7 +1709,6 @@
       "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
@@ -1723,7 +1720,6 @@
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1854,11 +1850,14 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
@@ -3389,7 +3388,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3482,7 +3480,6 @@
       "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.68.0",
         "@typescript-eslint/types": "8.68.0",
@@ -3714,9 +3711,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
-      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3727,7 +3724,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4036,7 +4032,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -4887,7 +4882,6 @@
       "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -5109,9 +5103,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -7853,7 +7847,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7863,7 +7856,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7910,7 +7902,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8015,8 +8006,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8278,7 +8268,6 @@
       "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -9005,7 +8994,6 @@
       "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -9205,7 +9193,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9561,7 +9548,6 @@
       "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -10130,7 +10116,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10398,7 +10383,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/AlertaDesktopPermissaoBanner.tsx
+++ b/frontend/src/components/AlertaDesktopPermissaoBanner.tsx
@@ -4,6 +4,7 @@ import {
   getNotificationPermission,
   type AlertasDesktopResultado,
 } from '../hooks/useAlertaFilaSemResponsavel'
+import { isCapacitorNative } from '../lib/capacitorNative'
 import { Button } from './ui/Button'
 
 const LS_DISMISS = 'dxconnect.notificacoes.desktop_prompt_dismissed'
@@ -29,10 +30,11 @@ type Props = {
 }
 
 /**
- * Pede permissão de notificações do SO para alertar fila com aba em 2º plano (#652).
- * O clique em «Ativar» é o gesto que desbloqueia áudio + permission prompt do browser.
+ * Pede permissão de notificações do SO para alertar fila com aba/app em 2º plano (#652).
+ * O clique em «Ativar» é o gesto que desbloqueia áudio + permission prompt (browser e APK).
  */
 export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
+  const nativo = isCapacitorNative()
   const [perm, setPerm] = useState<AlertasDesktopResultado>(() => getNotificationPermission())
   const [dismissed, setDismissed] = useState(readDismissed)
   const [busy, setBusy] = useState(false)
@@ -68,10 +70,10 @@ export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
   }, [])
 
   if (!enabled) return null
-  if (perm === 'unsupported') return null
+  // No APK a permissão nativa pode estar em default mesmo com Notification.permission diferente
+  if (!nativo && perm === 'unsupported') return null
   if (perm === 'granted' && feedback !== 'ok') return null
   if (dismissed && feedback !== 'ok' && feedback !== 'denied') return null
-  // Já pediu e foi negado no browser — só mostra se o utilizador acabou de negar neste clique
   if (perm === 'denied' && feedback !== 'denied') return null
   if (perm === 'granted' && feedback === 'ok') {
     return (
@@ -79,7 +81,9 @@ export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
         role="status"
         className="shrink-0 border-b border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-100"
       >
-        Alertas do sistema activos — vais ser avisado mesmo com a aba em segundo plano ou o navegador minimizado.
+        {nativo
+          ? 'Alertas do sistema ativos — você será avisado com o app em segundo plano ou fechado.'
+          : 'Alertas do sistema ativos — você será avisado com a aba em segundo plano, navegador minimizado ou app fechada.'}
       </div>
     )
   }
@@ -91,8 +95,9 @@ export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
         className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
       >
         <p className="min-w-0 flex-1">
-          Notificações bloqueadas neste browser. Para receber alertas com a aba em segundo plano, permita
-          notificações nas definições do site.
+          {nativo
+            ? 'Notificações bloqueadas neste aparelho. Permita notificações nas configurações do app para receber alertas com o DeskRudder em segundo plano.'
+            : 'Notificações bloqueadas neste navegador. Para receber alertas com a aba em segundo plano, permita notificações nas configurações do site.'}
         </p>
         <Button type="button" variant="ghost" className="h-8 shrink-0 px-2 text-xs" onClick={agoraNao}>
           Fechar
@@ -101,7 +106,6 @@ export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
     )
   }
 
-  // permission === 'default' e ainda não dispensado
   return (
     <div
       role="region"
@@ -109,10 +113,13 @@ export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
       className="flex shrink-0 flex-col gap-2 border-b border-cyan-200 bg-cyan-50 px-4 py-3 text-sm text-slate-800 dark:border-cyan-900/40 dark:bg-cyan-950/30 dark:text-slate-100 sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="min-w-0 space-y-0.5">
-        <p className="font-semibold text-slate-900 dark:text-white">Ativar alertas fora desta aba?</p>
+        <p className="font-semibold text-slate-900 dark:text-white">
+          {nativo ? 'Ativar alertas com o app em segundo plano ou fechado?' : 'Ativar alertas fora desta aba?'}
+        </p>
         <p className="text-xs text-slate-600 dark:text-slate-300 sm:text-sm">
-          Com a permissão do browser, o DeskRudder avisa novos chats na fila mesmo com outra aba aberta ou o
-          navegador minimizado.
+          {nativo
+            ? 'Com a permissão do Android, o DeskRudder avisa a fila mesmo com o app minimizado ou fechado (push).'
+            : 'Com a permissão do navegador, o DeskRudder avisa a fila mesmo com outra aba, navegador minimizado ou app fechada (PWA).'}
         </p>
       </div>
       <div className="flex shrink-0 flex-wrap items-center gap-2">

--- a/frontend/src/components/AlertaFilaAudioBanner.tsx
+++ b/frontend/src/components/AlertaFilaAudioBanner.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useState } from 'react'
+import {
+  reativarAlertaFilaAudio,
+  useFilaAguardandoMuted,
+  useFilaAudioNeedsGesture,
+  usePendenciasResumo,
+} from '../hooks/useAlertaFilaSemResponsavel'
+import { Button } from './ui/Button'
+
+type Props = {
+  enabled: boolean
+}
+
+/**
+ * App em foco com gente na fila, mas o browser/WebView bloqueou autoplay.
+ * Um toque desbloqueia o áudio e retoma o loop — evita precisar recarregar a página.
+ */
+export function AlertaFilaAudioBanner({ enabled }: Props) {
+  const needsGesture = useFilaAudioNeedsGesture()
+  const muted = useFilaAguardandoMuted()
+  const resumo = usePendenciasResumo(enabled)
+  const fila = resumo.wpp_fila_count + resumo.portal_fila_count
+  const [busy, setBusy] = useState(false)
+
+  const ativar = useCallback(() => {
+    setBusy(true)
+    try {
+      reativarAlertaFilaAudio()
+    } finally {
+      window.setTimeout(() => setBusy(false), 400)
+    }
+  }, [])
+
+  if (!enabled || muted || fila <= 0 || !needsGesture) return null
+
+  return (
+    <div
+      role="region"
+      aria-label="Ativar alerta sonoro da fila"
+      className="flex shrink-0 flex-col gap-2 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-slate-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-slate-100 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="min-w-0 space-y-0.5">
+        <p className="font-semibold text-slate-900 dark:text-white">Ativar alerta sonoro da fila</p>
+        <p className="text-xs text-slate-600 dark:text-slate-300 sm:text-sm">
+          Há {fila === 1 ? '1 chat aguardando' : `${fila} chats aguardando`}. O navegador bloqueou o som —
+          toque no botão para ouvir o alerta sem recarregar a página.
+        </p>
+      </div>
+      <Button type="button" variant="primary" className="h-9 shrink-0 px-4" loading={busy} onClick={ativar}>
+        Ativar som
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import { BrandLogo } from '../brand'
 import { useTheme } from '../contexts/ThemeContext'
 import { isCapacitorNative } from '../lib/capacitorNative'
 import { AlertaDesktopPermissaoBanner } from './AlertaDesktopPermissaoBanner'
+import { AlertaFilaAudioBanner } from './AlertaFilaAudioBanner'
 import { PwaInstallBanner } from './PwaInstallBanner'
 import { WebPushOptInBanner } from './WebPushOptInBanner'
 import { PontoAlertasBanner } from './PontoAlertasBanner'
@@ -160,9 +161,8 @@ function LayoutInner() {
         </header>
 
         {notificacoesEnabled && !isCapacitorNative() && !ocultarHeaderMobile ? <PwaInstallBanner enabled /> : null}
-        {notificacoesEnabled && !isCapacitorNative() && !ocultarHeaderMobile ? (
-          <AlertaDesktopPermissaoBanner enabled />
-        ) : null}
+        {notificacoesEnabled && !ocultarHeaderMobile ? <AlertaDesktopPermissaoBanner enabled /> : null}
+        {notificacoesEnabled && !ocultarHeaderMobile ? <AlertaFilaAudioBanner enabled /> : null}
         {notificacoesEnabled && !ocultarHeaderMobile ? <WebPushOptInBanner enabled /> : null}
         <PontoAlertasBanner />
 

--- a/frontend/src/components/WebPushOptInBanner.tsx
+++ b/frontend/src/components/WebPushOptInBanner.tsx
@@ -80,7 +80,7 @@ export function WebPushOptInBanner({ enabled }: Props) {
           role="status"
           className="shrink-0 border-b border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-100"
         >
-          Alertas no telemóvel activos — vais ser avisado mesmo com a app fechada.
+          Alertas no celular ativos — você será avisado mesmo com a app fechada.
         </div>
       )
     }
@@ -96,8 +96,8 @@ export function WebPushOptInBanner({ enabled }: Props) {
         className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-indigo-200 bg-indigo-50 px-4 py-2.5 text-sm text-slate-800 dark:border-indigo-900/40 dark:bg-indigo-950/30 dark:text-slate-100"
       >
         <p className="min-w-0 flex-1">
-          No iPhone/iPad, os alertas com a app fechada só funcionam depois de <strong>Adicionar ao Ecrã Início</strong>{' '}
-          (Safari 16.4 ou posterior). Abre o atalho e activa os alertas aí.
+          No iPhone/iPad, os alertas com a app fechada só funcionam depois de <strong>Adicionar à Tela de Início</strong>{' '}
+          (Safari 16.4 ou posterior). Abra o atalho e ative os alertas aí.
         </p>
         <Button
           type="button"
@@ -122,7 +122,7 @@ export function WebPushOptInBanner({ enabled }: Props) {
         className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
       >
         <p className="min-w-0 flex-1">
-          Notificações bloqueadas neste dispositivo. Permite-as nas definições para alertas com a app fechada.
+          Notificações bloqueadas neste dispositivo. Permita-as nas configurações para alertas com a app fechada.
         </p>
         <Button type="button" variant="ghost" className="h-8 shrink-0 px-2 text-xs" onClick={() => setFeedback(null)}>
           Fechar
@@ -136,13 +136,13 @@ export function WebPushOptInBanner({ enabled }: Props) {
   return (
     <div
       role="region"
-      aria-label="Ativar alertas no telemóvel"
+      aria-label="Ativar alertas no celular"
       className="flex shrink-0 flex-col gap-2 border-b border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-slate-800 dark:border-indigo-900/40 dark:bg-indigo-950/30 dark:text-slate-100 sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="min-w-0 space-y-0.5">
         <p className="font-semibold text-slate-900 dark:text-white">Alertas com a app fechada?</p>
         <p className="text-xs text-slate-600 dark:text-slate-300 sm:text-sm">
-          Recebe avisos da fila e de mensagens nos teus atendimentos mesmo fora do painel. Podes desligar em
+          Receba avisos da fila e de mensagens nos seus atendimentos mesmo fora do painel. Você pode desligar em
           Notificações.
         </p>
       </div>

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -91,9 +91,13 @@ let wppFilaLoopAudio: HTMLAudioElement | null = null
 let wppFilaLoopWanted = false
 let wppFilaLoopEndedHandler: (() => void) | null = null
 let wppFilaLoopRetryTimer: number | null = null
-/** Áudio «desbloqueado» por gesto do utilizador — melhora play em aba em background (#652). */
+/** Áudio desbloqueado por gesto do usuário — melhora play em aba em background (#652). */
 let audioUnlocked = false
 let audioUnlockInstalled = false
+/** Fila > 0, app em foco, mas play() falhou (autoplay) — UI pede um toque. */
+let filaAudioNeedsGesture = false
+type ListenerFilaAudioGesture = (needs: boolean) => void
+const listenersFilaAudioGesture = new Set<ListenerFilaAudioGesture>()
 let lastFilaDesktopNotifyAt = 0
 let filaBgNudgeTimer: number | null = null
 /** APK: false quando o OS põe a app em segundo plano (#823). Browser: permanece true. */
@@ -106,6 +110,40 @@ let sseUnsubscribe: (() => void) | null = null
 let chatInternoSseUnsubscribe: (() => void) | null = null
 let lastSemIncreaseAt = 0
 const recentAlertKeys = new Map<string, number>()
+
+function setFilaAudioNeedsGesture(needs: boolean) {
+  if (filaAudioNeedsGesture === needs) return
+  filaAudioNeedsGesture = needs
+  for (const l of listenersFilaAudioGesture) l(needs)
+}
+
+export function isFilaAudioNeedsGesture() {
+  return filaAudioNeedsGesture
+}
+
+export function useFilaAudioNeedsGesture(): boolean {
+  const [needs, setNeeds] = useState(filaAudioNeedsGesture)
+  useEffect(() => {
+    const listener: ListenerFilaAudioGesture = (n) => setNeeds(n)
+    listenersFilaAudioGesture.add(listener)
+    setNeeds(filaAudioNeedsGesture)
+    return () => {
+      listenersFilaAudioGesture.delete(listener)
+    }
+  }, [])
+  return needs
+}
+
+/** Gesto explícito (banner/login): desbloqueia áudio e retoma o loop da fila. */
+export function reativarAlertaFilaAudio() {
+  unlockAlertAudio()
+  setFilaAudioNeedsGesture(false)
+  const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+  if (fila > 0 && !filaAguardandoMuted) {
+    stopWppFilaLoop()
+    ensureWppFilaLoop()
+  }
+}
 
 export function setChatInternoAlertUserId(userId: number | null) {
   chatInternoUserId = userId
@@ -428,20 +466,31 @@ function startFilaLoopPlayback() {
   audio.volume = 0.38
   const playPromise = audio.play()
   if (playPromise && typeof playPromise.then === 'function') {
-    playPromise.catch(() => {
-      if (!wppFilaLoopWanted || filaAguardandoMuted || oneShotPlaying) return
-      // Em aba oculta o browser bloqueia play — notifica no SO e retenta ao voltar (#652)
-      const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
-      notifyFilaDesktop(filaCount)
-      if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
-        synthForKind('wpp_fila_pulse')
+    playPromise
+      .then(() => {
+        setFilaAudioNeedsGesture(false)
+      })
+      .catch(() => {
+        if (!wppFilaLoopWanted || filaAguardandoMuted || oneShotPlaying) return
+        const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+        // Em segundo plano o SO bloqueia play — notifica e retenta ao voltar (#652)
+        if (isAppInBackground()) {
+          notifyFilaDesktop(filaCount)
+          return
+        }
+        // App em foco: autoplay bloqueado até gesto — banner + synth + retry
+        setFilaAudioNeedsGesture(true)
+        if (audioUnlocked) {
+          synthForKind('wpp_fila_pulse')
+        }
         clearWppFilaLoopRetry()
         wppFilaLoopRetryTimer = window.setTimeout(() => {
           wppFilaLoopRetryTimer = null
-          if (wppFilaLoopWanted && !filaAguardandoMuted) startFilaLoopPlayback()
-        }, 400)
-      }
-    })
+          if (wppFilaLoopWanted && !filaAguardandoMuted && !isAppInBackground()) {
+            startFilaLoopPlayback()
+          }
+        }, 1200)
+      })
   }
 }
 
@@ -506,6 +555,7 @@ function syncWppFilaBeep(wppFilaCount: number) {
     ensureWppFilaLoop()
   } else {
     stopWppFilaLoop()
+    setFilaAudioNeedsGesture(false)
   }
   syncFilaBackgroundNudge()
 }
@@ -781,46 +831,76 @@ export function unlockAlertAudio() {
 export type AlertasDesktopResultado = 'granted' | 'denied' | 'default' | 'unsupported'
 
 /**
- * Pedido explícito (gesto do utilizador no banner): desbloqueia áudio + permissão
- * de notificação do SO para alertar com aba em 2º plano / browser minimizado (#652).
+ * Pedido explícito (gesto do usuário no banner/login): desbloqueia áudio + permissão
+ * de notificação do SO para alertar com aba em 2º plano / app minimizada (#652).
  */
 export async function ativarAlertasEmSegundoPlano(): Promise<AlertasDesktopResultado> {
   unlockAlertAudio()
-  if (typeof Notification === 'undefined') return 'unsupported'
-  if (Notification.permission === 'granted') {
-    // Confirmação curta — o utilizador acabou de autorizar / já tinha
-    try {
-      const n = new Notification(APP_NAME, {
-        body: 'Alertas activos mesmo com a aba em segundo plano.',
-        tag: 'dx-connect-fila-perm-ok',
-        silent: false,
-      })
-      window.setTimeout(() => n.close(), 4000)
-    } catch {
-      // ignore
-    }
-    return 'granted'
+  setFilaAudioNeedsGesture(false)
+  const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+  if (fila > 0 && !filaAguardandoMuted) {
+    ensureWppFilaLoop()
   }
-  if (Notification.permission === 'denied') return 'denied'
+
+  let resultado: AlertasDesktopResultado = 'unsupported'
+
   try {
-    const p = await Notification.requestPermission()
-    if (p === 'granted') {
+    const { isCapacitorNative } = await import('../lib/capacitorNative')
+    if (isCapacitorNative()) {
+      const { DeskRudderUnifiedPush } = await import('../plugins/unifiedPush')
+      const native = await DeskRudderUnifiedPush.requestNotificationPermission()
+      if (native.granted) {
+        if (fila > 0 && !filaAguardandoMuted) {
+          void DeskRudderUnifiedPush.showFilaWaiting({ count: fila }).catch(() => undefined)
+        }
+        resultado = 'granted'
+      } else if (native.state === 'denied') {
+        resultado = 'denied'
+      } else {
+        resultado = 'default'
+      }
+    }
+  } catch {
+    // ignore — fallback Web Notification
+  }
+
+  if (resultado !== 'granted' && resultado !== 'denied' && typeof Notification !== 'undefined') {
+    if (Notification.permission === 'granted') {
+      resultado = 'granted'
+    } else if (Notification.permission === 'denied') {
+      resultado = 'denied'
+    } else {
       try {
+        const p = await Notification.requestPermission()
+        resultado = p === 'granted' ? 'granted' : p === 'denied' ? 'denied' : 'default'
+      } catch {
+        resultado = 'denied'
+      }
+    }
+  }
+
+  if (resultado === 'granted') {
+    try {
+      if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
         const n = new Notification(APP_NAME, {
-          body: 'Alertas activos mesmo com a aba em segundo plano.',
+          body: 'Alertas ativos mesmo com a aba em segundo plano ou a app fechada.',
           tag: 'dx-connect-fila-perm-ok',
           silent: false,
         })
         window.setTimeout(() => n.close(), 4000)
-      } catch {
-        // ignore
       }
-      return 'granted'
+    } catch {
+      // ignore (APK pode não expor Notification)
     }
-    return p === 'denied' ? 'denied' : 'default'
-  } catch {
-    return 'denied'
+    try {
+      const { syncWebPushSubscription } = await import('./useWebPush')
+      await syncWebPushSubscription({ ativar: true })
+    } catch {
+      // VAPID ausente / distributor indisponível — banner de push continua disponível
+    }
   }
+
+  return resultado
 }
 
 export function getNotificationPermission(): AlertasDesktopResultado {
@@ -847,42 +927,56 @@ function installAudioUnlockListeners() {
 /**
  * Notificação do SO quando a app está em segundo plano — browsers/OS bloqueiam audio.play().
  * Respeita silenciar da fila. Dedup ~4s (exceto `force` do nudge periódico #823).
+ * No APK usa canal nativo com som alto (mesmo do UnifiedPush).
  */
 function notifyFilaDesktop(filaCount: number, opts?: { force?: boolean }) {
   if (filaAguardandoMuted || filaCount <= 0) return
   if (!isAppInBackground()) return
-  if (typeof Notification === 'undefined') return
-  if (Notification.permission !== 'granted') return
   const now = Date.now()
   if (!opts?.force && now - lastFilaDesktopNotifyAt < FILA_NOTIFY_DEDUP_MS) return
   lastFilaDesktopNotifyAt = now
-  try {
-    const body =
-      filaCount === 1
-        ? 'Há 1 chat aguardando atendimento'
-        : `Há ${filaCount} chats aguardando atendimento`
-    const n = new Notification(APP_NAME, {
-      body,
-      tag: FILA_NOTIFY_TAG,
-      silent: false,
-      renotify: true,
-      requireInteraction: true,
-    } as NotificationOptions)
-    n.onclick = () => {
-      try {
-        window.focus()
-        const path = '/chat/espera'
-        if (window.location.pathname !== path) {
-          window.location.assign(path)
-        }
-      } catch {
-        // ignore
+
+  void (async () => {
+    try {
+      const { isCapacitorNative } = await import('../lib/capacitorNative')
+      if (isCapacitorNative()) {
+        const { DeskRudderUnifiedPush } = await import('../plugins/unifiedPush')
+        await DeskRudderUnifiedPush.showFilaWaiting({ count: filaCount })
+        return
       }
-      n.close()
+    } catch {
+      // fallback Web Notification
     }
-  } catch {
-    // ignore
-  }
+    if (typeof Notification === 'undefined') return
+    if (Notification.permission !== 'granted') return
+    try {
+      const body =
+        filaCount === 1
+          ? 'Há 1 chat aguardando atendimento'
+          : `Há ${filaCount} chats aguardando atendimento`
+      const n = new Notification(APP_NAME, {
+        body,
+        tag: FILA_NOTIFY_TAG,
+        silent: false,
+        renotify: true,
+        requireInteraction: true,
+      } as NotificationOptions)
+      n.onclick = () => {
+        try {
+          window.focus()
+          const path = '/chat/espera'
+          if (window.location.pathname !== path) {
+            window.location.assign(path)
+          }
+        } catch {
+          // ignore
+        }
+        n.close()
+      }
+    } catch {
+      // ignore
+    }
+  })()
 }
 
 function ensureStarted() {
@@ -923,9 +1017,17 @@ function ensureStarted() {
       syncFilaBackgroundNudge()
       return
     }
-    // Retoma o loop imediatamente ao voltar à aba (#652), sem esperar o poll
+    // Retoma o loop ao voltar à aba — re-desbloqueia se já houve gesto (#652)
+    if (audioUnlocked) {
+      unlockAlertAudio()
+    }
     const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
-    syncWppFilaBeep(fila)
+    if (fila > 0 && !filaAguardandoMuted) {
+      stopWppFilaLoop()
+      ensureWppFilaLoop()
+    } else {
+      syncWppFilaBeep(fila)
+    }
     void poll()
   }
   const onBlurOrHidden = () => {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -23,6 +23,7 @@ import {
   writeRememberedAccount,
 } from '../lib/marketingHost'
 import { isCapacitorNative } from '../lib/capacitorNative'
+import { unlockAlertAudio } from '../hooks/useAlertaFilaSemResponsavel'
 import { isSaasControlPlaneFrontend, SAAS_LICENCAS_PATH } from '../lib/saasControlPlane'
 
 const fieldClass =
@@ -168,6 +169,7 @@ function LoginConta() {
     try {
       const tokens = await loginAgainstClientInstance(slug, email.trim(), senha)
       writeRememberedAccount(slug)
+      unlockAlertAudio()
       try {
         if (lembrarMe) {
           localStorage.setItem(LOGIN_EMAIL_STORAGE_KEY, email.trim())
@@ -332,6 +334,7 @@ function LoginCapacitor() {
     writeRememberedAccount(slug)
     try {
       await login(email.trim(), senha, lembrarMe)
+      unlockAlertAudio()
       try {
         if (lembrarMe) {
           localStorage.setItem(LOGIN_EMAIL_STORAGE_KEY, email.trim())
@@ -506,6 +509,7 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
     setLoading(true)
     try {
       await login(email.trim(), senha, lembrarMe)
+      unlockAlertAudio()
       const { atendentes } = await import('../api/client')
       const me = await atendentes.me()
       if (isOps && me.role !== 'saas_ops') {

--- a/frontend/src/plugins/unifiedPush.ts
+++ b/frontend/src/plugins/unifiedPush.ts
@@ -18,10 +18,20 @@ export type UnifiedPushRegistrationError = {
   reason: string
 }
 
+export type NotificationPermissionResult = {
+  granted: boolean
+  /** granted | denied | prompt | unsupported */
+  state: string
+}
+
 interface DeskRudderUnifiedPushPlugin {
   registerPush(options: { vapidPublicKey: string }): Promise<UnifiedPushEndpoint>
   unregisterPush(): Promise<void>
   consumePendingOpen(): Promise<UnifiedPushOpen>
+  /** Android 13+: pede POST_NOTIFICATIONS (gesto do usuário). */
+  requestNotificationPermission(): Promise<NotificationPermissionResult>
+  /** Alerta local da fila com canal de som alto (app em 2º plano). */
+  showFilaWaiting(options: { count: number }): Promise<void>
   addListener(
     eventName: 'endpoint',
     listenerFunc: (data: UnifiedPushEndpoint) => void,
@@ -48,6 +58,28 @@ class DeskRudderUnifiedPushWeb extends WebPlugin {
 
   async consumePendingOpen(): Promise<UnifiedPushOpen> {
     return {}
+  }
+
+  async requestNotificationPermission(): Promise<NotificationPermissionResult> {
+    if (typeof Notification === 'undefined') {
+      return { granted: false, state: 'unsupported' }
+    }
+    if (Notification.permission === 'granted') {
+      return { granted: true, state: 'granted' }
+    }
+    if (Notification.permission === 'denied') {
+      return { granted: false, state: 'denied' }
+    }
+    try {
+      const p = await Notification.requestPermission()
+      return { granted: p === 'granted', state: p }
+    } catch {
+      return { granted: false, state: 'denied' }
+    }
+  }
+
+  async showFilaWaiting(): Promise<void> {
+    /* no-op — browser usa Notification da web */
   }
 }
 

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -40,15 +40,22 @@ self.addEventListener('push', (event: PushEvent) => {
     data = { titulo: event.data?.text() || 'DeskRudder' }
   }
   const title = data.titulo || 'DeskRudder'
-  const body = data.corpo || 'Nova actividade no atendimento'
-  const isFila = data.tipo === 'chat.fila' || data.tipo === 'fila'
+  const body = data.corpo || 'Nova atividade no atendimento'
+  const tipo = data.tipo || ''
+  const isFila =
+    tipo === 'chat.fila' ||
+    tipo === 'chat.fila.remind' ||
+    tipo === 'portal.chat.fila' ||
+    tipo === 'ticket.fila' ||
+    tipo === 'fila' ||
+    tipo.endsWith('.fila')
   event.waitUntil(
     self.registration.showNotification(title, {
       body,
       icon: '/deskrudder-pwa-192.png',
       badge: '/deskrudder-pwa-192.png',
       data,
-      tag: `${data.tipo || 'push'}:${data.id || ''}`,
+      tag: isFila ? 'dx-connect-fila-aguardando' : `${tipo || 'push'}:${data.id || ''}`,
       renotify: true,
       requireInteraction: isFila,
       vibrate: isFila ? [200, 100, 200, 100, 200] : [180, 80, 180],


### PR DESCRIPTION
## Summary
- **App aberta:** desbloqueio de audio no login, banner «Ativar som» se o autoplay bloquear, retry do loop ao voltar ao foco
- **2o plano (APK/browser):** banner de permissao tambem no Capacitor; notificacao local com canal `deskrudder_fila` e nudge periodico
- **App fechada:** «Ativar alertas» inscreve Web Push/UnifiedPush no mesmo gesto; lembrete periodico `chat.fila.remind` (padrao 2 min) enquanto houver fila; SW/APK tratam lembretes com som reforçado

## Test plan
- [x] `npm run build` (frontend)
- [ ] `pytest -q tests/test_web_push.py` (Docker indisponivel no momento do PR — CI backend cobre)
- [ ] Login no mobile/APK com fila > 0: toca ou aparece «Ativar som»
- [ ] Minimizar com permissao: notificacao do sistema com som
- [ ] App kill + push ativo: recebe evento e lembrete periodico
- [ ] Silenciar na mesa / `push_fila=false` corta loop e push da fila

Made with [Cursor](https://cursor.com)