### PR TITLE
fix(mobile): plantão FGS + sessão/SSE estáveis no APK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Mobile (navegador e APK): alerta sonoro da fila de espera mais confiável com a app aberta — desbloqueio de áudio no login, banner «Ativar som» se o autoplay bloquear (sem precisar recarregar) e retomada do loop ao voltar ao foco
 - Mobile APK: banner de permissão de notificações também no app nativo; em segundo plano, notificação local com canal de som alto enquanto houver chat aguardando
 - Mobile (app fechada): ao ativar alertas, a inscrição Web Push / UnifiedPush passa a ser feita no mesmo gesto; o servidor reenvia push a cada 2 min enquanto houver fila (`chat.fila.remind`); PWA e APK tratam lembretes da fila com som/vibração reforçados
+- Mobile APK: após bloquear/desbloquear a tela, a sessão permanece (tokens em `localStorage`); o SSE reconecta ao voltar ao app e deixa de usar CapacitorHttp no stream (evita «desconectado» no reload)
+- Mobile APK: plantão com **Foreground Service** — notificação persistente «Há N chats aguardando» com a tela bloqueada; silenciar na mesa encerra o plantão; push continua se o OEM matar o app
 
 ## [26.08.019] - 2026-08-31
 

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -90,6 +90,10 @@ Correr após `npm run build:android` + `npm run cap:sync android` + instalar no 
 | 5 | Login noutra empresa | Dados da nova instância |
 | 6 | Notificações → activar push | Endpoint UnifiedPush registado na API da instância |
 | 7 | App em segundo plano / fechada + evento fila/mensagem | Notificação sistema |
+| 7b | Plantão ligado + 1 chat na fila + **bloquear tela** | Notificação persistente «DeskRudder — plantão»; toque abre `/chat/espera` |
+| 7c | Assumir chat / fila zerar ou **silenciar** na mesa | Notificação de plantão some |
+| 7d | Bloquear/desbloquear tela 10× | Permanece logado; fila atualiza sem login manual; SSE reconecta |
+| 7e | Matar app (swipe) com fila > 0 | Push / `chat.fila.remind` chega |
 | 8 | Toque na notificação | Abre a mesa/conversa **uma** vez |
 | 9 | Ticket: teclado no composer | Campo visível; double-tap no enviar não duplica |
 | 10 | WhatsApp: texto + figurinha | Envio único; teclado sem cortar o campo |
@@ -124,20 +128,35 @@ O worker `web-push-outbox` já existente envia para PWA **e** APK. Mute da fila 
 
 O distribuidor embutido usa os servidores de push da Google só como transporte nos telemóveis com Play Services. Sem Play Services, o alerta com a app fechada não chega (a PWA no Chrome continua a funcionar).
 
-### Matriz aberto / 2.º plano / fechado (#823)
+### Matriz aberto / 2.º plano / fechado (#823 + plantão FGS)
 
 | Estado | O que alerta |
 |--------|----------------|
-| **Aberto** (aba/app em foco) | SSE + loop de áudio da fila (`alerta.mp3`); se o autoplay bloquear, banner «Ativar som»; preferência «silenciar» na mesa corta o loop |
-| **2.º plano** (minimizada / outra app / aba oculta; processo ainda vivo) | Notification do SO com `renotify` + re-alerta periódico; no APK canal nativo `deskrudder_fila` + `App.appStateChange`. Push do servidor continua a chegar em eventos novos |
-| **Fechada / kill** | **Web Push** (PWA) ou **UnifiedPush** (APK) no evento de entrada na fila **e** lembrete periódico (`chat.fila.remind`, padrão a cada 2 min) enquanto a fila > 0 e `push_habilitado` + `push_fila` |
+| **Aberto** (aba/app em foco) | SSE estável + loop de áudio da fila (`alerta.mp3`); se o autoplay bloquear, banner «Ativar som»; preferência «silenciar» na mesa corta o loop |
+| **Tela bloqueada / 2.º plano com gente na fila (APK)** | **Foreground Service** de plantão (notificação contínua «Há N chats aguardando», canal `deskrudder_fila`, deep link `/chat/espera`). Não depende de `setInterval` / HTMLAudio no WebView |
+| **2.º plano (navegador / PWA)** | Notification do SO com `renotify` + re-alerta periódico (~12s) enquanto a aba está oculta e o processo vivo |
+| **Fechada / kill / OEM matou o FGS** | **Web Push** (PWA) ou **UnifiedPush** (APK) no evento de entrada na fila **e** lembrete periódico (`chat.fila.remind`, padrão a cada 2 min) enquanto a fila > 0 e `push_habilitado` + `push_fila` |
 | **iOS** | PWA no ecrã inicial (#695); sem SSE em background; push limitado pelo Safari |
 
-O banner «Ativar alertas» (permissão de notificação) aparece no **browser e no APK** e, no mesmo gesto, tenta inscrever o endpoint de push (necessário com a app fechada). O gesto de **Entrar** no login já desbloqueia o áudio HTML para a sessão.
+No APK, a sessão grava tokens sempre em `localStorage` (reload pós-lock não manda para o login). O stream SSE usa `EventSource` nativo do WebView (CapacitorHttp bufferiza `fetch` e quebra o stream). Ao voltar ao app (`appStateChange` ativo), o SSE reinicia e sai do fallback permanente.
+
+O banner «Ativar alertas» / «Ativar plantão» (permissão de notificação) aparece no **browser e no APK** e, no mesmo gesto, tenta inscrever o endpoint de push (necessário com a app fechada). Com a permissão concedida e fila > 0 (sem silenciar na mesa), o APK sobe o plantão FGS.
 
 Variável `WEB_PUSH_FILA_REMIND_MINUTES` (padrão `2`; `0` desliga o lembrete periódico).
 
-Silenciar na mesa (`ChatFilaSomToggle`) e «Avisar fila de espera» em Notificações ficam alinhados (`push_fila` ↔ mute local).
+Silenciar na mesa (`ChatFilaSomToggle`) e «Avisar fila de espera» em Notificações ficam alinhados (`push_fila` ↔ mute local) e **desligam o FGS** no APK.
+
+### Bateria / OEM (checklist no aparelho)
+
+Fabricantes (Xiaomi, Samsung, Huawei, etc.) podem matar o processo mesmo com Foreground Service. Peça ao atendente, uma vez por aparelho:
+
+1. **DeskRudder → Informações do app → Bateria** — sem restrição / «Sem restrições» / permitir atividade em segundo plano
+2. **Otimização de bateria** — isentar o DeskRudder (Android: Configurações → Apps → DeskRudder → Bateria)
+3. Xiaomi / HyperOS: Autostart + «Economia de bateria» → Sem restrições; opcional «bloquear» o app na lista de recentes para o OEM não matar
+4. Samsung: Apps em espera / sono profundo — remover DeskRudder da lista
+5. Validar: com plantão ligado e 1 chat na fila, bloquear a tela → notificação «DeskRudder — plantão» permanece; ao assumir/zerar a fila, some; ao matar o app (swipe), deve chegar push/`chat.fila.remind`
+
+Cada instância precisa de `VAPID_*` no `client.env` e `https://localhost` em `CORS_ORIGINS` (obrigatório para SSE no WebView Capacitor).
 
 Ícones de loja: `frontend/public/deskrudder-pwa-512.png` (e outline) — ver `MOBILE_STORE_RELEASE.md`. Os mipmaps Android (`ic_launcher*`) devem usar o mesmo mark PWA (fundo Deck `#F8FAFC`); regenerar a partir de `deskrudder-pwa-512.png` se o asset de marca mudar. Opcional: splash nativo com `@capacitor/assets`.
 

--- a/frontend/android/app/capacitor.build.gradle
+++ b/frontend/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-geolocation')
 
 }
 

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -42,12 +42,23 @@
                 <action android:name="org.unifiedpush.android.connector.PUSH_EVENT" />
             </intent-filter>
         </service>
+
+        <service
+            android:name=".FilaAlertForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Plantao de alerta da fila de espera do helpdesk enquanto o atendente esta de plantao" />
+        </service>
     </application>
 
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/FilaAlertForegroundService.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/FilaAlertForegroundService.kt
@@ -1,0 +1,138 @@
+package br.com.deskrudder.app
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+
+/**
+ * Notificação persistente de plantão enquanto há chats na fila.
+ * Mantém o processo mais vivo com a tela bloqueada (lock/unlock).
+ */
+class FilaAlertForegroundService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            else -> {
+                val count = intent?.getIntExtra(EXTRA_COUNT, 0) ?: 0
+                if (count <= 0) {
+                    stopSelf()
+                    return START_NOT_STICKY
+                }
+                ensureChannel()
+                val notification = buildNotification(count)
+                if (Build.VERSION.SDK_INT >= 34) {
+                    ServiceCompat.startForeground(
+                        this,
+                        NOTIFY_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+                    )
+                } else {
+                    startForeground(NOTIFY_ID, notification)
+                }
+                return START_STICKY
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    private fun buildNotification(count: Int): Notification {
+        val body =
+            if (count == 1) "Há 1 chat aguardando atendimento"
+            else "Há $count chats aguardando atendimento"
+        val tap = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(
+                UnifiedPushStore.EXTRA_PAYLOAD,
+                """{"tipo":"chat.fila","url_path":"/chat/espera"}""",
+            )
+        }
+        val pending = PendingIntent.getActivity(
+            this,
+            NOTIFY_ID,
+            tap,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_stat_notify)
+            .setContentTitle("DeskRudder — plantão")
+            .setContentText(body)
+            .setOngoing(true)
+            .setOnlyAlertOnce(false)
+            .setContentIntent(pending)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .build()
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "Fila de espera",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "Plantão: clientes aguardando atendimento no chat"
+                enableVibration(true)
+                setSound(
+                    android.media.RingtoneManager.getDefaultUri(
+                        android.media.RingtoneManager.TYPE_NOTIFICATION,
+                    ),
+                    null,
+                )
+                setShowBadge(true)
+            },
+        )
+    }
+
+    companion object {
+        const val CHANNEL_ID = "deskrudder_fila"
+        const val NOTIFY_ID = 82302
+        const val EXTRA_COUNT = "count"
+        const val ACTION_STOP = "br.com.deskrudder.app.STOP_FILA_ALERT"
+        const val ACTION_UPDATE = "br.com.deskrudder.app.UPDATE_FILA_ALERT"
+
+        fun start(context: Context, count: Int) {
+            val intent = Intent(context, FilaAlertForegroundService::class.java).apply {
+                action = ACTION_UPDATE
+                putExtra(EXTRA_COUNT, count)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, FilaAlertForegroundService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+    }
+}

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
@@ -151,6 +151,38 @@ class UnifiedPushPlugin : Plugin() {
         call.resolve()
     }
 
+    /** Plantão: Foreground Service com notificação persistente enquanto a fila > 0. */
+    @PluginMethod
+    fun startFilaAlert(call: PluginCall) {
+        val count = call.getInt("count") ?: 0
+        if (count <= 0) {
+            FilaAlertForegroundService.stop(context)
+            call.resolve()
+            return
+        }
+        if (Build.VERSION.SDK_INT >= 33 &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            call.resolve()
+            return
+        }
+        FilaAlertForegroundService.start(context, count)
+        call.resolve()
+    }
+
+    @PluginMethod
+    fun updateFilaAlert(call: PluginCall) {
+        startFilaAlert(call)
+    }
+
+    @PluginMethod
+    fun stopFilaAlert(call: PluginCall) {
+        FilaAlertForegroundService.stop(context)
+        NotificationManagerCompat.from(context).cancel(FILA_NOTIFY_ID)
+        call.resolve()
+    }
+
     private fun ensureFilaChannel() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val manager = context.getSystemService(NotificationManager::class.java) ?: return

--- a/frontend/android/capacitor.settings.gradle
+++ b/frontend/android/capacitor.settings.gradle
@@ -4,3 +4,6 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
+include ':capacitor-geolocation'
+project(':capacitor-geolocation').projectDir = new File('../node_modules/@capacitor/geolocation/android')

--- a/frontend/src/api/eventStream.ts
+++ b/frontend/src/api/eventStream.ts
@@ -4,6 +4,7 @@ import {
   invalidateSessionAndRedirectToLogin,
   resolvedApiBaseUrl,
 } from './client'
+import { isCapacitorNative } from '../lib/capacitorNative'
 import { isMultiTenantMode, resolveTenantIdFromHostname } from '../lib/tenant'
 
 export interface RealtimeEnvelope {
@@ -37,7 +38,7 @@ async function refreshAccessTokenForStream(): Promise<string | null> {
   if (isMultiTenantMode()) {
     headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
   }
-  const res = await fetch(`${base}${API_VERSION_PREFIX}/auth/refresh`, {
+  const res = await webFetch(`${base}${API_VERSION_PREFIX}/auth/refresh`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ refresh_token }),
@@ -86,15 +87,29 @@ function parseSseBlocks(buffer: string): { events: RealtimeEnvelope[]; rest: str
   return { events, rest }
 }
 
+/** Fetch do WebView — bypass do CapacitorHttp (não faz streaming / SSE). */
+function webFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const cap = (
+    window as unknown as {
+      Capacitor?: { CapacitorWebFetch?: typeof fetch }
+    }
+  ).Capacitor
+  const nativeWeb = cap?.CapacitorWebFetch
+  if (typeof nativeWeb === 'function') {
+    return nativeWeb(input, init)
+  }
+  return fetch(input, init)
+}
+
 async function openAuthenticatedStream(
   signal: AbortSignal,
   retried401: boolean,
 ): Promise<Response> {
-  let token = getAuthToken()
+  const token = getAuthToken()
   if (!token) {
     throw new Error('Token não informado')
   }
-  const res = await fetch(buildEventStreamUrl(), {
+  const res = await webFetch(buildEventStreamUrl(), {
     headers: authHeaders(token),
     signal,
   })
@@ -119,6 +134,109 @@ async function openAuthenticatedStream(
   return res
 }
 
+function buildEventSourceUrl(token: string): string {
+  const url = new URL(buildEventStreamUrl())
+  url.searchParams.set('token', token)
+  if (isMultiTenantMode()) {
+    url.searchParams.set('tid', String(resolveTenantIdFromHostname()))
+  }
+  return url.toString()
+}
+
+/**
+ * APK: EventSource nativo (stack do WebView) — CapacitorHttp bufferiza fetch e quebra SSE.
+ * Requer CORS com https://localhost na instância.
+ */
+function runEventStreamLoopEventSource(options: EventStreamRunOptions): Promise<void> {
+  const { signal, onEvent, onConnected, onError } = options
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+    let token = getAuthToken()
+    if (!token) {
+      reject(new Error('Token não informado'))
+      return
+    }
+
+    let es: EventSource | null = null
+    let settled = false
+    let sawConnected = false
+    let refreshTried = false
+
+    const finishOk = () => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve()
+    }
+    const finishErr = (err: Error) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      onError?.(err)
+      reject(err)
+    }
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort)
+      try {
+        es?.close()
+      } catch {
+        /* ignore */
+      }
+      es = null
+    }
+    const onAbort = () => {
+      finishOk()
+    }
+    signal.addEventListener('abort', onAbort)
+
+    const attach = (accessToken: string) => {
+      try {
+        es?.close()
+      } catch {
+        /* ignore */
+      }
+      es = new EventSource(buildEventSourceUrl(accessToken))
+      es.onmessage = (ev) => {
+        try {
+          const envelope = JSON.parse(ev.data) as RealtimeEnvelope
+          if (envelope.type === 'connected') {
+            sawConnected = true
+            onConnected?.()
+          }
+          onEvent(envelope)
+        } catch {
+          if (import.meta.env.DEV) {
+            console.warn('[SSE] JSON inválido (EventSource):', ev.data)
+          }
+        }
+      }
+      es.onerror = () => {
+        void (async () => {
+          if (settled || signal.aborted) return
+          // Sem connected: pode ser 401 / CORS — tenta refresh 1x
+          if (!sawConnected && !refreshTried) {
+            refreshTried = true
+            const refreshed = await refreshAccessTokenForStream()
+            if (refreshed) {
+              attach(refreshed)
+              return
+            }
+            invalidateSessionAndRedirectToLogin()
+            finishErr(new Error('Sessão expirada'))
+            return
+          }
+          finishErr(new Error('SSE EventSource desconectado'))
+        })()
+      }
+    }
+
+    attach(token)
+  })
+}
+
 export type EventStreamRunOptions = {
   signal: AbortSignal
   onEvent: (event: RealtimeEnvelope) => void
@@ -128,6 +246,10 @@ export type EventStreamRunOptions = {
 
 /** Lê o stream até abort ou erro de rede. */
 export async function runEventStreamLoop(options: EventStreamRunOptions): Promise<void> {
+  if (isCapacitorNative() && typeof EventSource !== 'undefined') {
+    return runEventStreamLoopEventSource(options)
+  }
+
   const { signal, onEvent, onConnected, onError } = options
   let response: Response
   try {

--- a/frontend/src/components/AlertaDesktopPermissaoBanner.tsx
+++ b/frontend/src/components/AlertaDesktopPermissaoBanner.tsx
@@ -82,7 +82,7 @@ export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
         className="shrink-0 border-b border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-100"
       >
         {nativo
-          ? 'Alertas do sistema ativos — você será avisado com o app em segundo plano ou fechado.'
+          ? 'Alertas do sistema ativos — com gente na fila, o Android mantém uma notificação de plantão mesmo com a tela bloqueada; push cobre se o app for encerrado.'
           : 'Alertas do sistema ativos — você será avisado com a aba em segundo plano, navegador minimizado ou app fechada.'}
       </div>
     )
@@ -114,11 +114,11 @@ export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
     >
       <div className="min-w-0 space-y-0.5">
         <p className="font-semibold text-slate-900 dark:text-white">
-          {nativo ? 'Ativar alertas com o app em segundo plano ou fechado?' : 'Ativar alertas fora desta aba?'}
+          {nativo ? 'Ativar plantão / alertas da fila?' : 'Ativar alertas fora desta aba?'}
         </p>
         <p className="text-xs text-slate-600 dark:text-slate-300 sm:text-sm">
           {nativo
-            ? 'Com a permissão do Android, o DeskRudder avisa a fila mesmo com o app minimizado ou fechado (push).'
+            ? 'O Android exige uma notificação persistente para alertar com a tela bloqueada. Com a permissão, o DeskRudder mostra o plantão enquanto houver chat na fila; se o app for morto, o push continua avisando.'
             : 'Com a permissão do navegador, o DeskRudder avisa a fila mesmo com outra aba, navegador minimizado ou app fechada (PWA).'}
         </p>
       </div>

--- a/frontend/src/components/chat/ChatFilaSomToggle.tsx
+++ b/frontend/src/components/chat/ChatFilaSomToggle.tsx
@@ -21,10 +21,14 @@ export function ChatFilaSomToggle({ className = '', size = 'sm' }: Props) {
       aria-pressed={muted}
       aria-label={
         muted
-          ? 'Ativar alerta sonoro da fila Aguardando'
-          : 'Silenciar alerta sonoro da fila Aguardando'
+          ? 'Ativar plantão / alerta da fila Aguardando'
+          : 'Silenciar plantão e alerta da fila Aguardando'
       }
-      title={muted ? 'Alerta da fila silenciado — clique para ativar' : 'Silenciar alerta da fila'}
+      title={
+        muted
+          ? 'Plantão silenciado — clique para alertar a fila (som e notificação)'
+          : 'Plantão ativo — clique para silenciar alerta da fila'
+      }
       onClick={(e) => {
         e.preventDefault()
         e.stopPropagation()

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -69,9 +69,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(async (email: string, senha: string, lembrarMe = true) => {
     const { auth } = await import('../api/client')
+    const { isCapacitorNative } = await import('../lib/capacitorNative')
     const res = await auth.login(email, senha)
     clearAuthToken()
-    if (lembrarMe) {
+    // APK: sempre localStorage — lock/unlock recarrega o WebView e sessionStorage some.
+    const persistir = isCapacitorNative() ? true : lembrarMe
+    if (persistir) {
       localStorage.setItem('token', res.access_token)
       if (res.refresh_token) localStorage.setItem('refresh_token', res.refresh_token)
     } else {

--- a/frontend/src/contexts/EventStreamContext.tsx
+++ b/frontend/src/contexts/EventStreamContext.tsx
@@ -16,6 +16,7 @@ import {
   type RealtimeEnvelope,
   type RealtimeEventHandler,
 } from '../api/eventStream'
+import { bindCapacitorAppState } from '../lib/capacitorNative'
 
 type ListenerMap = Map<string, Set<RealtimeEventHandler>>
 
@@ -23,6 +24,8 @@ interface EventStreamContextValue {
   connected: boolean
   useFallback: boolean
   subscribe: (type: string, handler: RealtimeEventHandler) => () => void
+  /** Força novo ciclo SSE (ex.: ao voltar do 2º plano no APK). */
+  restartStream: () => void
 }
 
 const EventStreamContext = createContext<EventStreamContextValue | null>(null)
@@ -37,6 +40,7 @@ export function EventStreamProvider({
   const listenersRef = useRef<ListenerMap>(new Map())
   const [connected, setConnected] = useState(false)
   const [useFallback, setUseFallback] = useState(false)
+  const [streamEpoch, setStreamEpoch] = useState(0)
 
   const dispatch = useCallback((event: RealtimeEnvelope) => {
     const handlers = listenersRef.current.get(event.type)
@@ -76,6 +80,20 @@ export function EventStreamProvider({
       }
     }
   }, [])
+
+  const restartStream = useCallback(() => {
+    setUseFallback(false)
+    setStreamEpoch((n) => n + 1)
+  }, [])
+
+  useEffect(() => {
+    return bindCapacitorAppState((isActive) => {
+      if (isActive && enabled) {
+        // Lock/unlock ou OEM matou o WebView: sai do fallback permanente e reconecta
+        restartStream()
+      }
+    })
+  }, [enabled, restartStream])
 
   useEffect(() => {
     if (!enabled) {
@@ -142,11 +160,11 @@ export function EventStreamProvider({
       abort.abort()
       setConnected(false)
     }
-  }, [enabled, dispatch])
+  }, [enabled, dispatch, streamEpoch])
 
   const value = useMemo(
-    () => ({ connected, useFallback, subscribe }),
-    [connected, useFallback, subscribe],
+    () => ({ connected, useFallback, subscribe, restartStream }),
+    [connected, useFallback, subscribe, restartStream],
   )
 
   return <EventStreamContext.Provider value={value}>{children}</EventStreamContext.Provider>

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { notificacoes, type Notificacoes } from '../api/client'
 import { useEventStream } from '../contexts/EventStreamContext'
 import { APP_NAME } from '../brand'
+import { isCapacitorNative } from '../lib/capacitorNative'
 
 const LS_KEY_LAST_SEM_RESP = 'dxconnect.notificacoes.last_sem_responsavel'
 const LS_KEY_LAST_NAO_LIDAS = 'dxconnect.notificacoes.last_nao_lidas'
@@ -100,6 +101,8 @@ type ListenerFilaAudioGesture = (needs: boolean) => void
 const listenersFilaAudioGesture = new Set<ListenerFilaAudioGesture>()
 let lastFilaDesktopNotifyAt = 0
 let filaBgNudgeTimer: number | null = null
+/** Última contagem enviada ao Foreground Service (evita spam de startService). */
+let lastFilaPlantaoCount: number | null = null
 /** APK: false quando o OS põe a app em segundo plano (#823). Browser: permanece true. */
 let nativeAppActive = true
 let capacitorAppStateBound = false
@@ -180,10 +183,12 @@ export function setFilaAguardandoMuted(muted: boolean) {
     stopWppFilaLoop()
     stopWppFilaOneShots()
     clearFilaBackgroundNudge()
+    syncFilaPlantaoFgs()
   } else {
     const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
     syncWppFilaBeep(filaCount)
     syncFilaBackgroundNudge()
+    syncFilaPlantaoFgs()
   }
   for (const l of listenersFilaMuted) l(muted)
 }
@@ -558,6 +563,38 @@ function syncWppFilaBeep(wppFilaCount: number) {
     setFilaAudioNeedsGesture(false)
   }
   syncFilaBackgroundNudge()
+  syncFilaPlantaoFgs()
+}
+
+/**
+ * APK: Foreground Service de plantão enquanto há fila e o alerta não está silenciado.
+ * Sobrevive a lock/unlock melhor que HTMLAudio / setInterval no WebView.
+ */
+function syncFilaPlantaoFgs() {
+  if (!isCapacitorNative()) return
+  const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+  void (async () => {
+    try {
+      const { DeskRudderUnifiedPush } = await import('../plugins/unifiedPush')
+      if (fila <= 0 || filaAguardandoMuted) {
+        if (lastFilaPlantaoCount != null && lastFilaPlantaoCount > 0) {
+          lastFilaPlantaoCount = 0
+          await DeskRudderUnifiedPush.stopFilaAlert()
+        }
+        return
+      }
+      if (lastFilaPlantaoCount === fila) return
+      const prev = lastFilaPlantaoCount
+      lastFilaPlantaoCount = fila
+      if (prev == null || prev <= 0) {
+        await DeskRudderUnifiedPush.startFilaAlert({ count: fila })
+      } else {
+        await DeskRudderUnifiedPush.updateFilaAlert({ count: fila })
+      }
+    } catch {
+      // Plugin ausente / permissão — push continua como rede de segurança
+    }
+  })()
 }
 
 /** App minimizada / aba oculta / janela sem foco / APK em 2.º plano (#823). */
@@ -581,6 +618,11 @@ function clearFilaBackgroundNudge() {
 }
 
 function syncFilaBackgroundNudge() {
+  // APK: Foreground Service cobre lock/2º plano — não depende do setInterval de 12s
+  if (isCapacitorNative()) {
+    clearFilaBackgroundNudge()
+    return
+  }
   const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
   const need = fila > 0 && !filaAguardandoMuted && isAppInBackground()
   if (!need) {
@@ -845,14 +887,12 @@ export async function ativarAlertasEmSegundoPlano(): Promise<AlertasDesktopResul
   let resultado: AlertasDesktopResultado = 'unsupported'
 
   try {
-    const { isCapacitorNative } = await import('../lib/capacitorNative')
-    if (isCapacitorNative()) {
+    const { isCapacitorNative: isNative } = await import('../lib/capacitorNative')
+    if (isNative()) {
       const { DeskRudderUnifiedPush } = await import('../plugins/unifiedPush')
       const native = await DeskRudderUnifiedPush.requestNotificationPermission()
       if (native.granted) {
-        if (fila > 0 && !filaAguardandoMuted) {
-          void DeskRudderUnifiedPush.showFilaWaiting({ count: fila }).catch(() => undefined)
-        }
+        syncFilaPlantaoFgs()
         resultado = 'granted'
       } else if (native.state === 'denied') {
         resultado = 'denied'
@@ -938,10 +978,9 @@ function notifyFilaDesktop(filaCount: number, opts?: { force?: boolean }) {
 
   void (async () => {
     try {
-      const { isCapacitorNative } = await import('../lib/capacitorNative')
       if (isCapacitorNative()) {
-        const { DeskRudderUnifiedPush } = await import('../plugins/unifiedPush')
-        await DeskRudderUnifiedPush.showFilaWaiting({ count: filaCount })
+        // Plantão FGS já cobre 2º plano / lock — evita notificação duplicada
+        syncFilaPlantaoFgs()
         return
       }
     } catch {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -333,7 +333,8 @@ function LoginCapacitor() {
     // Precisa do slug no storage para apiBaseUrl() apontar à instância; só fica se o login OK.
     writeRememberedAccount(slug)
     try {
-      await login(email.trim(), senha, lembrarMe)
+      // APK: sessão sempre persistente (reload pós-lock não pode mandar para o login)
+      await login(email.trim(), senha, true)
       unlockAlertAudio()
       try {
         if (lembrarMe) {

--- a/frontend/src/plugins/unifiedPush.ts
+++ b/frontend/src/plugins/unifiedPush.ts
@@ -32,6 +32,12 @@ interface DeskRudderUnifiedPushPlugin {
   requestNotificationPermission(): Promise<NotificationPermissionResult>
   /** Alerta local da fila com canal de som alto (app em 2º plano). */
   showFilaWaiting(options: { count: number }): Promise<void>
+  /** Plantão: inicia Foreground Service com notificação persistente. */
+  startFilaAlert(options: { count: number }): Promise<void>
+  /** Atualiza o texto/contagem do plantão (idempotente com start). */
+  updateFilaAlert(options: { count: number }): Promise<void>
+  /** Para o plantão e remove a notificação persistente. */
+  stopFilaAlert(): Promise<void>
   addListener(
     eventName: 'endpoint',
     listenerFunc: (data: UnifiedPushEndpoint) => void,
@@ -80,6 +86,18 @@ class DeskRudderUnifiedPushWeb extends WebPlugin {
 
   async showFilaWaiting(): Promise<void> {
     /* no-op — browser usa Notification da web */
+  }
+
+  async startFilaAlert(): Promise<void> {
+    /* no-op — só Android */
+  }
+
+  async updateFilaAlert(): Promise<void> {
+    /* no-op — só Android */
+  }
+
+  async stopFilaAlert(): Promise<void> {
+    /* no-op — só Android */
   }
 }
 


### PR DESCRIPTION
﻿## Summary

- APK: sessão sempre em `localStorage` + SSE via `EventSource` (sem CapacitorHttp) e restart ao voltar do lock/unlock
- Plantão Android com **Foreground Service** (notificação persistente enquanto há fila; mute/zerar encerra)
- Doc de bateria/OEM + checklist no aparelho; push/`chat.fila.remind` permanece como fallback se o OEM matar o app

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Instalar APK debug desta branch (ou da `main` pós-merge)
- [ ] Login no APK → bloquear/desbloquear tela 10× → permanece logado; fila atualiza; SSE reconecta
- [ ] Ativar plantão («Ativar alertas») + 1 chat na fila → bloquear tela → notificação «DeskRudder — plantão»
- [ ] Toque na notificação → abre `/chat/espera`
- [ ] Assumir/zerar fila ou silenciar na mesa → plantão some
- [ ] Matar app (swipe) com fila > 0 → push / `chat.fila.remind`
- [ ] Confirmar `CORS_ORIGINS` com `https://localhost` na instância de teste

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — FCM / listing Play ficam fora deste lote (sem issue nova neste PR)
- [x] Stubs/campos nullable N/A
- [x] Sem issue GitHub dedicada neste lote (follow-up de alerta mobile pós-#1053)
